### PR TITLE
feat: wire vol-target into live mean_reversion sizing

### DIFF
--- a/trading_bot/main.py
+++ b/trading_bot/main.py
@@ -143,7 +143,14 @@ class TradingBot:
         self._strategy_manager: StrategyManager | None = None
         if config.multi_strategy_enabled:
             strategy_configs: dict[str, Any] = config.get_strategy_configs()
-            strategies = create_strategies(strategy_configs)
+            vol_target_cfg: dict[str, Any] = (
+                config._raw.get("risk", {}) or {}
+            ).get("vol_target", {}) or {}
+            strategies = create_strategies(
+                strategy_configs,
+                db_path=db_path,
+                vol_target_config=vol_target_cfg,
+            )
             portfolio_mgr = PortfolioManager(
                 strategy_configs=strategy_configs,
                 total_cash=config.multi_strategy_total_allocation,

--- a/trading_bot/strategy/base.py
+++ b/trading_bot/strategy/base.py
@@ -51,10 +51,21 @@ class StrategyBase(ABC):
     strategy_id: str
     display_name: str
 
-    def __init__(self, strategy_id: str, display_name: str, config: dict[str, Any]) -> None:
+    def __init__(
+        self,
+        strategy_id: str,
+        display_name: str,
+        config: dict[str, Any],
+        db_path: str | None = None,
+        vol_target_config: dict[str, Any] | None = None,
+    ) -> None:
         self.strategy_id = strategy_id
         self.display_name = display_name
         self._config = config
+        # Live vol-target context. Backtester passes None and uses its own
+        # in-memory closed-trades buffer instead.
+        self._db_path: str | None = db_path
+        self._vol_target_config: dict[str, Any] = vol_target_config or {}
 
     @abstractmethod
     def evaluate_entry(
@@ -170,6 +181,7 @@ class StrategyBase(ABC):
         risk_per_trade_pct: float = 0.02,
         max_position_pct: float = 0.40,
         fractional: bool = False,
+        vol_multiplier: float = 1.0,
     ) -> float:
         """Share count so max loss ≈ risk_per_trade_pct of available_cash.
 
@@ -177,6 +189,8 @@ class StrategyBase(ABC):
         4 decimal places (Alpaca supports fractional shares down to 1/1000000).
         With ``fractional=False`` returns an integer share count.
         Bounded above by a max position value (max_position_pct of cash).
+        ``vol_multiplier`` scales the risk budget (not the cash cap), so
+        high-vol strategies shrink without breaking max-position-pct.
         Returns 0 when sizing is impossible.
         """
         if entry_price <= 0 or available_cash <= 0:
@@ -185,7 +199,9 @@ class StrategyBase(ABC):
         if risk_per_share <= 0:
             return 0.0
 
-        risk_dollars: float = available_cash * risk_per_trade_pct
+        risk_dollars: float = (
+            available_cash * risk_per_trade_pct * max(vol_multiplier, 0.0)
+        )
         shares_by_risk: float = risk_dollars / risk_per_share
         shares_by_cash: float = (available_cash * max_position_pct) / entry_price
 
@@ -193,3 +209,48 @@ class StrategyBase(ABC):
         if fractional:
             return round(shares, 4)
         return float(int(shares))
+
+    def vol_multiplier(self) -> float:
+        """Live vol-target multiplier from this strategy's recent DB trades.
+
+        Returns ``1.0`` (no adjustment) when:
+          - db_path was not supplied (e.g. backtester),
+          - the vol_target config is missing or annual_vol_pct ≤ 0,
+          - or the trades table doesn't yet have ``min_sample`` rows for
+            this strategy.
+
+        Caller-side: pass the result as ``vol_multiplier=`` to
+        :meth:`size_by_risk`. The result is cheap (one indexed query +
+        a stdev), but still cache per tick if you call from a hot loop.
+        """
+        if not self._db_path:
+            return 1.0
+        target_annual: float = float(
+            self._vol_target_config.get("annual_vol_pct", 0.0)
+        )
+        if target_annual <= 0:
+            return 1.0
+
+        from trading_bot.execution.vol_target import (
+            load_recent_trade_returns,
+            vol_target_multiplier,
+        )
+
+        lookback: int = int(self._vol_target_config.get("lookback_trades", 30))
+        recent: list[float] = load_recent_trade_returns(
+            self._db_path, self.strategy_id, lookback=lookback,
+        )
+        result = vol_target_multiplier(
+            recent,
+            target_annual_vol=target_annual,
+            expected_trades_per_year=int(
+                self._vol_target_config.get("trades_per_year", 252)
+            ),
+            min_multiplier=float(
+                self._vol_target_config.get("min_multiplier", 0.5)
+            ),
+            max_multiplier=float(
+                self._vol_target_config.get("max_multiplier", 1.5)
+            ),
+        )
+        return result.multiplier

--- a/trading_bot/strategy/strategies/__init__.py
+++ b/trading_bot/strategy/strategies/__init__.py
@@ -20,8 +20,17 @@ STRATEGY_REGISTRY: dict[str, type[StrategyBase]] = {
 }
 
 
-def create_strategies(strategy_configs: dict[str, dict[str, Any]]) -> list[StrategyBase]:
-    """Instantiate all enabled strategies from config."""
+def create_strategies(
+    strategy_configs: dict[str, dict[str, Any]],
+    db_path: str | None = None,
+    vol_target_config: dict[str, Any] | None = None,
+) -> list[StrategyBase]:
+    """Instantiate all enabled strategies from config.
+
+    ``db_path`` and ``vol_target_config`` are optional so the backtester
+    (which uses an in-memory closed-trades buffer) can keep its current
+    constructor invocation. Live callers should pass both.
+    """
     strategies: list[StrategyBase] = []
     for sid, cfg in strategy_configs.items():
         if not cfg.get("enabled", True):
@@ -29,5 +38,11 @@ def create_strategies(strategy_configs: dict[str, dict[str, Any]]) -> list[Strat
         cls: type[StrategyBase] | None = STRATEGY_REGISTRY.get(sid)
         if cls is None:
             continue
-        strategies.append(cls(config=cfg))
+        strategies.append(
+            cls(
+                config=cfg,
+                db_path=db_path,
+                vol_target_config=vol_target_config,
+            )
+        )
     return strategies

--- a/trading_bot/strategy/strategies/breakout.py
+++ b/trading_bot/strategy/strategies/breakout.py
@@ -18,11 +18,12 @@ logger: logging.Logger = logging.getLogger(__name__)
 class BreakoutStrategy(StrategyBase):
     """Enter on 20-day high breakout with volume; exit at 10-day low or stop."""
 
-    def __init__(self, config: dict[str, Any]) -> None:
+    def __init__(self, config: dict[str, Any], **kwargs: Any) -> None:
         super().__init__(
             strategy_id="breakout",
             display_name="Breakout",
             config=config,
+            **kwargs,
         )
         self._breakout_period: int = int(config.get("breakout_period", 20))
         self._exit_period: int = int(config.get("exit_period", 10))

--- a/trading_bot/strategy/strategies/mean_reversion.py
+++ b/trading_bot/strategy/strategies/mean_reversion.py
@@ -19,11 +19,12 @@ logger: logging.Logger = logging.getLogger(__name__)
 class MeanReversionStrategy(StrategyBase):
     """Buy when RSI(14) recovers from oversold; exit on RSI normalization or target."""
 
-    def __init__(self, config: dict[str, Any]) -> None:
+    def __init__(self, config: dict[str, Any], **kwargs: Any) -> None:
         super().__init__(
             strategy_id="mean_reversion",
             display_name="Mean Reversion",
             config=config,
+            **kwargs,
         )
         self._rsi_period: int = int(config.get("rsi_period", 14))
         self._rsi_oversold: float = float(config.get("rsi_oversold", 28))
@@ -243,6 +244,7 @@ class MeanReversionStrategy(StrategyBase):
             target_price = target_price_computed
 
         if self._use_risk_sizing:
+            vt_mult: float = self.vol_multiplier()
             shares = self.size_by_risk(
                 entry_price=current_price,
                 stop_price=stop_price,
@@ -250,6 +252,7 @@ class MeanReversionStrategy(StrategyBase):
                 risk_per_trade_pct=self._risk_per_trade_pct,
                 max_position_pct=self._max_position_pct,
                 fractional=self._fractional_shares,
+                vol_multiplier=vt_mult,
             )
         else:
             shares = self._compute_shares(current_price, stop_price, available_cash)

--- a/trading_bot/strategy/strategies/overnight_drift.py
+++ b/trading_bot/strategy/strategies/overnight_drift.py
@@ -32,11 +32,12 @@ logger: logging.Logger = logging.getLogger(__name__)
 class OvernightDriftStrategy(StrategyBase):
     """Buy at close, sell at next open — capture the overnight risk premium."""
 
-    def __init__(self, config: dict[str, Any]) -> None:
+    def __init__(self, config: dict[str, Any], **kwargs: Any) -> None:
         super().__init__(
             strategy_id="overnight_drift",
             display_name="Overnight Drift",
             config=config,
+            **kwargs,
         )
         self._max_positions: int = int(config.get("max_positions", 1))
         # Entry window — last bar of the session. Default 15:45-15:55 ET

--- a/trading_bot/strategy/strategies/sentiment_combo.py
+++ b/trading_bot/strategy/strategies/sentiment_combo.py
@@ -17,11 +17,12 @@ logger: logging.Logger = logging.getLogger(__name__)
 class SentimentComboStrategy(StrategyBase):
     """Enter when Finnhub sentiment is positive AND at least one technical signal fires."""
 
-    def __init__(self, config: dict[str, Any]) -> None:
+    def __init__(self, config: dict[str, Any], **kwargs: Any) -> None:
         super().__init__(
             strategy_id="sentiment_combo",
             display_name="Sentiment Combo",
             config=config,
+            **kwargs,
         )
         self._sentiment_threshold: float = float(config.get("sentiment_threshold", 0.15))
         self._min_technical_signals: int = int(config.get("min_technical_signals", 1))

--- a/trading_bot/strategy/strategies/trend_following.py
+++ b/trading_bot/strategy/strategies/trend_following.py
@@ -18,11 +18,12 @@ logger: logging.Logger = logging.getLogger(__name__)
 class TrendFollowingStrategy(StrategyBase):
     """Enter on EMA crossover with trend confirmation; exit via trailing stop."""
 
-    def __init__(self, config: dict[str, Any]) -> None:
+    def __init__(self, config: dict[str, Any], **kwargs: Any) -> None:
         super().__init__(
             strategy_id="trend_following",
             display_name="Trend Following",
             config=config,
+            **kwargs,
         )
         self._sma_period: int = int(config.get("sma_period", 50))
         self._ema_fast: int = int(config.get("ema_fast", 9))

--- a/trading_bot/tests/test_vol_target.py
+++ b/trading_bot/tests/test_vol_target.py
@@ -150,3 +150,87 @@ class TestLoadRecentTradeReturns:
         conn.close()
 
         assert load_recent_trade_returns(str(db), "mr", lookback=10) == []
+
+
+class TestStrategyBaseVolMultiplier:
+    """Live-path integration: vol_multiplier() on StrategyBase reads the
+    real trades table populated through the live schema."""
+
+    def _seed_trades(
+        self, conn: sqlite3.Connection, strategy_id: str, returns: list[float]
+    ) -> None:
+        from datetime import datetime, timedelta
+        base = datetime(2026, 1, 1, 10, 0, 0)
+        for i, r in enumerate(returns):
+            entry = 100.0
+            qty = 1
+            exit_price = entry * (1.0 + r)
+            ts = (base + timedelta(hours=i)).isoformat()
+            conn.execute(
+                """INSERT INTO trades (ticker, exchange, currency, side,
+                   entry_time, entry_price, quantity, exit_time, exit_price,
+                   hold_type, phase, strategy_id) VALUES (?,?,?,?,?,?,?,?,?,?,?,?)""",
+                ("SPY", "NASDAQ", "USD", "BUY",
+                 ts, entry, qty, ts, exit_price,
+                 "intraday", 1, strategy_id),
+            )
+        conn.commit()
+
+    def test_returns_one_when_db_path_missing(self) -> None:
+        from trading_bot.strategy.strategies.mean_reversion import MeanReversionStrategy
+        s = MeanReversionStrategy(config={"use_risk_sizing": True})
+        assert s.vol_multiplier() == 1.0
+
+    def test_returns_one_when_target_zero(self, tmp_db_path: str) -> None:
+        from trading_bot.strategy.strategies.mean_reversion import MeanReversionStrategy
+        s = MeanReversionStrategy(
+            config={"use_risk_sizing": True},
+            db_path=tmp_db_path,
+            vol_target_config={"annual_vol_pct": 0.0},
+        )
+        assert s.vol_multiplier() == 1.0
+
+    def test_scales_down_on_high_vol(self, tmp_db_path: str) -> None:
+        from trading_bot.strategy.strategies.mean_reversion import MeanReversionStrategy
+        # Big swings → realized per-trade vol way above target.
+        conn = sqlite3.connect(tmp_db_path)
+        self._seed_trades(conn, "mean_reversion", [0.05, -0.05] * 10)
+        conn.close()
+
+        s = MeanReversionStrategy(
+            config={"use_risk_sizing": True},
+            db_path=tmp_db_path,
+            vol_target_config={
+                "annual_vol_pct": 0.20,
+                "lookback_trades": 30,
+                "min_multiplier": 0.5,
+                "max_multiplier": 1.5,
+            },
+        )
+        assert s.vol_multiplier() == 0.5
+
+    def test_isolated_per_strategy(self, tmp_db_path: str) -> None:
+        from trading_bot.strategy.strategies.mean_reversion import MeanReversionStrategy
+        from trading_bot.strategy.strategies.breakout import BreakoutStrategy
+        # mean_reversion: high vol; breakout: tiny vol.
+        conn = sqlite3.connect(tmp_db_path)
+        self._seed_trades(conn, "mean_reversion", [0.05, -0.05] * 10)
+        self._seed_trades(conn, "breakout", [0.0001, -0.0001] * 10)
+        conn.close()
+
+        cfg = {
+            "annual_vol_pct": 0.20,
+            "lookback_trades": 30,
+            "min_multiplier": 0.5,
+            "max_multiplier": 1.5,
+        }
+        mr = MeanReversionStrategy(
+            config={"use_risk_sizing": True},
+            db_path=tmp_db_path, vol_target_config=cfg,
+        )
+        bo = BreakoutStrategy(
+            config={"use_risk_sizing": True},
+            db_path=tmp_db_path, vol_target_config=cfg,
+        )
+        assert mr.vol_multiplier() == 0.5
+        assert bo.vol_multiplier() == 1.5


### PR DESCRIPTION
## Summary

Closes the live wiring gap from [#9](https://github.com/alex5imon/ai-broker/pull/9). The backtester already had vol-targeting; the live entry path was still sizing on a flat risk-per-trade percentage with no volatility feedback. This commit threads the same machinery through ``StrategyManager`` → ``create_strategies()`` → ``StrategyBase``.

## What changed

### ``trading_bot/strategy/base.py``
- ``size_by_risk()`` accepts ``vol_multiplier`` (mirrors backtester signature)
- New ``StrategyBase.vol_multiplier()``: reads recent closed trades for this strategy from the trades table and returns the bounded multiplier. Returns ``1.0`` when ``db_path`` is None (backtester) or ``annual_vol_pct <= 0`` (default).

### ``trading_bot/strategy/strategies/__init__.py``
- ``create_strategies()`` now accepts optional ``db_path`` and ``vol_target_config`` and forwards them to each strategy ctor. Backtester invocation unchanged.

### ``trading_bot/strategy/strategies/*.py``
- All five concrete strategy ctors take ``**kwargs`` and forward to ``super().__init__()`` so new context flows through without each class repeating the signature.

### ``trading_bot/strategy/strategies/mean_reversion.py``
- ``evaluate_entry()`` reads ``self.vol_multiplier()`` and passes it to ``size_by_risk()``. The other strategies still use cash-based ``_compute_shares``; wiring them is a future change once they migrate to ``size_by_risk``.

### ``trading_bot/main.py``
- ``StrategyManager`` bootstrap reads ``risk.vol_target`` from config and forwards to ``create_strategies()``.

## Default behaviour preserved

``risk.vol_target.annual_vol_pct: 0.0`` in the shipped config means the multiplier is ``1.0`` for every strategy. Verified live:

```
mean_reversion:    vol_multiplier()=1.000 (db=True)
trend_following:   vol_multiplier()=1.000 (db=True)
breakout:          vol_multiplier()=1.000 (db=True)
overnight_drift:   vol_multiplier()=1.000 (db=True)
```

## Test plan

- [x] 14 vol-target tests pass (10 existing + 4 new for StrategyBase live path)
- [x] Full suite green: **545 passed, 2 skipped**
- [x] Smoke run against paper: ``StateRecovery`` still clean, all four strategies load with ``db=True`` and return multiplier 1.0
- [ ] Toggle ``annual_vol_pct: 0.20`` in paper after a month of live trades have accumulated, and verify trade sizes shrink/grow as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)