### PR TITLE
ci: pass FINNHUB_API_KEY to bot workflow

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -54,6 +54,7 @@ jobs:
           ALPACA_PAPER_SECRET: ${{ secrets.ALPACA_PAPER_SECRET }}
           ALPACA_LIVE_KEY_ID: ${{ secrets.ALPACA_LIVE_KEY_ID }}
           ALPACA_LIVE_SECRET: ${{ secrets.ALPACA_LIVE_SECRET }}
+          FINNHUB_API_KEY: ${{ secrets.FINNHUB_API_KEY }}
           BOT_LOG_DIR: logs
           BOT_STATE_DIR: state
         run: python -m trading_bot.main --mode normal


### PR DESCRIPTION
## Summary
You added `FINNHUB_API_KEY` to repo secrets, but `bot.yml` doesn't expose it as an env var. Without this one-line change, `SentimentAnalyzer` and `EarningsCalendar` still see no key at startup and silently return `None` — meaning the `pre_market_scan` fix from #6 still won't refresh sentiment/earnings on Monday.

## Test plan
- [ ] Merge before 13:00 UTC so the first GHA tick today picks up the env var
- [ ] After first tick, check logs for `Refreshing earnings calendar for N tickers` and `Refreshing sentiment for N symbols` (instead of `FINNHUB_API_KEY not set` warnings)