### PR TITLE
feat: walkforward harness + state recovery hardening

### DIFF
--- a/trading_bot/backtest/__init__.py
+++ b/trading_bot/backtest/__init__.py
@@ -1,0 +1,21 @@
+"""Backtest analysis utilities (walkforward, bootstrap CI)."""
+
+from trading_bot.backtest.walkforward import (
+    BootstrapCI,
+    StrategyWindowStats,
+    WalkforwardConfig,
+    WalkforwardResult,
+    WindowResult,
+    bootstrap_metric_ci,
+    run_walkforward,
+)
+
+__all__ = [
+    "BootstrapCI",
+    "StrategyWindowStats",
+    "WalkforwardConfig",
+    "WalkforwardResult",
+    "WindowResult",
+    "bootstrap_metric_ci",
+    "run_walkforward",
+]

--- a/trading_bot/backtest/walkforward.py
+++ b/trading_bot/backtest/walkforward.py
@@ -1,0 +1,455 @@
+"""Walkforward harness + bootstrap confidence intervals.
+
+Borrowed in spirit from edtechre/pybroker's walkforward analysis. The aim is
+to convert a single-window backtest result (e.g. SPY mean reversion 2008-2021,
+PF 1.54) into an honest out-of-sample distribution: split the date range into
+N rolling test windows, run the backtester on each, and aggregate per-strategy
+metrics with a non-parametric confidence interval over trade returns.
+
+Two layers:
+
+1. ``run_walkforward`` — slices a [from, to] range into ``window_days`` test
+   windows stepped by ``step_days``, runs a caller-supplied
+   ``run_window(d_from, d_to)`` coroutine on each, and aggregates the
+   per-window ``MultiStrategyResult`` outputs.
+
+2. ``bootstrap_metric_ci`` — non-parametric percentile bootstrap on a list of
+   trade returns, producing a CI for an arbitrary metric callable.
+
+This module deliberately avoids parameter retraining. The strategies in
+config.yaml are evaluated as-is on each test window; the OOS aggregate then
+shows whether the headline single-window metric holds across the full range
+or hinges on one favourable regime.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import random
+import statistics
+from dataclasses import dataclass, field
+from datetime import date, timedelta
+from typing import Awaitable, Callable, Sequence
+
+from trading_bot.multi_strategy_backtest import (
+    MultiStrategyResult,
+    StrategyResult,
+    StrategyTrade,
+)
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class WalkforwardConfig:
+    """Configuration for a walkforward run.
+
+    Attributes:
+        window_days: Length of each rolling test window in calendar days.
+        step_days: Days to step the window forward between iterations. If
+            equal to ``window_days``, windows are non-overlapping. If less,
+            windows overlap (more samples but correlated).
+        min_trades_per_window: Skip per-window stats if a strategy didn't
+            generate at least this many trades. Aggregate stats still include
+            the trades.
+        bootstrap_samples: Number of bootstrap resamples for CI. 1000 gives
+            stable percentiles without dominating runtime.
+        bootstrap_ci: Two-sided coverage. 0.95 → reports 2.5/97.5 percentiles.
+        random_seed: Seed for the bootstrap RNG so results are reproducible.
+    """
+
+    window_days: int = 90
+    step_days: int = 90
+    min_trades_per_window: int = 5
+    bootstrap_samples: int = 1000
+    bootstrap_ci: float = 0.95
+    random_seed: int = 0
+
+
+@dataclass(frozen=True)
+class BootstrapCI:
+    """Percentile-bootstrap confidence interval for a scalar metric."""
+
+    metric: str
+    point_estimate: float
+    lower: float
+    upper: float
+    samples: int
+
+    def as_dict(self) -> dict[str, float | int | str]:
+        return {
+            "metric": self.metric,
+            "point_estimate": round(self.point_estimate, 4),
+            "lower": round(self.lower, 4),
+            "upper": round(self.upper, 4),
+            "samples": self.samples,
+        }
+
+
+@dataclass(frozen=True)
+class StrategyWindowStats:
+    """Per-window summary for a single strategy."""
+
+    window_idx: int
+    from_date: str
+    to_date: str
+    trades: int
+    return_pct: float
+    win_rate: float
+    profit_factor: float | None
+    max_drawdown_pct: float
+
+
+@dataclass
+class WindowResult:
+    """Wraps the raw MultiStrategyResult plus its window index."""
+
+    window_idx: int
+    from_date: date
+    to_date: date
+    result: MultiStrategyResult
+
+
+@dataclass
+class WalkforwardResult:
+    """Aggregate output of a walkforward run."""
+
+    config: WalkforwardConfig
+    from_date: str
+    to_date: str
+    windows: list[WindowResult] = field(default_factory=list)
+    # strategy_id -> per-window stats (one row per window where ran)
+    per_window: dict[str, list[StrategyWindowStats]] = field(default_factory=dict)
+    # strategy_id -> aggregated OOS stats across all windows
+    aggregate: dict[str, dict[str, float | int | None]] = field(default_factory=dict)
+    # strategy_id -> {metric_name: BootstrapCI}
+    bootstrap: dict[str, dict[str, BootstrapCI]] = field(default_factory=dict)
+
+    def summary(self) -> str:
+        lines: list[str] = [
+            "Walkforward summary",
+            f"  Range: {self.from_date} to {self.to_date}",
+            f"  Windows: {len(self.windows)} "
+            f"(window={self.config.window_days}d, step={self.config.step_days}d)",
+            "",
+        ]
+        for sid, agg in self.aggregate.items():
+            lines.append(f"  Strategy: {sid}")
+            lines.append(
+                f"    Trades: {agg['trades']}  "
+                f"WinRate: {_fmt_pct(agg.get('win_rate'))}  "
+                f"PF: {_fmt_num(agg.get('profit_factor'))}  "
+                f"OOS Return: {_fmt_pct(agg.get('return_pct'))}  "
+                f"Sharpe: {_fmt_num(agg.get('sharpe_approx'))}"
+            )
+            cis = self.bootstrap.get(sid, {})
+            for metric_name, ci in cis.items():
+                lines.append(
+                    f"    {metric_name} CI {int(self.config.bootstrap_ci * 100)}%: "
+                    f"[{ci.lower:.3f}, {ci.upper:.3f}] "
+                    f"(point={ci.point_estimate:.3f})"
+                )
+            lines.append("")
+        return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Core API
+# ---------------------------------------------------------------------------
+
+
+WindowRunner = Callable[[date, date], Awaitable[MultiStrategyResult]]
+
+
+async def run_walkforward(
+    from_date: date,
+    to_date: date,
+    run_window: WindowRunner,
+    config: WalkforwardConfig | None = None,
+) -> WalkforwardResult:
+    """Run rolling-window OOS evaluation.
+
+    Args:
+        from_date: Inclusive start.
+        to_date: Inclusive end.
+        run_window: Async callable that runs the underlying backtest for a
+            single window and returns its ``MultiStrategyResult``.
+        config: Walkforward parameters; defaults if not supplied.
+    """
+    cfg: WalkforwardConfig = config or WalkforwardConfig()
+    if cfg.window_days <= 0 or cfg.step_days <= 0:
+        raise ValueError("window_days and step_days must be positive")
+
+    windows: list[WindowResult] = []
+    cursor: date = from_date
+    idx: int = 0
+    while cursor <= to_date:
+        window_end: date = min(cursor + timedelta(days=cfg.window_days - 1), to_date)
+        if (window_end - cursor).days < max(cfg.window_days // 4, 1):
+            # Skip a tiny trailing window; aggregate would be too noisy.
+            break
+
+        logger.info(
+            "Walkforward window %d: %s -> %s",
+            idx + 1, cursor.isoformat(), window_end.isoformat(),
+        )
+        try:
+            window_result: MultiStrategyResult = await run_window(cursor, window_end)
+        except Exception:
+            logger.exception(
+                "Window %d failed (%s -> %s) — skipping",
+                idx + 1, cursor.isoformat(), window_end.isoformat(),
+            )
+            cursor = cursor + timedelta(days=cfg.step_days)
+            idx += 1
+            continue
+
+        windows.append(
+            WindowResult(
+                window_idx=idx,
+                from_date=cursor,
+                to_date=window_end,
+                result=window_result,
+            )
+        )
+        cursor = cursor + timedelta(days=cfg.step_days)
+        idx += 1
+
+    out: WalkforwardResult = WalkforwardResult(
+        config=cfg,
+        from_date=from_date.isoformat(),
+        to_date=to_date.isoformat(),
+        windows=windows,
+    )
+    if not windows:
+        logger.warning("Walkforward produced no windows")
+        return out
+
+    _aggregate(out, cfg)
+    return out
+
+
+def bootstrap_metric_ci(
+    trade_returns: Sequence[float],
+    metric: Callable[[Sequence[float]], float],
+    *,
+    metric_name: str,
+    samples: int = 1000,
+    coverage: float = 0.95,
+    seed: int = 0,
+) -> BootstrapCI | None:
+    """Percentile-bootstrap CI for a metric over trade-return resamples.
+
+    Args:
+        trade_returns: Per-trade fractional returns (e.g. PnL / cost basis).
+        metric: Callable that maps a resampled list to a scalar (e.g. PF,
+            mean, Sharpe-approx).
+        metric_name: Label for the result.
+        samples: Number of bootstrap resamples (with replacement).
+        coverage: Two-sided CI coverage (e.g. 0.95 → 2.5/97.5 percentiles).
+        seed: RNG seed for reproducibility.
+
+    Returns:
+        ``BootstrapCI`` or ``None`` if there aren't enough trades to be useful.
+    """
+    n: int = len(trade_returns)
+    if n < 5:
+        return None
+    if not 0.0 < coverage < 1.0:
+        raise ValueError(f"coverage must be in (0, 1), got {coverage}")
+
+    rng: random.Random = random.Random(seed)
+    point: float = metric(list(trade_returns))
+
+    estimates: list[float] = []
+    for _ in range(samples):
+        resample: list[float] = [rng.choice(trade_returns) for _ in range(n)]
+        try:
+            estimates.append(metric(resample))
+        except (ZeroDivisionError, ValueError):
+            continue
+
+    if not estimates:
+        return None
+
+    estimates.sort()
+    alpha: float = (1.0 - coverage) / 2.0
+    lower: float = _percentile(estimates, alpha)
+    upper: float = _percentile(estimates, 1.0 - alpha)
+    return BootstrapCI(
+        metric=metric_name,
+        point_estimate=point,
+        lower=lower,
+        upper=upper,
+        samples=len(estimates),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Built-in metrics for trade-return bootstrapping
+# ---------------------------------------------------------------------------
+
+
+def metric_profit_factor(returns: Sequence[float]) -> float:
+    """Sum(positive) / |Sum(negative)|. Returns +inf if no losses, 0 if all zero."""
+    gains: float = sum(r for r in returns if r > 0)
+    losses: float = -sum(r for r in returns if r < 0)
+    if losses == 0:
+        return float("inf") if gains > 0 else 0.0
+    return gains / losses
+
+
+def metric_win_rate(returns: Sequence[float]) -> float:
+    if not returns:
+        return 0.0
+    return sum(1 for r in returns if r > 0) / len(returns)
+
+
+def metric_mean_return(returns: Sequence[float]) -> float:
+    return statistics.fmean(returns) if returns else 0.0
+
+
+def metric_sharpe_approx(returns: Sequence[float]) -> float:
+    """Simple Sharpe approximation: mean / stdev. Per-trade, no annualisation."""
+    if len(returns) < 2:
+        return 0.0
+    mean: float = statistics.fmean(returns)
+    sd: float = statistics.pstdev(returns)
+    if sd == 0:
+        return 0.0
+    return mean / sd
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _aggregate(out: WalkforwardResult, cfg: WalkforwardConfig) -> None:
+    # Index per-strategy trades and per-window stats.
+    by_strategy: dict[str, list[StrategyTrade]] = {}
+    by_strategy_returns: dict[str, list[float]] = {}
+    display_name: dict[str, str] = {}
+
+    for window in out.windows:
+        for sr in window.result.strategies:
+            sid: str = sr.strategy_id
+            display_name.setdefault(sid, sr.display_name)
+
+            by_strategy.setdefault(sid, []).extend(sr.trades)
+            by_strategy_returns.setdefault(sid, []).extend(
+                _trade_returns(sr)
+            )
+
+            stats: StrategyWindowStats = StrategyWindowStats(
+                window_idx=window.window_idx,
+                from_date=window.from_date.isoformat(),
+                to_date=window.to_date.isoformat(),
+                trades=sr.total_trades,
+                return_pct=sr.return_pct,
+                win_rate=sr.win_rate,
+                profit_factor=sr.profit_factor,
+                max_drawdown_pct=sr.max_drawdown_pct,
+            )
+            out.per_window.setdefault(sid, []).append(stats)
+
+    # Aggregate metrics across all OOS trades.
+    for sid, trades in by_strategy.items():
+        returns: list[float] = by_strategy_returns[sid]
+        wins: int = sum(1 for r in returns if r > 0)
+        losses: int = sum(1 for r in returns if r < 0)
+        total: int = len(returns)
+        gross_pnl: float = sum(t.net_pnl_usd for t in trades)
+        # OOS return: compound the per-window returns (geometric, more
+        # realistic than summing).
+        compounded_return_pct: float = _compound_window_returns(out.per_window[sid])
+
+        per_window_stats: list[StrategyWindowStats] = out.per_window.get(sid, [])
+
+        out.aggregate[sid] = {
+            "display_name": display_name[sid],
+            "trades": total,
+            "wins": wins,
+            "losses": losses,
+            "win_rate": (wins / total * 100.0) if total else 0.0,
+            "profit_factor": metric_profit_factor(returns) if total else None,
+            "return_pct": compounded_return_pct,
+            "total_pnl_usd": gross_pnl,
+            "sharpe_approx": metric_sharpe_approx(returns),
+            "windows_traded": sum(1 for w in per_window_stats if w.trades > 0),
+        }
+
+    # Bootstrap CIs.
+    for sid, returns in by_strategy_returns.items():
+        if len(returns) < 5:
+            continue
+        cis: dict[str, BootstrapCI] = {}
+        for metric_name, fn in (
+            ("profit_factor", metric_profit_factor),
+            ("win_rate", metric_win_rate),
+            ("mean_return", metric_mean_return),
+            ("sharpe_approx", metric_sharpe_approx),
+        ):
+            ci = bootstrap_metric_ci(
+                returns,
+                metric=fn,
+                metric_name=metric_name,
+                samples=cfg.bootstrap_samples,
+                coverage=cfg.bootstrap_ci,
+                seed=cfg.random_seed,
+            )
+            if ci is not None:
+                cis[metric_name] = ci
+        out.bootstrap[sid] = cis
+
+
+def _trade_returns(sr: StrategyResult) -> list[float]:
+    """Per-trade fractional return (pnl / cost basis)."""
+    out: list[float] = []
+    for t in sr.trades:
+        cost: float = t.entry_price * float(t.shares)
+        if cost <= 0 or t.exit_price is None:
+            continue
+        out.append(t.net_pnl_usd / cost)
+    return out
+
+
+def _compound_window_returns(stats: list[StrategyWindowStats]) -> float:
+    """Compound a list of per-window percent returns geometrically."""
+    factor: float = 1.0
+    for s in stats:
+        factor *= 1.0 + (s.return_pct / 100.0)
+    return (factor - 1.0) * 100.0
+
+
+def _percentile(sorted_values: list[float], q: float) -> float:
+    """Linear-interpolation percentile on a sorted list."""
+    if not sorted_values:
+        return float("nan")
+    if len(sorted_values) == 1:
+        return sorted_values[0]
+    pos: float = q * (len(sorted_values) - 1)
+    lo: int = int(math.floor(pos))
+    hi: int = int(math.ceil(pos))
+    if lo == hi:
+        return sorted_values[lo]
+    frac: float = pos - lo
+    return sorted_values[lo] * (1.0 - frac) + sorted_values[hi] * frac
+
+
+def _fmt_pct(value: float | int | None) -> str:
+    if value is None:
+        return "n/a"
+    return f"{float(value):+.2f}%"
+
+
+def _fmt_num(value: float | int | None) -> str:
+    if value is None:
+        return "n/a"
+    return f"{float(value):.3f}"

--- a/trading_bot/gateway/recovery.py
+++ b/trading_bot/gateway/recovery.py
@@ -10,8 +10,8 @@ from __future__ import annotations
 import logging
 import sqlite3
 from dataclasses import dataclass, field
-from datetime import date, datetime
-from typing import Any
+from datetime import date, datetime, time, timedelta
+from typing import Any, Callable
 from zoneinfo import ZoneInfo
 
 from alpaca.trading.models import Position as AlpacaPosition
@@ -24,6 +24,10 @@ from trading_bot.notifications.notifier import Notifier
 logger: logging.Logger = logging.getLogger(__name__)
 
 ET: ZoneInfo = TZ_EASTERN
+
+# Default thresholds — overridable via config.
+_DEFAULT_STALE_ENTRY_MINUTES: int = 5
+_DEFAULT_EOD_FLATTEN_TIME: str = "15:55"
 
 
 @dataclass
@@ -39,6 +43,8 @@ class RecoveryResult:
     quantities_updated: list[str] = field(default_factory=list)
     stops_placed: list[str] = field(default_factory=list)
     settlements_updated: int = 0
+    stale_orders_cancelled: list[str] = field(default_factory=list)
+    eod_flatten_orders: list[str] = field(default_factory=list)
 
     account_equity: float = 0.0
     settled_cash: float = 0.0
@@ -50,6 +56,8 @@ class RecoveryResult:
             self.positions_created
             or self.positions_closed_mismatch
             or self.quantities_updated
+            or self.stale_orders_cancelled
+            or self.eod_flatten_orders
         )
 
     def summary(self) -> str:
@@ -68,6 +76,15 @@ class RecoveryResult:
             lines.append(f"Updated quantities: {', '.join(self.quantities_updated)}")
         if self.stops_placed:
             lines.append(f"Placed missing stop orders: {', '.join(self.stops_placed)}")
+        if self.stale_orders_cancelled:
+            lines.append(
+                f"Cancelled stale entry orders: {', '.join(self.stale_orders_cancelled)}"
+            )
+        if self.eod_flatten_orders:
+            lines.append(
+                f"EOD flatten — closing intraday positions: "
+                f"{', '.join(self.eod_flatten_orders)}"
+            )
         if self.settlements_updated:
             lines.append(f"Settlements marked settled: {self.settlements_updated}")
         if not self.has_discrepancies:
@@ -84,11 +101,15 @@ class StateRecovery:
         db_path: str,
         notifier: Notifier,
         config: dict[str, Any] | None = None,
+        now_fn: "Callable[[], datetime] | None" = None,  # noqa: F821
     ) -> None:
         self._gw: GatewayConnection = gateway
         self._db_path: str = db_path
         self._notifier: Notifier = notifier
         self._config: dict[str, Any] = config or {}
+        # Injectable clock — defaults to wall clock in ET. Tests pass a
+        # fixed clock to exercise the EOD-flatten branches deterministically.
+        self._now_fn = now_fn or (lambda: datetime.now(tz=ET))
 
     async def recover(self) -> RecoveryResult:
         """Run the full state-recovery sequence."""
@@ -118,10 +139,18 @@ class StateRecovery:
         # 6. Verify stop orders
         await self._verify_stop_orders(alpaca_positions, alpaca_orders, result)
 
-        # 7. Update settlements
+        # 7. Cancel stale entry orders. Fresh order list because step 6 may
+        #    have placed new stops, but those are GTC and not stale.
+        await self._cancel_stale_entry_orders(alpaca_orders, result)
+
+        # 8. EOD intraday flatten. Closes intraday-tagged DB positions if the
+        #    cron tick lands after the configured cutoff (default 15:55 ET).
+        await self._eod_intraday_flatten(alpaca_positions, result)
+
+        # 9. Update settlements
         result.settlements_updated = self._update_settlements()
 
-        # 8. Log and alert
+        # 10. Log and alert
         logger.info("State recovery complete:\n%s", result.summary())
         if result.has_discrepancies:
             await self._notifier.gateway_alert(
@@ -255,6 +284,131 @@ class StateRecovery:
         except Exception:
             logger.exception("Failed to place emergency stop for %s", ticker)
 
+    async def _cancel_stale_entry_orders(
+        self,
+        alpaca_orders: list[AlpacaOrder],
+        result: RecoveryResult,
+    ) -> None:
+        """Cancel pending entry orders older than the stale threshold.
+
+        Borrowed from alpacahq/example-scalping: a stateless tick missed by
+        cron can leave a buy/sell ``new`` order hanging at a price that no
+        longer reflects the signal. We cancel any non-stop, non-trailing
+        entry order older than ``stale_entry_order_minutes``.
+        """
+        exit_cfg: dict[str, Any] = self._config.get("exit_intraday", {})
+        threshold_min: int = int(
+            exit_cfg.get("stale_entry_order_minutes", _DEFAULT_STALE_ENTRY_MINUTES)
+        )
+        if threshold_min <= 0:
+            return
+
+        now: datetime = self._now_fn()
+        cutoff: datetime = now - timedelta(minutes=threshold_min)
+
+        for order in alpaca_orders:
+            order_type: str = order.type.value if order.type else ""
+            # Don't cancel risk-management orders. Those are GTC by design.
+            if order_type in ("stop", "trailing_stop", "stop_limit"):
+                continue
+
+            submitted_at: datetime | None = _to_et(
+                getattr(order, "submitted_at", None)
+                or getattr(order, "created_at", None)
+            )
+            if submitted_at is None or submitted_at >= cutoff:
+                continue
+
+            ticker: str = str(order.symbol)
+            order_id: str = str(getattr(order, "id", "") or "")
+            try:
+                self._gw.client.cancel_order_by_id(order_id)
+                age_min: float = (now - submitted_at).total_seconds() / 60.0
+                logger.warning(
+                    "Cancelled stale %s order for %s (id=%s, age=%.1f min)",
+                    order_type, ticker, order_id, age_min,
+                )
+                result.stale_orders_cancelled.append(ticker)
+            except Exception:
+                logger.exception(
+                    "Failed to cancel stale order id=%s ticker=%s",
+                    order_id, ticker,
+                )
+
+    async def _eod_intraday_flatten(
+        self,
+        alpaca_positions: list[AlpacaPosition],
+        result: RecoveryResult,
+    ) -> None:
+        """Close DB-tagged intraday positions if past the EOD cutoff.
+
+        Swing positions are intentionally untouched. Only intraday-tagged
+        positions in the local DB are flattened — that keeps the policy
+        decision (which holds are intraday) inside our config rather than
+        relying on broker metadata.
+        """
+        exit_cfg: dict[str, Any] = self._config.get("exit_intraday", {})
+        cutoff_str: str = str(
+            exit_cfg.get("eod_flatten_time_et", _DEFAULT_EOD_FLATTEN_TIME)
+        )
+        if not cutoff_str:
+            return
+
+        try:
+            cutoff_t: time = time.fromisoformat(cutoff_str)
+        except ValueError:
+            logger.warning("Invalid eod_flatten_time_et=%r — skipping", cutoff_str)
+            return
+
+        now_et: datetime = self._now_fn()
+        if now_et.time() < cutoff_t:
+            return
+
+        intraday_tickers: set[str] = self._intraday_tickers_in_db()
+        if not intraday_tickers:
+            return
+
+        from alpaca.trading.requests import MarketOrderRequest
+        from alpaca.trading.enums import OrderSide, TimeInForce
+
+        for pos in alpaca_positions:
+            ticker: str = str(pos.symbol)
+            if ticker not in intraday_tickers:
+                continue
+            qty: int = int(float(pos.qty or 0))
+            if qty == 0:
+                continue
+
+            side: OrderSide = OrderSide.SELL if qty > 0 else OrderSide.BUY
+            try:
+                request = MarketOrderRequest(
+                    symbol=ticker,
+                    qty=abs(qty),
+                    side=side,
+                    time_in_force=TimeInForce.DAY,
+                )
+                self._gw.client.submit_order(order_data=request)
+                logger.warning(
+                    "EOD flatten: %s %d %s (cutoff=%s)",
+                    side.value, abs(qty), ticker, cutoff_str,
+                )
+                result.eod_flatten_orders.append(ticker)
+            except Exception:
+                logger.exception("EOD flatten failed for %s", ticker)
+
+    def _intraday_tickers_in_db(self) -> set[str]:
+        conn: sqlite3.Connection = sqlite3.connect(self._db_path)
+        try:
+            cursor = conn.execute(
+                "SELECT ticker FROM positions "
+                "WHERE status != 'CLOSED' AND hold_type = 'intraday'"
+            )
+            return {row[0] for row in cursor.fetchall()}
+        except sqlite3.OperationalError:
+            return set()
+        finally:
+            conn.close()
+
     def _update_settlements(self) -> int:
         today_str: str = date.today().isoformat()
         conn: sqlite3.Connection = sqlite3.connect(self._db_path)
@@ -358,3 +512,21 @@ def _safe_float(value: Any) -> float:
         return float(value)
     except (TypeError, ValueError):
         return 0.0
+
+
+def _to_et(value: Any) -> datetime | None:
+    """Coerce an Alpaca timestamp (datetime or ISO string) to ET, or None."""
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        dt: datetime = value
+    elif isinstance(value, str):
+        try:
+            dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    else:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=ZoneInfo("UTC"))
+    return dt.astimezone(ET)

--- a/trading_bot/multi_strategy_backtest.py
+++ b/trading_bot/multi_strategy_backtest.py
@@ -22,8 +22,11 @@ import logging
 import statistics
 from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta, time
-from typing import Any
+from typing import Any, TYPE_CHECKING
 from zoneinfo import ZoneInfo
+
+if TYPE_CHECKING:
+    from trading_bot.backtest.walkforward import WalkforwardResult
 
 import pandas as pd
 
@@ -1787,6 +1790,73 @@ def save_comparison_json(
     return output_path
 
 
+def save_walkforward_json(
+    result: "WalkforwardResult",
+    output_path: str | None = None,
+) -> str:
+    """Save a walkforward run (per-window stats, aggregate, bootstrap CIs)."""
+    import os
+
+    payload: dict[str, Any] = {
+        "from_date": result.from_date,
+        "to_date": result.to_date,
+        "config": {
+            "window_days": result.config.window_days,
+            "step_days": result.config.step_days,
+            "bootstrap_samples": result.config.bootstrap_samples,
+            "bootstrap_ci": result.config.bootstrap_ci,
+            "min_trades_per_window": result.config.min_trades_per_window,
+        },
+        "windows": [
+            {
+                "window_idx": w.window_idx,
+                "from_date": w.from_date.isoformat(),
+                "to_date": w.to_date.isoformat(),
+            }
+            for w in result.windows
+        ],
+        "aggregate": result.aggregate,
+        "per_window": {
+            sid: [
+                {
+                    "window_idx": s.window_idx,
+                    "from_date": s.from_date,
+                    "to_date": s.to_date,
+                    "trades": s.trades,
+                    "return_pct": round(s.return_pct, 4),
+                    "win_rate": round(s.win_rate, 4),
+                    "profit_factor": (
+                        round(s.profit_factor, 4) if s.profit_factor is not None else None
+                    ),
+                    "max_drawdown_pct": round(s.max_drawdown_pct, 4),
+                }
+                for s in stats
+            ]
+            for sid, stats in result.per_window.items()
+        },
+        "bootstrap": {
+            sid: {name: ci.as_dict() for name, ci in cis.items()}
+            for sid, cis in result.bootstrap.items()
+        },
+    }
+
+    if output_path is None:
+        out_dir = os.path.join(os.getcwd(), "backtest_results")
+        os.makedirs(out_dir, exist_ok=True)
+        now = datetime.now(ZoneInfo("Europe/London"))
+        ts = now.strftime("%Y%m%dT%H%M%S")
+        output_path = os.path.join(
+            out_dir,
+            f"walkforward_{result.from_date}_to_{result.to_date}_{ts}.json",
+        )
+
+    with open(output_path, "w", encoding="utf-8") as fh:
+        json.dump(payload, fh, indent=2, default=str)
+
+    logger.info("Walkforward results saved to %s", output_path)
+    return output_path
+
+
 # ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
@@ -1835,6 +1905,26 @@ async def main() -> None:
         "--tickers", type=str, default="SPY,QQQ,XLF,XLK",
         help="Comma-separated tickers for --multi-intraday mode",
     )
+    parser.add_argument(
+        "--walkforward", action="store_true",
+        help="Run rolling-window OOS evaluation with bootstrap CIs",
+    )
+    parser.add_argument(
+        "--wf-window", type=int, default=90,
+        help="Walkforward window size in calendar days (default: 90)",
+    )
+    parser.add_argument(
+        "--wf-step", type=int, default=90,
+        help="Walkforward step size in calendar days (default: 90)",
+    )
+    parser.add_argument(
+        "--wf-bootstrap", type=int, default=1000,
+        help="Bootstrap resamples for walkforward CIs (default: 1000)",
+    )
+    parser.add_argument(
+        "--wf-ci", type=float, default=0.95,
+        help="Walkforward CI coverage in (0, 1) (default: 0.95)",
+    )
     args = parser.parse_args()
 
     logger.info(
@@ -1855,49 +1945,96 @@ async def main() -> None:
         tickers = list(raw.get("us", []))
         await download_all(config, tickers, d_from, d_to)
 
-    engine = MultiStrategyBacktester(config)
-
-    # Filter strategies if --strategies specified
+    # Validate the strategy filter early so we fail fast on a typo'd
+    # strategy id, rather than running an empty backtest per window.
     if args.strategies:
         selected = set(s.strip() for s in args.strategies.split(","))
-        before = len(engine._strategies)
-        engine._strategies = [s for s in engine._strategies if s.strategy_id in selected]
+        probe = MultiStrategyBacktester(config)
+        matched = [s.strategy_id for s in probe._strategies if s.strategy_id in selected]
         logger.info(
             "Strategy filter: %d -> %d strategies (%s)",
-            before, len(engine._strategies), [s.strategy_id for s in engine._strategies],
+            len(probe._strategies), len(matched), matched,
         )
-        if not engine._strategies:
+        if not matched:
             logger.error("No matching strategies found for: %s", selected)
             return
 
-    if args.multi_intraday:
-        ticker_list = [t.strip() for t in args.tickers.split(",") if t.strip()]
-        logger.info("Running multi-ticker intraday backtest on %s", ticker_list)
-        result = await engine.run_multi_ticker_intraday(
-            d_from, d_to,
-            tickers=ticker_list,
-            cash_per_strategy_usd=args.cash,
-            regime_filter=not args.no_regime_filter,
+    ticker_list = [t.strip() for t in args.tickers.split(",") if t.strip()]
+
+    async def _run_window(d1: date, d2: date) -> MultiStrategyResult:
+        # Each window needs a fresh engine so per-strategy state
+        # (cash, peak equity, cooldowns) doesn't leak across windows.
+        window_engine = MultiStrategyBacktester(config)
+        if args.strategies:
+            selected = set(s.strip() for s in args.strategies.split(","))
+            window_engine._strategies = [
+                s for s in window_engine._strategies if s.strategy_id in selected
+            ]
+        if args.multi_intraday:
+            return await window_engine.run_multi_ticker_intraday(
+                d1, d2,
+                tickers=ticker_list,
+                cash_per_strategy_usd=args.cash,
+                regime_filter=not args.no_regime_filter,
+            )
+        if args.spy:
+            return await window_engine.run_spy_intraday(
+                d1, d2,
+                cash_per_strategy_usd=args.cash,
+                regime_filter=not args.no_regime_filter,
+            )
+        if args.daily:
+            return await window_engine.run_daily(
+                d1, d2,
+                cash_per_strategy_usd=args.cash,
+                min_avg_volume=args.min_volume,
+                min_price=args.min_price,
+                max_price=args.max_price,
+                regime_filter=not args.no_regime_filter,
+            )
+        return await window_engine.run(d1, d2, cash_per_strategy_usd=args.cash)
+
+    if args.walkforward:
+        from trading_bot.backtest.walkforward import (
+            WalkforwardConfig,
+            run_walkforward,
         )
+
+        wf_cfg = WalkforwardConfig(
+            window_days=args.wf_window,
+            step_days=args.wf_step,
+            bootstrap_samples=args.wf_bootstrap,
+            bootstrap_ci=args.wf_ci,
+        )
+        logger.info(
+            "Running walkforward: window=%dd step=%dd bootstrap=%d ci=%.2f",
+            wf_cfg.window_days, wf_cfg.step_days,
+            wf_cfg.bootstrap_samples, wf_cfg.bootstrap_ci,
+        )
+        wf_result = await run_walkforward(d_from, d_to, _run_window, config=wf_cfg)
+        report = wf_result.summary()
+        for line in report.splitlines():
+            logger.info(line)
+        print(report)
+
+        json_path = save_walkforward_json(wf_result)
+        logger.info("Walkforward JSON saved to %s", json_path)
+        logger.info("Log file: %s", log_path)
+        print(f"\nWalkforward results saved to: {json_path}")
+        print(f"Log file: {log_path}")
+        return
+
+    if args.multi_intraday:
+        logger.info("Running multi-ticker intraday backtest on %s", ticker_list)
+        result = await _run_window(d_from, d_to)
     elif args.spy:
         logger.info("Running SPY intraday backtest (5-min bars)")
-        result = await engine.run_spy_intraday(
-            d_from, d_to,
-            cash_per_strategy_usd=args.cash,
-            regime_filter=not args.no_regime_filter,
-        )
+        result = await _run_window(d_from, d_to)
     elif args.daily:
         logger.info("Running daily-bar backtest on S&P 500 universe")
-        result = await engine.run_daily(
-            d_from, d_to,
-            cash_per_strategy_usd=args.cash,
-            min_avg_volume=args.min_volume,
-            min_price=args.min_price,
-            max_price=args.max_price,
-            regime_filter=not args.no_regime_filter,
-        )
+        result = await _run_window(d_from, d_to)
     else:
-        result = await engine.run(d_from, d_to, cash_per_strategy_usd=args.cash)
+        result = await _run_window(d_from, d_to)
 
     report = format_comparison_report(result)
     for line in report.splitlines():
@@ -1908,7 +2045,7 @@ async def main() -> None:
     logger.info("JSON results saved to %s", json_path)
     logger.info("Log file: %s", log_path)
     print(f"\nResults saved to: {json_path}")
-    print(f"Log file: {log_path}")
+    print(f"\nLog file: {log_path}")
 
 
 if __name__ == "__main__":

--- a/trading_bot/tests/test_state_recovery.py
+++ b/trading_bot/tests/test_state_recovery.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import sqlite3
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 from zoneinfo import ZoneInfo
@@ -18,15 +18,20 @@ ET = ZoneInfo("US/Eastern")
 # ---------------------------------------------------------------------------
 
 
-def _make_recovery(gateway, db_path: str, notifier) -> Any:
+def _make_recovery(
+    gateway,
+    db_path: str,
+    notifier,
+    now: datetime | None = None,
+    config: dict[str, Any] | None = None,
+) -> Any:
     from trading_bot.gateway.recovery import StateRecovery
     return StateRecovery(
         gateway=gateway,
         db_path=db_path,
         notifier=notifier,
-        config={
-            "exit_intraday": {"stop_loss_pct": 0.02},
-        },
+        config=config or {"exit_intraday": {"stop_loss_pct": 0.02}},
+        now_fn=(lambda: now) if now is not None else None,
     )
 
 
@@ -47,12 +52,35 @@ def _alpaca_position(
 def _alpaca_order(
     ticker: str,
     order_type: str = "stop",
+    submitted_at: datetime | None = None,
+    order_id: str = "ord-1",
 ) -> MagicMock:
     order = MagicMock()
     order.symbol = ticker
     order.type = MagicMock()
     order.type.value = order_type
+    order.id = order_id
+    order.submitted_at = submitted_at
+    order.created_at = submitted_at
     return order
+
+
+def _insert_db_position_intraday(
+    conn: sqlite3.Connection,
+    ticker: str,
+    qty: int = 100,
+    entry_price: float = 10.0,
+) -> int:
+    cur = conn.execute(
+        """INSERT INTO positions
+           (ticker, exchange, currency, quantity, entry_price, entry_time,
+            status, hold_type, phase, strategy_id)
+           VALUES (?,?,?,?,?,?,?,?,?,?)""",
+        (ticker, "NASDAQ", "USD", qty, entry_price,
+         datetime.now(ET).isoformat(), "POSITION_OPEN", "intraday", 1, "mr"),
+    )
+    conn.commit()
+    return cur.lastrowid
 
 
 def _insert_db_position(
@@ -192,6 +220,114 @@ class TestStateRecovery:
         recovery = _make_recovery(gw, tmp_db_path, mock_notifier)
         result = await recovery.recover()
         assert not result.has_discrepancies
+
+    @pytest.mark.asyncio
+    async def test_stale_entry_order_cancelled(
+        self, tmp_db_path: str, mock_notifier
+    ) -> None:
+        """A 'limit' order older than the threshold is cancelled."""
+        old_ts = datetime.now(ET) - timedelta(minutes=10)
+        stale = _alpaca_order("PLTR", order_type="limit", submitted_at=old_ts, order_id="abc")
+        gw = self._make_gateway(positions=[], orders=[stale])
+
+        recovery = _make_recovery(gw, tmp_db_path, mock_notifier)
+        result = await recovery.recover()
+
+        assert "PLTR" in result.stale_orders_cancelled
+        gw.client.cancel_order_by_id.assert_called_once_with("abc")
+
+    @pytest.mark.asyncio
+    async def test_fresh_entry_order_not_cancelled(
+        self, tmp_db_path: str, mock_notifier
+    ) -> None:
+        """A recently submitted entry order is left alone."""
+        fresh_ts = datetime.now(ET) - timedelta(seconds=30)
+        fresh = _alpaca_order("PLTR", order_type="limit", submitted_at=fresh_ts)
+        gw = self._make_gateway(positions=[], orders=[fresh])
+
+        recovery = _make_recovery(gw, tmp_db_path, mock_notifier)
+        result = await recovery.recover()
+
+        assert not result.stale_orders_cancelled
+        gw.client.cancel_order_by_id.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_stop_orders_never_cancelled_as_stale(
+        self, tmp_db_path: str, mock_notifier
+    ) -> None:
+        """Stop and trailing-stop orders are GTC by design — never stale."""
+        old_ts = datetime.now(ET) - timedelta(hours=4)
+        old_stop = _alpaca_order("PLTR", order_type="stop", submitted_at=old_ts)
+        # Need a position so the existing stop-verification step doesn't try
+        # to place a fresh stop and call submit_order.
+        pos = _alpaca_position("PLTR", qty=100)
+        gw = self._make_gateway(positions=[pos], orders=[old_stop])
+
+        recovery = _make_recovery(gw, tmp_db_path, mock_notifier)
+        result = await recovery.recover()
+
+        assert not result.stale_orders_cancelled
+        gw.client.cancel_order_by_id.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_eod_flatten_closes_intraday_position(
+        self, tmp_db_path: str, mock_notifier
+    ) -> None:
+        """Past 15:55 ET: intraday-tagged position is flattened."""
+        conn = sqlite3.connect(tmp_db_path)
+        _insert_db_position_intraday(conn, "PLTR", qty=100)
+        conn.close()
+
+        pos = _alpaca_position("PLTR", qty=100)
+        # Stop already exists so the stop-verifier doesn't call submit_order.
+        stop = _alpaca_order("PLTR", order_type="stop")
+        gw = self._make_gateway(positions=[pos], orders=[stop])
+
+        eod_now = datetime(2026, 4, 28, 15, 56, tzinfo=ET)
+        recovery = _make_recovery(gw, tmp_db_path, mock_notifier, now=eod_now)
+        result = await recovery.recover()
+
+        assert "PLTR" in result.eod_flatten_orders
+        # Stop already exists, so only the flatten market-order is submitted.
+        assert gw.client.submit_order.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_eod_flatten_skipped_for_swing_positions(
+        self, tmp_db_path: str, mock_notifier
+    ) -> None:
+        """Swing-tagged positions are not flattened at EOD."""
+        conn = sqlite3.connect(tmp_db_path)
+        _insert_db_position(conn, "PLTR", qty=100)  # default hold_type='swing'
+        conn.close()
+
+        pos = _alpaca_position("PLTR", qty=100)
+        stop = _alpaca_order("PLTR", order_type="stop")
+        gw = self._make_gateway(positions=[pos], orders=[stop])
+
+        eod_now = datetime(2026, 4, 28, 15, 58, tzinfo=ET)
+        recovery = _make_recovery(gw, tmp_db_path, mock_notifier, now=eod_now)
+        result = await recovery.recover()
+
+        assert not result.eod_flatten_orders
+
+    @pytest.mark.asyncio
+    async def test_eod_flatten_skipped_before_cutoff(
+        self, tmp_db_path: str, mock_notifier
+    ) -> None:
+        """Before 15:55 ET, even intraday positions are kept open."""
+        conn = sqlite3.connect(tmp_db_path)
+        _insert_db_position_intraday(conn, "PLTR", qty=100)
+        conn.close()
+
+        pos = _alpaca_position("PLTR", qty=100)
+        stop = _alpaca_order("PLTR", order_type="stop")
+        gw = self._make_gateway(positions=[pos], orders=[stop])
+
+        midday = datetime(2026, 4, 28, 11, 30, tzinfo=ET)
+        recovery = _make_recovery(gw, tmp_db_path, mock_notifier, now=midday)
+        result = await recovery.recover()
+
+        assert not result.eod_flatten_orders
 
     @pytest.mark.asyncio
     async def test_settlements_updated_on_recovery(

--- a/trading_bot/tests/test_walkforward.py
+++ b/trading_bot/tests/test_walkforward.py
@@ -1,0 +1,261 @@
+"""Tests for the walkforward harness and bootstrap CI utilities."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from trading_bot.backtest.walkforward import (
+    BootstrapCI,
+    WalkforwardConfig,
+    bootstrap_metric_ci,
+    metric_mean_return,
+    metric_profit_factor,
+    metric_sharpe_approx,
+    metric_win_rate,
+    run_walkforward,
+)
+from trading_bot.multi_strategy_backtest import (
+    MultiStrategyResult,
+    StrategyResult,
+    StrategyTrade,
+)
+
+ET = ZoneInfo("US/Eastern")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _trade(
+    pnl: float,
+    entry_price: float = 100.0,
+    shares: float = 1.0,
+    strategy_id: str = "mr",
+) -> StrategyTrade:
+    return StrategyTrade(
+        strategy_id=strategy_id,
+        ticker="SPY",
+        exchange="NASDAQ",
+        entry_time=datetime(2026, 1, 1, 10, 0, tzinfo=ET),
+        entry_price=entry_price,
+        shares=shares,
+        stop_price=entry_price * 0.98,
+        target_price=None,
+        trail_pct=None,
+        signals={},
+        exit_time=datetime(2026, 1, 1, 11, 0, tzinfo=ET),
+        exit_price=entry_price + pnl / shares,
+        exit_reason="target",
+        gross_pnl_usd=pnl,
+        net_pnl_usd=pnl,
+    )
+
+
+def _multi_result(
+    from_date: date,
+    to_date: date,
+    return_pct: float,
+    trades_pnl: list[float],
+) -> MultiStrategyResult:
+    sr = StrategyResult(
+        strategy_id="mr",
+        display_name="Mean Reversion",
+        initial_cash_usd=1000.0,
+        final_cash_usd=1000.0 * (1 + return_pct / 100.0),
+        trades=[_trade(p) for p in trades_pnl],
+        total_trades=len(trades_pnl),
+        wins=sum(1 for p in trades_pnl if p > 0),
+        losses=sum(1 for p in trades_pnl if p < 0),
+        total_pnl_usd=sum(trades_pnl),
+        return_pct=return_pct,
+        max_drawdown_pct=2.0,
+        win_rate=(
+            (sum(1 for p in trades_pnl if p > 0) / len(trades_pnl)) * 100.0
+            if trades_pnl else 0.0
+        ),
+        profit_factor=(
+            sum(p for p in trades_pnl if p > 0)
+            / max(0.0001, -sum(p for p in trades_pnl if p < 0))
+            if any(p < 0 for p in trades_pnl) else None
+        ),
+    )
+    return MultiStrategyResult(
+        from_date=from_date.isoformat(),
+        to_date=to_date.isoformat(),
+        trading_days=21,
+        strategies=[sr],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Bootstrap CI
+# ---------------------------------------------------------------------------
+
+
+class TestBootstrapCI:
+    def test_returns_none_below_min_sample(self) -> None:
+        ci = bootstrap_metric_ci(
+            [0.01, 0.02], metric=metric_mean_return,
+            metric_name="mean", samples=100, seed=1,
+        )
+        assert ci is None
+
+    def test_lower_le_point_le_upper(self) -> None:
+        returns = [0.02, -0.01, 0.03, -0.005, 0.015, 0.01, -0.02, 0.025]
+        ci = bootstrap_metric_ci(
+            returns, metric=metric_mean_return,
+            metric_name="mean_return", samples=500, seed=42,
+        )
+        assert ci is not None
+        assert ci.lower <= ci.point_estimate <= ci.upper
+
+    def test_seed_is_reproducible(self) -> None:
+        returns = [0.02, -0.01, 0.03, -0.005, 0.015, 0.01, -0.02, 0.025]
+        ci1 = bootstrap_metric_ci(
+            returns, metric=metric_profit_factor,
+            metric_name="pf", samples=500, seed=7,
+        )
+        ci2 = bootstrap_metric_ci(
+            returns, metric=metric_profit_factor,
+            metric_name="pf", samples=500, seed=7,
+        )
+        assert ci1 == ci2
+
+    def test_invalid_coverage_raises(self) -> None:
+        with pytest.raises(ValueError):
+            bootstrap_metric_ci(
+                [0.01] * 10, metric=metric_mean_return,
+                metric_name="m", samples=10, coverage=1.5, seed=0,
+            )
+
+    def test_profit_factor_handles_no_losses(self) -> None:
+        # All-winners → +inf PF point estimate, no crash.
+        returns = [0.01] * 10
+        ci = bootstrap_metric_ci(
+            returns, metric=metric_profit_factor,
+            metric_name="pf", samples=200, seed=0,
+        )
+        assert ci is not None
+        # Point estimate is +inf; bounds should also be +inf.
+        assert ci.point_estimate == float("inf")
+
+
+class TestWindowMetrics:
+    def test_win_rate(self) -> None:
+        assert metric_win_rate([0.01, -0.01, 0.02, 0.03]) == 0.75
+
+    def test_profit_factor_basic(self) -> None:
+        # gains = 0.05, losses = 0.02 → PF = 2.5
+        assert metric_profit_factor([0.03, -0.02, 0.02]) == pytest.approx(2.5)
+
+    def test_sharpe_approx_zero_when_constant(self) -> None:
+        assert metric_sharpe_approx([0.01, 0.01, 0.01]) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# run_walkforward
+# ---------------------------------------------------------------------------
+
+
+class TestRunWalkforward:
+    @pytest.mark.asyncio
+    async def test_splits_into_non_overlapping_windows(self) -> None:
+        # 90-day windows over 270 days → 3 windows.
+        d_from = date(2026, 1, 1)
+        d_to = date(2026, 9, 27)  # 269 days
+
+        captured: list[tuple[date, date]] = []
+
+        async def runner(d1: date, d2: date) -> MultiStrategyResult:
+            captured.append((d1, d2))
+            return _multi_result(d1, d2, return_pct=2.0, trades_pnl=[10, -5, 15, -3, 8])
+
+        cfg = WalkforwardConfig(window_days=90, step_days=90, bootstrap_samples=100)
+        result = await run_walkforward(d_from, d_to, runner, config=cfg)
+
+        assert len(result.windows) == 3
+        # First window starts at d_from.
+        assert captured[0][0] == d_from
+        # Windows are contiguous and 90 days each (last may be truncated).
+        for d1, d2 in captured[:-1]:
+            assert (d2 - d1).days == 89
+
+    @pytest.mark.asyncio
+    async def test_aggregate_stats_match_per_window(self) -> None:
+        d_from = date(2026, 1, 1)
+        d_to = date(2026, 6, 30)
+
+        async def runner(d1: date, d2: date) -> MultiStrategyResult:
+            return _multi_result(d1, d2, return_pct=3.0, trades_pnl=[12, -4, 8, -3, 10, -2])
+
+        cfg = WalkforwardConfig(window_days=90, step_days=90, bootstrap_samples=200)
+        result = await run_walkforward(d_from, d_to, runner, config=cfg)
+
+        assert "mr" in result.aggregate
+        agg = result.aggregate["mr"]
+        # Two windows × 6 trades = 12 OOS trades.
+        assert agg["trades"] == 12
+        # trades_pnl=[12,-4,8,-3,10,-2] → 3 wins, 3 losses per window.
+        assert agg["wins"] == 6
+        assert agg["losses"] == 6
+        # OOS return compounds two +3% windows: (1.03)^2 - 1 = 6.09%.
+        assert agg["return_pct"] == pytest.approx(6.09, rel=1e-3)
+
+    @pytest.mark.asyncio
+    async def test_bootstrap_cis_attached_for_each_strategy(self) -> None:
+        d_from = date(2026, 1, 1)
+        d_to = date(2026, 3, 31)
+
+        async def runner(d1: date, d2: date) -> MultiStrategyResult:
+            return _multi_result(d1, d2, return_pct=2.0,
+                                 trades_pnl=[10, -3, 8, -2, 12, -4, 6])
+
+        cfg = WalkforwardConfig(window_days=90, step_days=90,
+                                bootstrap_samples=200, bootstrap_ci=0.90)
+        result = await run_walkforward(d_from, d_to, runner, config=cfg)
+
+        cis = result.bootstrap.get("mr", {})
+        assert "profit_factor" in cis
+        assert "win_rate" in cis
+        assert "mean_return" in cis
+        assert "sharpe_approx" in cis
+        for ci in cis.values():
+            assert isinstance(ci, BootstrapCI)
+            # Coverage was 0.90, so lower < upper is the only invariant we
+            # can assert without making the test flaky.
+            assert ci.lower <= ci.upper
+
+    @pytest.mark.asyncio
+    async def test_window_failure_is_skipped_not_fatal(self) -> None:
+        d_from = date(2026, 1, 1)
+        d_to = date(2026, 6, 30)
+        call_count = {"n": 0}
+
+        async def runner(d1: date, d2: date) -> MultiStrategyResult:
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise RuntimeError("simulated data load failure")
+            return _multi_result(d1, d2, return_pct=1.0, trades_pnl=[5, -2, 3, -1, 4])
+
+        cfg = WalkforwardConfig(window_days=90, step_days=90, bootstrap_samples=100)
+        result = await run_walkforward(d_from, d_to, runner, config=cfg)
+
+        # First window failed and was skipped; second was recorded.
+        assert len(result.windows) == 1
+
+    @pytest.mark.asyncio
+    async def test_invalid_window_days_raises(self) -> None:
+        async def runner(d1: date, d2: date) -> MultiStrategyResult:
+            return _multi_result(d1, d2, return_pct=0.0, trades_pnl=[])
+
+        with pytest.raises(ValueError):
+            await run_walkforward(
+                date(2026, 1, 1), date(2026, 6, 30),
+                runner,
+                config=WalkforwardConfig(window_days=0, step_days=10),
+            )


### PR DESCRIPTION
## Summary

Two upgrades borrowed from popular OSS trading bots:

- **Walkforward + bootstrap CI** (from [edtechre/pybroker](https://github.com/edtechre/pybroker)) — rolling-window OOS evaluation with non-parametric confidence intervals on PF / win-rate / Sharpe / mean return. Directly addresses overfitting risk on the headline SPY mean-reversion result (60.8% / PF 1.54).
- **State recovery hardening** (from [alpacahq/example-scalping](https://github.com/alpacahq/example-scalping)) — stale-entry-order cancellation and EOD intraday flatten, layered onto the existing position/stop reconciliation. Closes a real correctness gap in the stateless-tick model.

## What's new

### `trading_bot/backtest/walkforward.py` (new module)
- `run_walkforward(from, to, run_window, config)` — slices the date range into rolling windows, runs the existing backtester per window, aggregates per-strategy OOS stats with **geometrically compounded** returns.
- `bootstrap_metric_ci(returns, metric, ...)` — percentile bootstrap with reproducible seeding.
- CLI: `--walkforward --wf-window 90 --wf-step 90 --wf-bootstrap 1000 --wf-ci 0.95`. Works with all four backtest modes (`--spy`, `--multi-intraday`, `--daily`, default).
- Output saved to `backtest_results/walkforward_<from>_to_<to>_<ts>.json`.
- Each window builds a fresh engine so cash/cooldown state cannot leak across windows.

### `trading_bot/gateway/recovery.py` (extended)
- `_cancel_stale_entry_orders` — cancels non-stop entry orders older than `exit_intraday.stale_entry_order_minutes` (default 5). Stop / trailing-stop / stop-limit are GTC by design and untouched.
- `_eod_intraday_flatten` — at/after `exit_intraday.eod_flatten_time_et` (default `15:55` ET), submits closing market orders for any DB position tagged `hold_type='intraday'`. Swing positions ignored.
- Injectable `now_fn` clock keeps the time-of-day branch deterministically testable.

## Config (optional — defaults apply if omitted)

```yaml
exit_intraday:
  stale_entry_order_minutes: 5
  eod_flatten_time_et: "15:55"
```

## Test plan

- [x] 13 new walkforward tests (window slicing, OOS aggregate compounding, bootstrap CI invariants, failed-window resilience, config validation)
- [x] 6 new state-recovery tests (stale cancel, fresh-not-cancelled, stop-orders-never-stale, EOD flatten intraday, EOD skip swing, EOD skip before cutoff)
- [x] Full suite: **527 passed, 2 skipped** (pre-existing skips)
- [ ] Smoke run `--walkforward` against SPY 5-min cache before relying on the OOS numbers
- [ ] Spot-check stale-cancel and EOD branches in paper trading before live

🤖 Generated with [Claude Code](https://claude.com/claude-code)