### PR TITLE
feat: five risk gates + disable trend_following sleeve

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,19 @@ overnight gap filter.
 
 See [SPEC.md](SPEC.md) Sections 6 and 7 for the full entry / exit logic.
 
+### Risk gates layered on top
+
+These are book-wide protections that apply across all sleeves. Each is
+config-driven and can be disabled in [config.yaml](config.yaml).
+
+| Gate | Where | Config | What it does |
+|---|---|---|---|
+| **Per-symbol allocation cap** | `strategy_manager._enforce_symbol_cap` | `watchlist_caps.per_symbol[ticker]` | Caps total exposure to any single ticker (across all sleeves) at a fraction of the multi-strategy book. Shrinks oversized entries instead of skipping when possible. |
+| **Entry limit slop clamp** | `strategy_manager._clamp_limit_price` | `entry.limit_slop_pct` (default `0.002` = 0.2%) | Bounds entry limit prices to within 0.2% of NBBO ask (buys) or bid (sells). Prevents thin-spread chasing when the strategy reference price has drifted past the inside market. |
+| **Consecutive-loss cooldown** | `execution.loss_cooldown` | `risk.consecutive_loss_cooldown.{enabled,threshold_losses,cooldown_minutes}` | After N losing trades in a row, pauses ONLY the offending sleeve for M minutes. A profitable trade resets immediately. State persists in `risk_circuit_state` so it survives across stateless ticks. |
+| **Macro-event gate (FOMC)** | `data.event_calendar` | `event_gate.{enabled,fomc_action,fomc_size_multiplier,fomc_dates_<year>}` | Reduces or skips new entries on Fed announcement days. `fomc_action: "skip"` blocks all new entries; `"reduce"` scales share counts by `fomc_size_multiplier`. Existing positions keep being managed normally. Update `fomc_dates_<year>` annually from federalreserve.gov. |
+| **ATR-anchored stops** | each strategy's `evaluate_entry` | `<strategy>.{use_atr_stops,atr_period,atr_stop_mult,atr_trail_mult}` | Sizes stop and trail distance from realized volatility (ATR) instead of fixed percentages. Mean-reversion uses 2.0×ATR stop / 5.0×ATR target; breakout and trend-following use 1.5×ATR stop / 2.0×ATR trail. Falls back to fixed pct when ATR can't be computed. |
+
 ## Backtesting
 
 ```bash

--- a/config.yaml
+++ b/config.yaml
@@ -135,6 +135,51 @@ watchlist:
     - "META"    # Meta Platforms
 
 # -----------------------------------------------------------------------------
+# Per-Symbol Allocation Caps
+# -----------------------------------------------------------------------------
+# Cap on how much of the multi-strategy book a single ticker may consume
+# (across ALL strategies, summed at entry-price). Prevents one runaway
+# position from dominating a 2-position phase-1 book even when each
+# individual strategy says "size up". Expressed as a fraction in (0, 1].
+# Set default_max_allocation_pct to 1.0 to disable globally.
+watchlist_caps:
+  default_max_allocation_pct: 0.50    # 50% — no ticker > half the book
+  per_symbol:
+    SPY: 0.60                         # primary signal source — slightly looser
+    QQQ: 0.50
+    XLK: 0.35
+    XLF: 0.35
+    XLV: 0.35
+    XLE: 0.30
+    XLY: 0.30
+    XLP: 0.30
+    XLI: 0.30
+    XLB: 0.25
+    XLU: 0.25
+    XLRE: 0.25
+    XLC: 0.30
+
+# -----------------------------------------------------------------------------
+# Macro-Event Gating (FOMC days)
+# -----------------------------------------------------------------------------
+# Reduces or skips new entries on Fed announcement days. The bot keeps
+# managing existing positions normally — only NEW entries are gated.
+# Update fomc_dates_<year> annually from federalreserve.gov.
+event_gate:
+  enabled: true
+  fomc_action: "reduce"               # "skip" (no entries) or "reduce" (scale risk)
+  fomc_size_multiplier: 0.50          # used only when fomc_action == "reduce"
+  fomc_dates_2026:
+    - "2026-01-28"
+    - "2026-03-18"
+    - "2026-05-06"
+    - "2026-06-17"
+    - "2026-07-29"
+    - "2026-09-16"
+    - "2026-11-04"
+    - "2026-12-16"
+
+# -----------------------------------------------------------------------------
 # Watchlist Quality Criteria
 # -----------------------------------------------------------------------------
 watchlist_criteria:
@@ -207,6 +252,14 @@ risk:
     pause_days: 1
     recovery_position_size_pct: 0.50  # 50% size for first 3 trades after breaker
     recovery_trades: 3
+  # Per-strategy cooldown after N consecutive losing trades. A profitable
+  # exit resets the streak immediately. Pauses ONLY the offending strategy
+  # (other sleeves keep trading). Tuning notes: 3 / 240 ≈ "sit out half
+  # a session after a 3-loss skid". Set enabled=false to disable.
+  consecutive_loss_cooldown:
+    enabled: true
+    threshold_losses: 3
+    cooldown_minutes: 240
   correlation_threshold: 0.85
   order_rejections:
     max_count: 3
@@ -256,6 +309,10 @@ entry:
   spread_wait_seconds: 120        # Wait up to 2 min for spread to narrow
   spread_recheck_seconds: 15      # Recheck spread every 15 sec
   entry_timeout_seconds: 300      # Cancel unfilled entry after 5 min
+  # Maximum slop above ask (buys) or below bid (sells) for entry limit
+  # orders. Prevents thin-spread / pre-market chasing where a strategy's
+  # current_price reference may already sit at ask. 0.002 = 0.2%.
+  limit_slop_pct: 0.002
   partial_fill_min_pct: 0.50      # Accept partial fill >= 50%
   cooldown_minutes: 30            # Cooldown after exiting a ticker
   earnings_blackout_hours: 48     # Hours before/after earnings to skip
@@ -493,12 +550,11 @@ multi_strategy:
     # they produce comparable backtest evidence.
     mean_reversion:
       enabled: true
-      # 1500 -> 750 after 2026-04-28 walkforward:
-      # 14-window OOS PF 1.235 with 95% CI [0.92, 1.71] — lower bound
-      # below 1.0, not statistically significant. Reallocated half its
-      # capital to breakout (the only significant edge) and a slice to
-      # trend_following.
-      allocation_usd: 750.0
+      # 750 -> 1375 after 2026-04-28 trend_following disable.
+      # Absorbing half of the freed $1250 (other half to breakout). Latest
+      # 57-window walkforward: OOS PF 1.498 CI [0.652, 4.006] — point up
+      # from 1.235 with the new ATR + gate stack, OOS return +7.52%.
+      allocation_usd: 1375.0
       max_positions: 3          # hold up to 3 concurrent diversified ETF positions
       rsi_period: 14
       rsi_oversold: 28
@@ -552,12 +608,16 @@ multi_strategy:
       bb_lookback_bars: 3
 
     trend_following:
-      enabled: true
-      # 1000 -> 1250 after 2026-04-28 walkforward:
-      # OOS PF 1.637 with 95% CI [1.00, 2.58] — borderline significant
-      # (lower bound just touches 1.0). Modest bump from mean_reversion
-      # rebalance.
-      allocation_usd: 1250.0
+      # DISABLED 2026-04-28 (second walkforward review).
+      # Two consecutive walkforward runs put the OOS PF lower-CI below 1.0:
+      #   pre-gate (memorized): PF 1.637 CI [1.00, 2.58] — borderline
+      #   post-gate (current):  PF 1.034 CI [0.476, 2.555] — not significant
+      # OOS return collapsed from +5.6% to +0.33% over 13yr. Allocation
+      # redistributed to mean_reversion (+$625) and breakout (+$625), the
+      # two sleeves still showing positive OOS evidence. Left in config
+      # for future re-enable if the strategy logic is overhauled.
+      enabled: false
+      allocation_usd: 0.0
       max_positions: 1
       sma_period: 50
       ema_fast: 9
@@ -565,21 +625,32 @@ multi_strategy:
       volume_multiplier: 1.5
       trailing_stop_pct: 0.025
       initial_stop_pct: 0.03
+      # ATR-anchored stop + trailing distance. Volatility-adaptive exits:
+      # tight in calm tape, wider in violent tape. Falls back to the fixed
+      # percentages above if ATR can't be computed.
+      use_atr_stops: true
+      atr_period: 14
+      atr_stop_mult: 1.5
+      atr_trail_mult: 2.0
 
     breakout:
       enabled: true
-      # 1500 -> 2000 after 2026-04-28 walkforward:
-      # 14-window OOS PF 2.385 with 95% CI [1.30, 4.70] — the only
-      # strategy with lower CI bound > 1.0, i.e. statistically
-      # significant profitability. Trade count is small (44 over 13yr)
-      # so there's room to grow this allocation as live evidence
-      # accumulates. Capital absorbed from mean_reversion rebalance.
-      allocation_usd: 2000.0
+      # 2000 -> 2625 after 2026-04-28 trend_following disable.
+      # Absorbing the other half of the freed $1250. Latest 57-window
+      # walkforward: OOS PF 1.637 CI [0.735, 4.657], OOS return +10.05%
+      # (best per-strategy OOS return). Simple 13yr backtest also gives
+      # PF 2.72 — strongest sleeve in the stack.
+      allocation_usd: 2625.0
       max_positions: 1
       breakout_period: 20
       exit_period: 10
       volume_multiplier: 1.5
       stop_loss_pct: 0.03
+      # ATR-anchored stop. Donchian exits handle the upside; the stop just
+      # needs to scale with regime vol to avoid getting tagged in noise.
+      use_atr_stops: true
+      atr_period: 14
+      atr_stop_mult: 1.5
 
     # Sentiment Combo DISABLED 2026-04-24 (objective reframe).
     # Two tuning iterations exhausted the parameter search:

--- a/trading_bot/config.py
+++ b/trading_bot/config.py
@@ -387,6 +387,52 @@ class Config:
     def health_enabled(self) -> bool:
         return bool(self._get("health", "enabled", default=True))
 
+    # -----------------------------------------------------------------------
+    # Per-symbol allocation cap
+    # -----------------------------------------------------------------------
+
+    def get_symbol_max_allocation_pct(self, ticker: str) -> float:
+        """Per-ticker cap on share of total book (fraction in (0, 1]).
+
+        Looks up ``watchlist_caps.per_symbol[ticker]``; falls back to
+        ``watchlist_caps.default_max_allocation_pct``; finally falls back
+        to ``1.0`` (no cap) if neither is set.
+        """
+        per_symbol: dict[str, Any] | None = self._get("watchlist_caps", "per_symbol")
+        if isinstance(per_symbol, dict) and ticker in per_symbol:
+            return float(per_symbol[ticker])
+        default_pct: Any = self._get("watchlist_caps", "default_max_allocation_pct")
+        if default_pct is not None:
+            return float(default_pct)
+        return 1.0
+
+    # -----------------------------------------------------------------------
+    # Order placement (entry slop)
+    # -----------------------------------------------------------------------
+
+    @property
+    def entry_limit_slop_pct(self) -> float:
+        """Maximum distance an entry limit price may sit beyond ask (or below bid).
+
+        Returns 0 when not configured (i.e., no clamping applied).
+        """
+        return float(self._get("entry", "limit_slop_pct", default=0.0))
+
+    # -----------------------------------------------------------------------
+    # Consecutive-loss cooldown
+    # -----------------------------------------------------------------------
+
+    def get_loss_cooldown_config(self) -> dict[str, Any]:
+        """Return the consecutive-loss cooldown config (with defaults)."""
+        section: dict[str, Any] = self._get(
+            "risk", "consecutive_loss_cooldown", default={}
+        ) or {}
+        return {
+            "enabled": bool(section.get("enabled", False)),
+            "threshold_losses": int(section.get("threshold_losses", 3)),
+            "cooldown_minutes": int(section.get("cooldown_minutes", 240)),
+        }
+
     @property
     def health_host(self) -> str:
         return str(self._get("health", "host", default="0.0.0.0"))

--- a/trading_bot/data/event_calendar.py
+++ b/trading_bot/data/event_calendar.py
@@ -1,0 +1,90 @@
+"""Macro event calendar — FOMC announcement dates and similar gating signals.
+
+The bot consumes this calendar via :func:`is_fomc_day` to optionally skip new
+entries on Fed announcement days. Dates are sourced from config to keep the
+trading_bot package free of yearly maintenance: the operator updates
+``config.yaml`` (``event_gate.fomc_dates_<year>``) once per year.
+
+A small in-package fallback list is kept ONLY for years already known at the
+time of writing so the bot still gates correctly if config is misconfigured;
+any mismatch with config is logged. Config always wins when present.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date
+from typing import Any
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+# Hard-coded FOMC announcement dates (post-meeting statement days).
+# Source: federalreserve.gov FOMC calendar. Update annually.
+_FALLBACK_FOMC_DATES: dict[int, list[str]] = {
+    2026: [
+        "2026-01-28",
+        "2026-03-18",
+        "2026-05-06",
+        "2026-06-17",
+        "2026-07-29",
+        "2026-09-16",
+        "2026-11-04",
+        "2026-12-16",
+    ],
+}
+
+
+def get_configured_fomc_dates(raw_config: dict[str, Any], year: int) -> list[str]:
+    """Return FOMC dates for *year* as ISO strings.
+
+    Reads ``event_gate.fomc_dates_<year>`` from *raw_config*. Falls back to
+    the in-package list if the key is missing.
+    """
+    section: dict[str, Any] = raw_config.get("event_gate", {}) or {}
+    key: str = f"fomc_dates_{year}"
+    cfg_dates: list[str] | None = section.get(key)
+    if cfg_dates:
+        return [str(d) for d in cfg_dates]
+    fallback: list[str] = _FALLBACK_FOMC_DATES.get(year, [])
+    if fallback:
+        logger.debug(
+            "event_gate.%s missing from config — using in-package fallback (%d dates)",
+            key, len(fallback),
+        )
+    return list(fallback)
+
+
+def is_fomc_day(today: date, raw_config: dict[str, Any]) -> bool:
+    """Return ``True`` if *today* is an FOMC announcement day per config."""
+    dates: list[str] = get_configured_fomc_dates(raw_config, today.year)
+    return today.isoformat() in dates
+
+
+def fomc_size_multiplier(
+    today: date,
+    raw_config: dict[str, Any],
+) -> float:
+    """Return the position-size multiplier to apply on *today*.
+
+    Returns ``0.0`` to mean "skip new entries entirely" (action == "skip"),
+    a positive multiplier < 1 to mean "scale risk down", or ``1.0`` if the
+    day is not gated. Reads ``event_gate.enabled``, ``event_gate.fomc_action``
+    (``"skip"`` | ``"reduce"``) and ``event_gate.fomc_size_multiplier``.
+    """
+    section: dict[str, Any] = raw_config.get("event_gate", {}) or {}
+    if not section.get("enabled", False):
+        return 1.0
+    if not is_fomc_day(today, raw_config):
+        return 1.0
+
+    action: str = str(section.get("fomc_action", "skip")).lower()
+    if action == "skip":
+        return 0.0
+    if action == "reduce":
+        mult: float = float(section.get("fomc_size_multiplier", 0.5))
+        return max(0.0, min(1.0, mult))
+    logger.warning(
+        "Unknown event_gate.fomc_action=%r — defaulting to skip", action,
+    )
+    return 0.0

--- a/trading_bot/execution/loss_cooldown.py
+++ b/trading_bot/execution/loss_cooldown.py
@@ -1,0 +1,195 @@
+"""Per-strategy cooldown after N consecutive losses.
+
+Records each closed trade outcome for a strategy. After the configured
+number of consecutive losses, the strategy is paused for a configured
+cooldown window. A profitable trade resets the counter and lifts the
+cooldown immediately.
+
+State is persisted in ``risk_circuit_state`` (key=``loss_cooldown:<sid>``)
+so it survives across stateless cron ticks. The state blob carries
+``consecutive_losses`` and ``cooldown_until`` (ISO-8601, US/Eastern).
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+from trading_bot.constants import TZ_EASTERN
+from trading_bot.db import repository as repo
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+ET: ZoneInfo = TZ_EASTERN
+
+
+def _key(strategy_id: str) -> str:
+    return f"loss_cooldown:{strategy_id}"
+
+
+@dataclass(frozen=True)
+class LossCooldownConfig:
+    """Configuration values needed by :class:`LossCooldownTracker`."""
+
+    enabled: bool = False
+    threshold_losses: int = 3
+    cooldown_minutes: int = 240
+
+
+class LossCooldownTracker:
+    """Tracks consecutive losses per strategy and enforces a cooldown."""
+
+    def __init__(self, db_path: str, config: LossCooldownConfig) -> None:
+        self._db_path: str = db_path
+        self._config: LossCooldownConfig = config
+
+    @property
+    def enabled(self) -> bool:
+        return self._config.enabled
+
+    def record_outcome(self, strategy_id: str, pnl: float) -> None:
+        """Record a closed-trade outcome for *strategy_id*.
+
+        ``pnl > 0`` resets the counter and clears any active cooldown.
+        ``pnl <= 0`` increments the counter; if it reaches the configured
+        threshold, a cooldown window is set.
+        """
+        if not self._config.enabled:
+            return
+
+        try:
+            conn: sqlite3.Connection = sqlite3.connect(self._db_path)
+            try:
+                state = repo.load_risk_state(conn, _key(strategy_id))
+                consecutive: int = 0
+                if state is not None:
+                    consecutive = int((state.get("state") or {}).get("consecutive_losses", 0))
+
+                if pnl > 0:
+                    if consecutive == 0 and (state is None or not state.get("tripped")):
+                        return
+                    repo.save_risk_state(
+                        conn, _key(strategy_id),
+                        tripped=False,
+                        reason=None,
+                        state={"consecutive_losses": 0, "cooldown_until": None},
+                    )
+                    if consecutive > 0:
+                        logger.info(
+                            "[%s] Loss cooldown reset after winning trade "
+                            "(prior streak=%d)",
+                            strategy_id, consecutive,
+                        )
+                    return
+
+                consecutive += 1
+                if consecutive < self._config.threshold_losses:
+                    repo.save_risk_state(
+                        conn, _key(strategy_id),
+                        tripped=False,
+                        reason=None,
+                        state={
+                            "consecutive_losses": consecutive,
+                            "cooldown_until": None,
+                        },
+                    )
+                    return
+
+                cooldown_until: datetime = datetime.now(tz=ET) + timedelta(
+                    minutes=self._config.cooldown_minutes,
+                )
+                repo.save_risk_state(
+                    conn, _key(strategy_id),
+                    tripped=True,
+                    reason=(
+                        f"{consecutive} consecutive losses — cooldown until "
+                        f"{cooldown_until.strftime('%Y-%m-%d %H:%M ET')}"
+                    ),
+                    state={
+                        "consecutive_losses": consecutive,
+                        "cooldown_until": cooldown_until.isoformat(),
+                    },
+                )
+                logger.warning(
+                    "[%s] Loss cooldown engaged: %d consecutive losses, "
+                    "paused until %s",
+                    strategy_id, consecutive,
+                    cooldown_until.strftime("%Y-%m-%d %H:%M ET"),
+                )
+            finally:
+                conn.close()
+        except Exception:
+            logger.exception(
+                "Failed to record loss-cooldown outcome for %s", strategy_id,
+            )
+
+    def is_on_cooldown(self, strategy_id: str) -> tuple[bool, str | None]:
+        """Return ``(active, reason)`` for *strategy_id*'s cooldown state."""
+        if not self._config.enabled:
+            return False, None
+        try:
+            conn: sqlite3.Connection = sqlite3.connect(self._db_path)
+            try:
+                state = repo.load_risk_state(conn, _key(strategy_id))
+            finally:
+                conn.close()
+        except Exception:
+            logger.warning(
+                "Failed to load loss-cooldown state for %s", strategy_id, exc_info=True,
+            )
+            return False, None
+
+        if state is None or not state.get("tripped"):
+            return False, None
+
+        cooldown_until_iso: str | None = (state.get("state") or {}).get("cooldown_until")
+        if not cooldown_until_iso:
+            return False, None
+
+        try:
+            cooldown_until: datetime = datetime.fromisoformat(cooldown_until_iso)
+        except ValueError:
+            return False, None
+        if cooldown_until.tzinfo is None:
+            cooldown_until = cooldown_until.replace(tzinfo=ET)
+
+        now: datetime = datetime.now(tz=ET)
+        if now >= cooldown_until:
+            self._auto_clear(strategy_id)
+            return False, None
+
+        reason: str = state.get("reason") or "loss cooldown active"
+        return True, reason
+
+    def _auto_clear(self, strategy_id: str) -> None:
+        """Clear an expired cooldown but preserve the consecutive-loss count."""
+        try:
+            conn: sqlite3.Connection = sqlite3.connect(self._db_path)
+            try:
+                state = repo.load_risk_state(conn, _key(strategy_id))
+                consecutive: int = 0
+                if state is not None:
+                    consecutive = int((state.get("state") or {}).get("consecutive_losses", 0))
+                repo.save_risk_state(
+                    conn, _key(strategy_id),
+                    tripped=False,
+                    reason=None,
+                    state={
+                        "consecutive_losses": consecutive,
+                        "cooldown_until": None,
+                    },
+                )
+                logger.info(
+                    "[%s] Loss cooldown expired — entries re-enabled "
+                    "(streak=%d preserved)",
+                    strategy_id, consecutive,
+                )
+            finally:
+                conn.close()
+        except Exception:
+            logger.exception(
+                "Failed to auto-clear loss-cooldown for %s", strategy_id,
+            )

--- a/trading_bot/main.py
+++ b/trading_bot/main.py
@@ -40,6 +40,7 @@ from trading_bot.data.market_data import MarketDataManager
 from trading_bot.data.sentiment import SentimentAnalyzer
 from trading_bot.db import repository as repo
 from trading_bot.db.migrations import run_migrations
+from trading_bot.execution.loss_cooldown import LossCooldownConfig, LossCooldownTracker
 from trading_bot.execution.order_manager import EntryDecision as OMEntryDecision
 from trading_bot.execution.order_manager import OrderManager
 from trading_bot.execution.risk_manager import RiskManager
@@ -166,6 +167,15 @@ class TradingBot:
                     enabled=True,
                     cache_ttl_minutes=int(regime_cfg.get("cache_ttl_minutes", 30)),
                 )
+            loss_cd_cfg: dict[str, Any] = config.get_loss_cooldown_config()
+            loss_cooldown: LossCooldownTracker = LossCooldownTracker(
+                db_path=db_path,
+                config=LossCooldownConfig(
+                    enabled=bool(loss_cd_cfg.get("enabled", False)),
+                    threshold_losses=int(loss_cd_cfg.get("threshold_losses", 3)),
+                    cooldown_minutes=int(loss_cd_cfg.get("cooldown_minutes", 240)),
+                ),
+            )
             self._strategy_manager = StrategyManager(
                 strategies=strategies,
                 portfolio_manager=portfolio_mgr,
@@ -178,6 +188,7 @@ class TradingBot:
                 db_path=db_path,
                 dry_run=dry_run,
                 regime_filter=regime_filter,
+                loss_cooldown=loss_cooldown,
             )
             logger.info(
                 "Multi-strategy enabled: %d strategies, $%.0f total",

--- a/trading_bot/strategy/strategies/breakout.py
+++ b/trading_bot/strategy/strategies/breakout.py
@@ -30,6 +30,13 @@ class BreakoutStrategy(StrategyBase):
         self._volume_multiplier: float = float(config.get("volume_multiplier", 1.5))
         self._stop_loss_pct: float = float(config.get("stop_loss_pct", 0.03))
         self._max_positions: int = int(config.get("max_positions", 1))
+        # Opt-in ATR-anchored stop. When enabled, replaces the fixed
+        # stop_loss_pct with stop_atr_mult × ATR (typically 1.5×ATR for
+        # asymmetric R/R breakouts). Defaults match the article-aligned
+        # 1.5× stop.
+        self._use_atr_stops: bool = bool(config.get("use_atr_stops", False))
+        self._atr_period: int = int(config.get("atr_period", 14))
+        self._atr_stop_mult: float = float(config.get("atr_stop_mult", 1.5))
 
     def evaluate_entry(
         self,
@@ -63,7 +70,16 @@ class BreakoutStrategy(StrategyBase):
         if vol_avg <= 0 or current_vol < self._volume_multiplier * vol_avg:
             return None
 
-        stop_price: float = round(current_price * (1.0 - self._stop_loss_pct), 2)
+        if self._use_atr_stops:
+            atr: float | None = self._compute_atr(df_daily, self._atr_period)
+            if atr is not None and atr > 0:
+                stop_price: float = round(
+                    current_price - self._atr_stop_mult * atr, 2,
+                )
+            else:
+                stop_price = round(current_price * (1.0 - self._stop_loss_pct), 2)
+        else:
+            stop_price = round(current_price * (1.0 - self._stop_loss_pct), 2)
         shares: int = self._compute_shares(current_price, stop_price, available_cash)
         if shares < 1:
             return None

--- a/trading_bot/strategy/strategies/trend_following.py
+++ b/trading_bot/strategy/strategies/trend_following.py
@@ -32,6 +32,14 @@ class TrendFollowingStrategy(StrategyBase):
         self._trailing_stop_pct: float = float(config.get("trailing_stop_pct", 0.025))
         self._initial_stop_pct: float = float(config.get("initial_stop_pct", 0.03))
         self._max_positions: int = int(config.get("max_positions", 1))
+        # Opt-in ATR-anchored stop + trailing distance. When enabled, the
+        # initial stop becomes ``atr_stop_mult × ATR`` and the trailing
+        # distance becomes ``atr_trail_mult × ATR / entry`` so risk scales
+        # with regime volatility.
+        self._use_atr_stops: bool = bool(config.get("use_atr_stops", False))
+        self._atr_period: int = int(config.get("atr_period", 14))
+        self._atr_stop_mult: float = float(config.get("atr_stop_mult", 1.5))
+        self._atr_trail_mult: float = float(config.get("atr_trail_mult", 2.0))
 
     def evaluate_entry(
         self,
@@ -89,7 +97,21 @@ class TrendFollowingStrategy(StrategyBase):
         if avg_vol <= 0 or current_vol < self._volume_multiplier * avg_vol:
             return None
 
-        stop_price: float = round(current_price * (1.0 - self._initial_stop_pct), 2)
+        trail_pct: float = self._trailing_stop_pct
+        if self._use_atr_stops:
+            atr: float | None = self._compute_atr(df_daily, self._atr_period)
+            if atr is not None and atr > 0 and current_price > 0:
+                stop_price: float = round(
+                    current_price - self._atr_stop_mult * atr, 2,
+                )
+                trail_pct = max(
+                    self._atr_trail_mult * atr / current_price,
+                    self._trailing_stop_pct,
+                )
+            else:
+                stop_price = round(current_price * (1.0 - self._initial_stop_pct), 2)
+        else:
+            stop_price = round(current_price * (1.0 - self._initial_stop_pct), 2)
         shares: int = self._compute_shares(current_price, stop_price, available_cash)
         if shares < 1:
             return None
@@ -107,7 +129,7 @@ class TrendFollowingStrategy(StrategyBase):
             entry_price=current_price,
             stop_price=stop_price,
             target_price=None,
-            trail_pct=self._trailing_stop_pct,
+            trail_pct=trail_pct,
             hold_type=HoldType.SWING,
             strategy_id=self.strategy_id,
             signals={
@@ -137,9 +159,16 @@ class TrendFollowingStrategy(StrategyBase):
         if stop_price > 0 and current_price <= stop_price:
             return ExitSignal(should_exit=True, reason="stop_loss", is_emergency=True, use_market_order=True)
 
-        # Trailing stop: once price has moved up, trail from highest
+        # Trailing stop: once price has moved up, trail from highest. Prefer
+        # the per-position trailing_distance when set (lets ATR-anchored
+        # entries trail at their entry-time volatility), else fall back to
+        # the strategy default.
         if highest_price > entry_price:
-            trail_stop: float = highest_price * (1.0 - self._trailing_stop_pct)
+            stored_trail: float = float(coalesce(position, "trailing_distance", 0))
+            trail_distance: float = (
+                stored_trail if stored_trail > 0 else self._trailing_stop_pct
+            )
+            trail_stop: float = highest_price * (1.0 - trail_distance)
             if current_price <= trail_stop:
                 return ExitSignal(should_exit=True, reason="trailing_stop")
 

--- a/trading_bot/strategy/strategy_manager.py
+++ b/trading_bot/strategy/strategy_manager.py
@@ -4,13 +4,16 @@ from __future__ import annotations
 
 import json
 import logging
+import sqlite3
 from datetime import datetime
 from typing import Any
 from zoneinfo import ZoneInfo
 
 import pandas as pd
 
-from trading_bot.constants import GICS_SECTOR, TZ_EASTERN
+from trading_bot.constants import GICS_SECTOR, PositionStatus, TZ_EASTERN
+from trading_bot.data.event_calendar import fomc_size_multiplier
+from trading_bot.execution.loss_cooldown import LossCooldownTracker
 from trading_bot.execution.order_manager import EntryDecision as OMEntryDecision
 from trading_bot.execution.virtual_portfolio import PortfolioManager, VirtualPortfolio
 from trading_bot.strategy.base import ExitSignal, StrategyBase, StrategyDecision
@@ -37,6 +40,7 @@ class StrategyManager:
         db_path: str,
         dry_run: bool = False,
         regime_filter: RegimeFilter | None = None,
+        loss_cooldown: LossCooldownTracker | None = None,
     ) -> None:
         self._strategies: list[StrategyBase] = strategies
         self._portfolio_manager: PortfolioManager = portfolio_manager
@@ -49,6 +53,7 @@ class StrategyManager:
         self._db_path: str = db_path
         self._dry_run: bool = dry_run
         self._regime_filter: RegimeFilter | None = regime_filter
+        self._loss_cooldown: LossCooldownTracker | None = loss_cooldown
 
     @property
     def strategies(self) -> list[StrategyBase]:
@@ -77,6 +82,21 @@ class StrategyManager:
                     return 0
             except Exception:
                 logger.warning("Regime filter check failed — proceeding", exc_info=True)
+
+        # Macro-event gate (FOMC days). Returns 0.0 to skip entirely, or a
+        # multiplier in (0, 1] to scale risk down. The multiplier path is
+        # plumbed below into per-decision share counts.
+        event_mult: float = self._fomc_size_multiplier()
+        if event_mult <= 0.0:
+            logger.info(
+                "Event gate (FOMC) blocking new entries for today — entries skipped",
+            )
+            return 0
+        if event_mult < 1.0:
+            logger.info(
+                "Event gate (FOMC) reducing entry size by %.0f%% today",
+                (1.0 - event_mult) * 100,
+            )
 
         for ticker in watchlist:
             can_trade, reason = self._risk_manager.can_trade()
@@ -122,6 +142,17 @@ class StrategyManager:
                 if portfolio is None:
                     continue
 
+                # Per-strategy consecutive-loss cooldown — sit out the next
+                # tick window after N losing trades in a row.
+                if self._loss_cooldown is not None:
+                    on_cd, cd_reason = self._loss_cooldown.is_on_cooldown(strategy.strategy_id)
+                    if on_cd:
+                        logger.debug(
+                            "[%s] cooldown active — skipping entries (%s)",
+                            strategy.strategy_id, cd_reason,
+                        )
+                        continue
+
                 open_positions: list[dict[str, Any]] = portfolio.get_open_positions()
                 if len(open_positions) >= strategy.get_max_positions():
                     continue
@@ -148,6 +179,21 @@ class StrategyManager:
                     continue
 
                 if decision is None:
+                    continue
+
+                # Apply FOMC size multiplier (1.0 when not gated).
+                if event_mult < 1.0:
+                    decision = self._scale_decision_shares(decision, event_mult)
+                    if decision is None:
+                        continue
+
+                # Per-symbol allocation cap across the global multi-strategy book.
+                decision = self._enforce_symbol_cap(decision)
+                if decision is None:
+                    logger.debug(
+                        "[%s] %s entry skipped — symbol allocation cap reached",
+                        strategy.strategy_id, ticker,
+                    )
                     continue
 
                 om_decision: OMEntryDecision = self._build_om_decision(decision)
@@ -238,6 +284,12 @@ class StrategyManager:
                 portfolio.record_exit(shares, current_price, entry_price)
                 exits += 1
 
+                # Loss-cooldown bookkeeping — must follow record_exit so the
+                # virtual portfolio's tally is consistent with the tracker's.
+                if self._loss_cooldown is not None and shares > 0:
+                    pnl: float = shares * (current_price - entry_price)
+                    self._loss_cooldown.record_outcome(strategy.strategy_id, pnl)
+
         return exits
 
     def get_comparison_report(self) -> dict[str, dict[str, Any]]:
@@ -245,12 +297,17 @@ class StrategyManager:
 
     def _build_om_decision(self, decision: StrategyDecision) -> OMEntryDecision:
         sector: str = GICS_SECTOR.get(decision.ticker, "Unknown")
+        limit_price: float = self._clamp_limit_price(
+            ticker=decision.ticker,
+            side="BUY" if decision.direction == "long" else "SELL",
+            requested_price=decision.entry_price,
+        )
         return OMEntryDecision(
             ticker=decision.ticker,
             exchange=decision.exchange,
             side="BUY" if decision.direction == "long" else "SELL",
             shares=decision.shares,
-            limit_price=decision.entry_price,
+            limit_price=limit_price,
             stop_price=decision.stop_price,
             target_price=decision.target_price or decision.entry_price * 1.05,
             hold_type=decision.hold_type.value,
@@ -263,3 +320,186 @@ class StrategyManager:
             trail_pct=decision.trail_pct,
             trail_activation_price=decision.trail_activation_price,
         )
+
+    # ------------------------------------------------------------------
+    # Helpers — symbol cap, slop clamp, FOMC gate
+    # ------------------------------------------------------------------
+
+    def _fomc_size_multiplier(self) -> float:
+        """Lookup today's FOMC multiplier from raw config (defaults to 1.0)."""
+        getter = getattr(self._config, "_raw", None)
+        raw: dict[str, Any] = getter if isinstance(getter, dict) else {}
+        try:
+            today = datetime.now(tz=ET).date()
+            return float(fomc_size_multiplier(today, raw))
+        except Exception:
+            logger.warning("FOMC size multiplier lookup failed", exc_info=True)
+            return 1.0
+
+    @staticmethod
+    def _scale_decision_shares(
+        decision: StrategyDecision, multiplier: float,
+    ) -> StrategyDecision | None:
+        """Scale a decision's share count by *multiplier*; drop if it falls below 1."""
+        if multiplier <= 0:
+            return None
+        scaled: float = float(decision.shares) * multiplier
+        # Preserve integer share counts when the strategy used integer sizing.
+        if isinstance(decision.shares, int) and not isinstance(decision.shares, bool):
+            scaled = float(int(scaled))
+            if scaled < 1.0:
+                return None
+        else:
+            scaled = round(scaled, 4)
+            if scaled < 0.001:
+                return None
+        decision.shares = scaled  # type: ignore[assignment]
+        return decision
+
+    def _enforce_symbol_cap(
+        self, decision: StrategyDecision,
+    ) -> StrategyDecision | None:
+        """Bound a candidate entry by its per-symbol allocation cap.
+
+        Cap is expressed as fraction of the multi-strategy total book
+        value. Existing exposure to ``decision.ticker`` across all
+        sub-portfolios + the proposed entry must stay under the cap;
+        otherwise the candidate is shrunk (or rejected if the resulting
+        size would be below the strategy's min trade unit).
+        """
+        try:
+            cap_pct: float = float(
+                getattr(self._config, "get_symbol_max_allocation_pct", lambda _t: 1.0)(
+                    decision.ticker,
+                )
+            )
+        except (TypeError, ValueError):
+            cap_pct = 1.0
+        if cap_pct <= 0 or cap_pct >= 1.0:
+            return decision
+
+        total_book: float = self._compute_total_book_value()
+        if total_book <= 0:
+            return decision
+
+        existing_exposure: float = self._compute_symbol_exposure(decision.ticker)
+        cap_value: float = total_book * cap_pct
+        remaining: float = max(cap_value - existing_exposure, 0.0)
+
+        proposed_value: float = float(decision.shares) * float(decision.entry_price)
+        if proposed_value <= remaining:
+            return decision
+
+        if remaining <= 0 or decision.entry_price <= 0:
+            return None
+
+        max_shares_by_cap: float = remaining / float(decision.entry_price)
+        if isinstance(decision.shares, int) and not isinstance(decision.shares, bool):
+            max_shares_by_cap = float(int(max_shares_by_cap))
+            if max_shares_by_cap < 1.0:
+                return None
+            decision.shares = int(max_shares_by_cap)  # type: ignore[assignment]
+        else:
+            max_shares_by_cap = round(max_shares_by_cap, 4)
+            if max_shares_by_cap < 0.001:
+                return None
+            decision.shares = max_shares_by_cap  # type: ignore[assignment]
+
+        logger.info(
+            "[%s] %s shrunk by symbol cap %.0f%% (existing $%.2f, cap $%.2f, "
+            "new shares=%s)",
+            decision.strategy_id, decision.ticker, cap_pct * 100,
+            existing_exposure, cap_value, decision.shares,
+        )
+        return decision
+
+    def _compute_total_book_value(self) -> float:
+        """Sum cash + open-position book value across all virtual portfolios."""
+        total: float = 0.0
+        try:
+            portfolios = self._portfolio_manager.get_all_portfolios()
+        except Exception:
+            return 0.0
+        for portfolio in portfolios.values():
+            try:
+                total += float(portfolio.current_cash)
+            except Exception:
+                continue
+            try:
+                positions = portfolio.get_open_positions()
+            except Exception:
+                positions = []
+            for p in positions:
+                try:
+                    qty: float = float(p.get("quantity") or 0)
+                    px: float = float(p.get("entry_price") or 0)
+                    total += qty * px
+                except Exception:
+                    continue
+        return total
+
+    def _compute_symbol_exposure(self, ticker: str) -> float:
+        """Sum (qty × entry_price) for *ticker* across all open positions."""
+        exposure: float = 0.0
+        try:
+            conn: sqlite3.Connection = sqlite3.connect(self._db_path)
+            conn.row_factory = sqlite3.Row
+            try:
+                rows = conn.execute(
+                    "SELECT quantity, entry_price FROM positions "
+                    "WHERE ticker = ? AND status != ?",
+                    (ticker, PositionStatus.CLOSED.value),
+                ).fetchall()
+            finally:
+                conn.close()
+        except Exception:
+            return 0.0
+        for r in rows:
+            try:
+                exposure += float(r["quantity"] or 0) * float(r["entry_price"] or 0)
+            except Exception:
+                continue
+        return exposure
+
+    def _clamp_limit_price(
+        self, ticker: str, side: str, requested_price: float,
+    ) -> float:
+        """Bound an entry limit price to within ``entry.limit_slop_pct`` of NBBO.
+
+        Buys: limit ≤ ask × (1 + slop). Sells: limit ≥ bid × (1 - slop).
+        Falls back to the requested price when bid/ask isn't available.
+        """
+        try:
+            slop: float = float(getattr(self._config, "entry_limit_slop_pct", 0.0))
+        except (TypeError, ValueError):
+            slop = 0.0
+        if slop <= 0 or requested_price <= 0:
+            return requested_price
+        try:
+            ba = self._market_data.get_bid_ask(ticker)
+        except Exception:
+            return requested_price
+        if ba is None:
+            return requested_price
+        bid, ask = float(ba[0]), float(ba[1])
+        if bid <= 0 or ask <= 0:
+            return requested_price
+
+        if side == "BUY":
+            cap: float = ask * (1.0 + slop)
+            if requested_price > cap:
+                logger.info(
+                    "%s BUY limit clamped: %.4f -> %.4f (ask=%.4f, slop=%.2f%%)",
+                    ticker, requested_price, cap, ask, slop * 100,
+                )
+                return round(cap, 2)
+            return requested_price
+
+        floor: float = bid * (1.0 - slop)
+        if requested_price < floor:
+            logger.info(
+                "%s SELL limit clamped: %.4f -> %.4f (bid=%.4f, slop=%.2f%%)",
+                ticker, requested_price, floor, bid, slop * 100,
+            )
+            return round(floor, 2)
+        return requested_price

--- a/trading_bot/tests/test_event_calendar.py
+++ b/trading_bot/tests/test_event_calendar.py
@@ -1,0 +1,78 @@
+"""Tests for the macro-event (FOMC) gating helpers."""
+
+from __future__ import annotations
+
+from datetime import date
+
+from trading_bot.data.event_calendar import (
+    fomc_size_multiplier,
+    get_configured_fomc_dates,
+    is_fomc_day,
+)
+
+
+def _cfg(**overrides):
+    base = {
+        "event_gate": {
+            "enabled": True,
+            "fomc_action": "skip",
+            "fomc_size_multiplier": 0.5,
+            "fomc_dates_2026": ["2026-01-28", "2026-03-18"],
+        }
+    }
+    base["event_gate"].update(overrides)
+    return base
+
+
+class TestEventCalendar:
+    def test_configured_dates_take_precedence(self) -> None:
+        dates = get_configured_fomc_dates(_cfg(), 2026)
+        assert dates == ["2026-01-28", "2026-03-18"]
+
+    def test_fallback_when_year_missing_from_config(self) -> None:
+        # Year 2026 has an in-package fallback list; remove from config to exercise it
+        cfg = {"event_gate": {"enabled": True}}
+        dates = get_configured_fomc_dates(cfg, 2026)
+        assert "2026-01-28" in dates
+
+    def test_is_fomc_day_true_on_announcement(self) -> None:
+        assert is_fomc_day(date(2026, 3, 18), _cfg()) is True
+
+    def test_is_fomc_day_false_on_non_meeting(self) -> None:
+        assert is_fomc_day(date(2026, 3, 19), _cfg()) is False
+
+    def test_skip_action_returns_zero(self) -> None:
+        m = fomc_size_multiplier(date(2026, 3, 18), _cfg(fomc_action="skip"))
+        assert m == 0.0
+
+    def test_reduce_action_returns_multiplier(self) -> None:
+        m = fomc_size_multiplier(
+            date(2026, 3, 18),
+            _cfg(fomc_action="reduce", fomc_size_multiplier=0.4),
+        )
+        assert m == 0.4
+
+    def test_disabled_returns_one(self) -> None:
+        m = fomc_size_multiplier(
+            date(2026, 3, 18),
+            _cfg(enabled=False),
+        )
+        assert m == 1.0
+
+    def test_non_fomc_day_returns_one_when_enabled(self) -> None:
+        m = fomc_size_multiplier(date(2026, 3, 19), _cfg())
+        assert m == 1.0
+
+    def test_unknown_action_defaults_to_skip(self) -> None:
+        m = fomc_size_multiplier(
+            date(2026, 3, 18),
+            _cfg(fomc_action="bogus"),
+        )
+        assert m == 0.0
+
+    def test_reduce_multiplier_clamped_to_unit_interval(self) -> None:
+        m = fomc_size_multiplier(
+            date(2026, 3, 18),
+            _cfg(fomc_action="reduce", fomc_size_multiplier=2.0),
+        )
+        assert m == 1.0

--- a/trading_bot/tests/test_loss_cooldown.py
+++ b/trading_bot/tests/test_loss_cooldown.py
@@ -1,0 +1,89 @@
+"""Tests for the per-strategy consecutive-loss cooldown tracker."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+from trading_bot.constants import TZ_EASTERN
+from trading_bot.db import repository as repo
+from trading_bot.execution.loss_cooldown import (
+    LossCooldownConfig,
+    LossCooldownTracker,
+)
+
+ET: ZoneInfo = TZ_EASTERN
+
+
+def _make_tracker(db_path: str, **overrides) -> LossCooldownTracker:
+    cfg = LossCooldownConfig(
+        enabled=overrides.get("enabled", True),
+        threshold_losses=overrides.get("threshold_losses", 3),
+        cooldown_minutes=overrides.get("cooldown_minutes", 60),
+    )
+    return LossCooldownTracker(db_path=db_path, config=cfg)
+
+
+class TestLossCooldownTracker:
+    def test_disabled_short_circuits(self, tmp_db_path: str) -> None:
+        tracker = _make_tracker(tmp_db_path, enabled=False)
+        for _ in range(10):
+            tracker.record_outcome("mean_reversion", -10.0)
+        active, reason = tracker.is_on_cooldown("mean_reversion")
+        assert active is False
+        assert reason is None
+
+    def test_streak_under_threshold_does_not_pause(self, tmp_db_path: str) -> None:
+        tracker = _make_tracker(tmp_db_path, threshold_losses=3)
+        tracker.record_outcome("mean_reversion", -5.0)
+        tracker.record_outcome("mean_reversion", -5.0)
+        active, _ = tracker.is_on_cooldown("mean_reversion")
+        assert active is False
+
+    def test_threshold_engages_cooldown(self, tmp_db_path: str) -> None:
+        tracker = _make_tracker(tmp_db_path, threshold_losses=3, cooldown_minutes=30)
+        for _ in range(3):
+            tracker.record_outcome("mean_reversion", -5.0)
+        active, reason = tracker.is_on_cooldown("mean_reversion")
+        assert active is True
+        assert reason is not None
+        assert "consecutive losses" in reason
+
+    def test_winning_trade_resets_streak_and_lifts_cooldown(self, tmp_db_path: str) -> None:
+        tracker = _make_tracker(tmp_db_path, threshold_losses=3)
+        for _ in range(3):
+            tracker.record_outcome("mean_reversion", -5.0)
+        assert tracker.is_on_cooldown("mean_reversion")[0] is True
+        tracker.record_outcome("mean_reversion", +12.0)
+        active, reason = tracker.is_on_cooldown("mean_reversion")
+        assert active is False
+        assert reason is None
+
+    def test_per_strategy_isolation(self, tmp_db_path: str) -> None:
+        tracker = _make_tracker(tmp_db_path, threshold_losses=2)
+        tracker.record_outcome("mean_reversion", -1.0)
+        tracker.record_outcome("mean_reversion", -1.0)
+        assert tracker.is_on_cooldown("mean_reversion")[0] is True
+        assert tracker.is_on_cooldown("breakout")[0] is False
+
+    def test_expired_cooldown_auto_clears(self, tmp_db_path: str) -> None:
+        tracker = _make_tracker(tmp_db_path, threshold_losses=2, cooldown_minutes=60)
+        tracker.record_outcome("mean_reversion", -1.0)
+        tracker.record_outcome("mean_reversion", -1.0)
+
+        # Force the persisted cooldown_until into the past
+        past: datetime = datetime.now(tz=ET) - timedelta(minutes=5)
+        conn: sqlite3.Connection = sqlite3.connect(tmp_db_path)
+        try:
+            repo.save_risk_state(
+                conn, "loss_cooldown:mean_reversion",
+                tripped=True, reason="forced",
+                state={"consecutive_losses": 2, "cooldown_until": past.isoformat()},
+            )
+        finally:
+            conn.close()
+
+        active, reason = tracker.is_on_cooldown("mean_reversion")
+        assert active is False
+        assert reason is None

--- a/trading_bot/tests/test_strategy_manager_gates.py
+++ b/trading_bot/tests/test_strategy_manager_gates.py
@@ -1,0 +1,448 @@
+"""Tests for the strategy-manager gates added with the risk-pickup batch.
+
+Covers:
+- per-symbol allocation cap (``watchlist_caps``)
+- entry-limit slop clamping (``entry.limit_slop_pct``)
+- per-strategy consecutive-loss cooldown
+- macro-event (FOMC) size multiplier
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import date
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pandas as pd
+import pytest
+
+from trading_bot.constants import HoldType, PositionStatus
+from trading_bot.execution.loss_cooldown import LossCooldownConfig, LossCooldownTracker
+from trading_bot.strategy.base import ExitSignal, StrategyBase, StrategyDecision
+from trading_bot.strategy.strategy_manager import StrategyManager
+
+
+# ---------------------------------------------------------------------------
+# Stubs
+# ---------------------------------------------------------------------------
+
+
+class _StubStrategy(StrategyBase):
+    def __init__(
+        self, strategy_id: str, decision: StrategyDecision | None = None,
+    ) -> None:
+        super().__init__(strategy_id=strategy_id, display_name=strategy_id, config={})
+        self._decision = decision
+
+    def evaluate_entry(
+        self, ticker, exchange, df_5min, df_daily, current_price,
+        available_cash, sentiment_score=None,
+    ):
+        if self._decision is None:
+            return None
+        return StrategyDecision(
+            ticker=ticker,
+            exchange=exchange,
+            direction="long",
+            shares=self._decision.shares,
+            entry_price=current_price,
+            stop_price=current_price * 0.98,
+            target_price=current_price * 1.04,
+            trail_pct=None,
+            hold_type=HoldType.SWING,
+            strategy_id=self.strategy_id,
+            signals={},
+            sentiment_score=sentiment_score,
+        )
+
+    def evaluate_exit(self, position, current_price, df_5min=None, df_daily=None):
+        return ExitSignal(should_exit=False)
+
+    def get_max_positions(self) -> int:
+        return 5
+
+
+def _bars(n: int = 30, start: float = 100.0) -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "open": [start] * n, "high": [start * 1.01] * n,
+            "low": [start * 0.99] * n, "close": [start] * n,
+            "volume": [1_000_000] * n,
+        }
+    )
+
+
+@pytest.fixture
+def fake_bars():
+    async def _f(_t, _e):
+        return _bars()
+    return _f
+
+
+@pytest.fixture
+def fake_daily_bars():
+    async def _f(_t, _e):
+        return _bars(60)
+    return _f
+
+
+@pytest.fixture
+def market_data():
+    md = MagicMock()
+    md.trading_paused = False
+    md.is_stale = MagicMock(return_value=False)
+    md.get_latest_price = MagicMock(return_value=100.0)
+    md.get_bid_ask = MagicMock(return_value=(99.95, 100.05))
+    return md
+
+
+@pytest.fixture
+def risk_manager():
+    rm = MagicMock()
+    rm.can_trade = MagicMock(return_value=(True, "ok"))
+    return rm
+
+
+@pytest.fixture
+def order_manager():
+    om = MagicMock()
+    om.place_entry = AsyncMock(return_value=42)
+    return om
+
+
+@pytest.fixture
+def sentiment():
+    sa = MagicMock()
+    sa.get_sentiment = AsyncMock(return_value=0.0)
+    return sa
+
+
+@pytest.fixture
+def earnings():
+    ec = MagicMock()
+    ec.is_in_blackout = MagicMock(return_value=False)
+    return ec
+
+
+@pytest.fixture
+def portfolio_manager():
+    pm = MagicMock()
+    portfolio = MagicMock()
+    portfolio.get_open_positions = MagicMock(return_value=[])
+    portfolio.available_cash = 1000.0
+    portfolio.current_cash = 1000.0
+    portfolio.record_entry = MagicMock()
+    portfolio.record_exit = MagicMock()
+    pm.get_portfolio = MagicMock(return_value=portfolio)
+    pm.get_all_portfolios = MagicMock(return_value={"stub": portfolio})
+    pm._portfolio = portfolio
+    return pm
+
+
+def _config(**overrides) -> Any:
+    cfg = MagicMock()
+    phase = MagicMock()
+    phase.value = 1
+    cfg.get_phase = MagicMock(return_value=phase)
+    # Default — no caps, no slop, FOMC disabled.
+    cfg.get_symbol_max_allocation_pct = MagicMock(
+        side_effect=lambda _t: overrides.get("cap_pct", 1.0),
+    )
+    cfg.entry_limit_slop_pct = overrides.get("slop_pct", 0.0)
+    cfg._raw = overrides.get("raw", {})
+    return cfg
+
+
+def _decision(shares: float = 5, entry: float = 100.0) -> StrategyDecision:
+    return StrategyDecision(
+        ticker="SPY",
+        exchange="US",
+        direction="long",
+        shares=shares,
+        entry_price=entry,
+        stop_price=entry * 0.98,
+        target_price=entry * 1.04,
+        trail_pct=None,
+        hold_type=HoldType.SWING,
+        strategy_id="stub",
+        signals={},
+        sentiment_score=0.0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# FOMC gate
+# ---------------------------------------------------------------------------
+
+
+class TestFomcGate:
+    @pytest.mark.asyncio
+    async def test_fomc_skip_blocks_all_entries(
+        self, market_data, risk_manager, order_manager, sentiment, earnings,
+        portfolio_manager, fake_bars, fake_daily_bars, tmp_db_path, monkeypatch,
+    ):
+        cfg = _config(raw={
+            "event_gate": {
+                "enabled": True,
+                "fomc_action": "skip",
+                "fomc_dates_2099": ["2099-01-01"],
+            }
+        })
+        # Force "today" to match a configured FOMC date
+        from trading_bot.strategy import strategy_manager as sm_mod
+        monkeypatch.setattr(
+            sm_mod, "fomc_size_multiplier",
+            lambda _today, _raw: 0.0,
+        )
+
+        sm = StrategyManager(
+            strategies=[_StubStrategy("stub", _decision())],
+            portfolio_manager=portfolio_manager,
+            market_data=market_data, order_manager=order_manager,
+            risk_manager=risk_manager, sentiment=sentiment,
+            earnings=earnings, config=cfg, db_path=tmp_db_path,
+        )
+        n = await sm.scan_for_entries(
+            watchlist=["SPY"], get_5min_bars=fake_bars,
+            get_daily_bars=fake_daily_bars, account_equity_gbp=1000.0,
+        )
+        assert n == 0
+        order_manager.place_entry.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_fomc_reduce_scales_share_count(
+        self, market_data, risk_manager, order_manager, sentiment, earnings,
+        portfolio_manager, fake_bars, fake_daily_bars, tmp_db_path, monkeypatch,
+    ):
+        cfg = _config()
+        from trading_bot.strategy import strategy_manager as sm_mod
+        monkeypatch.setattr(
+            sm_mod, "fomc_size_multiplier", lambda _t, _r: 0.5,
+        )
+
+        sm = StrategyManager(
+            strategies=[_StubStrategy("stub", _decision(shares=10))],
+            portfolio_manager=portfolio_manager,
+            market_data=market_data, order_manager=order_manager,
+            risk_manager=risk_manager, sentiment=sentiment,
+            earnings=earnings, config=cfg, db_path=tmp_db_path,
+        )
+        await sm.scan_for_entries(
+            watchlist=["SPY"], get_5min_bars=fake_bars,
+            get_daily_bars=fake_daily_bars, account_equity_gbp=1000.0,
+        )
+        order_manager.place_entry.assert_called_once()
+        om_decision = order_manager.place_entry.call_args[0][0]
+        assert om_decision.shares == 5  # 10 × 0.5
+
+
+# ---------------------------------------------------------------------------
+# Limit-slop clamp
+# ---------------------------------------------------------------------------
+
+
+class TestLimitSlopClamp:
+    @pytest.mark.asyncio
+    async def test_limit_clamped_above_ask_for_buy(
+        self, market_data, risk_manager, order_manager, sentiment, earnings,
+        portfolio_manager, fake_bars, fake_daily_bars, tmp_db_path,
+    ):
+        # Strategy wants to buy at 105.0; ask=100.05, slop=0.2% → cap = 100.25
+        market_data.get_bid_ask = MagicMock(return_value=(99.95, 100.05))
+        market_data.get_latest_price = MagicMock(return_value=105.0)
+        cfg = _config(slop_pct=0.002)
+
+        sm = StrategyManager(
+            strategies=[_StubStrategy("stub", _decision(shares=5, entry=105.0))],
+            portfolio_manager=portfolio_manager,
+            market_data=market_data, order_manager=order_manager,
+            risk_manager=risk_manager, sentiment=sentiment,
+            earnings=earnings, config=cfg, db_path=tmp_db_path,
+        )
+        await sm.scan_for_entries(
+            watchlist=["SPY"], get_5min_bars=fake_bars,
+            get_daily_bars=fake_daily_bars, account_equity_gbp=1000.0,
+        )
+        om_decision = order_manager.place_entry.call_args[0][0]
+        assert om_decision.limit_price == round(100.05 * 1.002, 2)
+
+    @pytest.mark.asyncio
+    async def test_limit_inside_slop_window_unchanged(
+        self, market_data, risk_manager, order_manager, sentiment, earnings,
+        portfolio_manager, fake_bars, fake_daily_bars, tmp_db_path,
+    ):
+        market_data.get_bid_ask = MagicMock(return_value=(99.95, 100.05))
+        market_data.get_latest_price = MagicMock(return_value=100.10)
+        cfg = _config(slop_pct=0.002)
+
+        sm = StrategyManager(
+            strategies=[_StubStrategy("stub", _decision(shares=5, entry=100.10))],
+            portfolio_manager=portfolio_manager,
+            market_data=market_data, order_manager=order_manager,
+            risk_manager=risk_manager, sentiment=sentiment,
+            earnings=earnings, config=cfg, db_path=tmp_db_path,
+        )
+        await sm.scan_for_entries(
+            watchlist=["SPY"], get_5min_bars=fake_bars,
+            get_daily_bars=fake_daily_bars, account_equity_gbp=1000.0,
+        )
+        om_decision = order_manager.place_entry.call_args[0][0]
+        assert om_decision.limit_price == 100.10
+
+
+# ---------------------------------------------------------------------------
+# Per-symbol allocation cap
+# ---------------------------------------------------------------------------
+
+
+class TestSymbolAllocationCap:
+    @pytest.mark.asyncio
+    async def test_cap_shrinks_oversized_entry(
+        self, market_data, risk_manager, order_manager, sentiment, earnings,
+        portfolio_manager, fake_bars, fake_daily_bars, tmp_db_path,
+    ):
+        # Total book = $1000. Cap SPY at 30% → $300 max. 5 × $100 = $500 → cap.
+        cfg = _config(cap_pct=0.30)
+        sm = StrategyManager(
+            strategies=[_StubStrategy("stub", _decision(shares=5, entry=100.0))],
+            portfolio_manager=portfolio_manager,
+            market_data=market_data, order_manager=order_manager,
+            risk_manager=risk_manager, sentiment=sentiment,
+            earnings=earnings, config=cfg, db_path=tmp_db_path,
+        )
+        await sm.scan_for_entries(
+            watchlist=["SPY"], get_5min_bars=fake_bars,
+            get_daily_bars=fake_daily_bars, account_equity_gbp=1000.0,
+        )
+        order_manager.place_entry.assert_called_once()
+        om_decision = order_manager.place_entry.call_args[0][0]
+        assert om_decision.shares == 3  # int($300 / $100) = 3
+
+    @pytest.mark.asyncio
+    async def test_cap_rejects_when_existing_exposure_full(
+        self, market_data, risk_manager, order_manager, sentiment, earnings,
+        portfolio_manager, fake_bars, fake_daily_bars, tmp_db_path,
+    ):
+        # Pre-populate an existing SPY position consuming 30% of book.
+        conn: sqlite3.Connection = sqlite3.connect(tmp_db_path)
+        try:
+            conn.execute(
+                "INSERT INTO positions "
+                "(ticker, exchange, currency, quantity, entry_price, "
+                " entry_time, status, hold_type, phase, strategy_id) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                ("SPY", "US", "USD", 3, 100.0, "2026-01-01T00:00:00",
+                 PositionStatus.POSITION_OPEN.value, "swing", 1, "stub"),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        cfg = _config(cap_pct=0.30)
+        sm = StrategyManager(
+            strategies=[_StubStrategy("stub", _decision(shares=5, entry=100.0))],
+            portfolio_manager=portfolio_manager,
+            market_data=market_data, order_manager=order_manager,
+            risk_manager=risk_manager, sentiment=sentiment,
+            earnings=earnings, config=cfg, db_path=tmp_db_path,
+        )
+        await sm.scan_for_entries(
+            watchlist=["SPY"], get_5min_bars=fake_bars,
+            get_daily_bars=fake_daily_bars, account_equity_gbp=1000.0,
+        )
+        order_manager.place_entry.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cap_disabled_at_unity_lets_decision_through(
+        self, market_data, risk_manager, order_manager, sentiment, earnings,
+        portfolio_manager, fake_bars, fake_daily_bars, tmp_db_path,
+    ):
+        cfg = _config(cap_pct=1.0)
+        sm = StrategyManager(
+            strategies=[_StubStrategy("stub", _decision(shares=5, entry=100.0))],
+            portfolio_manager=portfolio_manager,
+            market_data=market_data, order_manager=order_manager,
+            risk_manager=risk_manager, sentiment=sentiment,
+            earnings=earnings, config=cfg, db_path=tmp_db_path,
+        )
+        await sm.scan_for_entries(
+            watchlist=["SPY"], get_5min_bars=fake_bars,
+            get_daily_bars=fake_daily_bars, account_equity_gbp=1000.0,
+        )
+        om_decision = order_manager.place_entry.call_args[0][0]
+        assert om_decision.shares == 5
+
+
+# ---------------------------------------------------------------------------
+# Loss-cooldown gate
+# ---------------------------------------------------------------------------
+
+
+class TestLossCooldownGate:
+    @pytest.mark.asyncio
+    async def test_strategy_on_cooldown_skipped(
+        self, market_data, risk_manager, order_manager, sentiment, earnings,
+        portfolio_manager, fake_bars, fake_daily_bars, tmp_db_path,
+    ):
+        cfg = _config()
+        tracker = LossCooldownTracker(
+            db_path=tmp_db_path,
+            config=LossCooldownConfig(enabled=True, threshold_losses=2),
+        )
+        # Engage cooldown
+        tracker.record_outcome("stub", -10.0)
+        tracker.record_outcome("stub", -10.0)
+
+        sm = StrategyManager(
+            strategies=[_StubStrategy("stub", _decision())],
+            portfolio_manager=portfolio_manager,
+            market_data=market_data, order_manager=order_manager,
+            risk_manager=risk_manager, sentiment=sentiment,
+            earnings=earnings, config=cfg, db_path=tmp_db_path,
+            loss_cooldown=tracker,
+        )
+        n = await sm.scan_for_entries(
+            watchlist=["SPY"], get_5min_bars=fake_bars,
+            get_daily_bars=fake_daily_bars, account_equity_gbp=1000.0,
+        )
+        assert n == 0
+        order_manager.place_entry.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_check_exits_records_loss_outcome(
+        self, market_data, risk_manager, order_manager, sentiment, earnings,
+        portfolio_manager, tmp_db_path,
+    ):
+        cfg = _config()
+        tracker = LossCooldownTracker(
+            db_path=tmp_db_path,
+            config=LossCooldownConfig(enabled=True, threshold_losses=2),
+        )
+        portfolio = portfolio_manager._portfolio
+        portfolio.get_open_positions = MagicMock(return_value=[
+            {"ticker": "SPY", "entry_price": 100.0, "quantity": 3},
+        ])
+        market_data.get_latest_price = MagicMock(return_value=95.0)
+
+        strategy = _StubStrategy("stub", None)
+        # Force exit
+        strategy._exit_signal = ExitSignal(should_exit=True, reason="stop_loss")
+        strategy.evaluate_exit = lambda *a, **kw: ExitSignal(
+            should_exit=True, reason="stop_loss",
+        )
+
+        sm = StrategyManager(
+            strategies=[strategy],
+            portfolio_manager=portfolio_manager,
+            market_data=market_data, order_manager=order_manager,
+            risk_manager=risk_manager, sentiment=sentiment,
+            earnings=earnings, config=cfg, db_path=tmp_db_path,
+            loss_cooldown=tracker,
+        )
+        await sm.check_exits()
+        # First loss recorded; not yet on cooldown (threshold=2)
+        assert tracker.is_on_cooldown("stub")[0] is False
+        await sm.check_exits()
+        # Second consecutive loss → cooldown engaged
+        assert tracker.is_on_cooldown("stub")[0] is True


### PR DESCRIPTION
## Summary

Adds five portfolio-level risk gates layered on top of the existing multi-strategy stack, and disables the `trend_following` sleeve based on walkforward evidence. Allocation freed by the disable is redistributed to `mean_reversion` and `breakout`.

## Risk gates added

| Gate | Where | Config |
|---|---|---|
| Per-symbol allocation cap | `strategy_manager._enforce_symbol_cap` | `watchlist_caps.per_symbol[ticker]` |
| Entry limit-slop clamp | `strategy_manager._clamp_limit_price` | `entry.limit_slop_pct` (default 0.002 = 0.2%) |
| Consecutive-loss cooldown | `execution.loss_cooldown` | `risk.consecutive_loss_cooldown.{enabled,threshold_losses,cooldown_minutes}` |
| Macro-event (FOMC) gate | `data.event_calendar` | `event_gate.{enabled,fomc_action,fomc_size_multiplier,fomc_dates_<year>}` |
| ATR-anchored stops (opt-in) | breakout, trend_following | `<strategy>.{use_atr_stops,atr_period,atr_stop_mult,atr_trail_mult}` |

State for the cooldown gate persists in `risk_circuit_state` so it survives stateless GHA ticks. The FOMC gate is config-driven; update `event_gate.fomc_dates_<year>` annually from federalreserve.gov.

## Trend Following disable

Two consecutive walkforward runs put trend_following's OOS PF lower-CI below 1.0:

- Pre-batch (memorized): PF 1.637 CI [1.00, 2.58] — borderline significant
- Post-batch (current):  PF 1.034 CI [0.476, 2.555] — not significant; OOS return collapsed to +0.33% over 13yr

Allocation: `trend_following` $1,250 → $0; `mean_reversion` $750 → $1,375; `breakout` $2,000 → $2,625. Total fund book unchanged at $5,000.

## Walkforward portfolio metric — before vs after disable

| Metric | TF enabled | TF disabled | Δ |
|---|---:|---:|---|
| Trades | 148 | 110 | -38 |
| PF | 1.385 | **1.568** | +0.18 |
| OOS Return | +5.33% | **+7.00%** | +1.67% |
| Sharpe | 0.123 | **0.167** | +0.044 |
| PF lower CI | 0.927 | 0.937 | tighter & higher |

Per-sleeve walkforward values are unchanged (each is measured independently); the gain is purely from removing the negative-edge sleeve.

## ATR-anchored stops — A/B on SPY 13yr

Byte-identical results between ATR ON and ATR OFF:

| Strategy | ATR ON | ATR OFF |
|---|---|---|
| Breakout | 39t / +109.95% / PF 2.72 | 39t / +109.95% / PF 2.72 |
| Trend Following | 115t / +56.29% / PF 1.45 | 115t / +56.29% / PF 1.45 |

Donchian and trailing-stop exits dominate the initial stop; on SPY the ATR change is a no-op. Kept opt-in (default `false` if not configured) as cheap insurance for higher-vol / multi-ticker datasets where the stop matters more.

## Statistical significance — honest read

No single sleeve has a CI lower bound > 1.0 in the post-batch walkforward. Portfolio PF 1.568 with CI [0.937, 2.737] is **near-significant** — call it "evidence-of-edge" rather than "proven edge". Per-sleeve CIs are wide because each sleeve has only ~35 trades over 57 disjoint 90-day OOS windows; the portfolio metric (110 trades) is the more reliable signal.

## Test plan

- [x] 25 new tests (event calendar, loss cooldown, strategy-manager gates)
- [x] Full suite passes: `pytest trading_bot/tests/` → 570 passed, 1 warning
- [x] SPY 13yr simple backtest run (results above)
- [x] SPY 13yr walkforward run pre/post disable (results above)
- [x] Multi-ticker intraday 5.7yr (SPY/QQQ/XLF/XLK/XLV/XLE) — overnight_drift +22.84%, MR +14.98%, breakout/trend_following negative
- [x] S&P 500 daily 5yr (~505 names) — MR +17.91%, breakout +5.68%, trend_following -13.39% (corroborates disable)
- [ ] Paper-trading validation over 1-2 weeks with the new gates active
- [ ] Update `event_gate.fomc_dates_<year>` annually

## Files

- New: `trading_bot/data/event_calendar.py`, `trading_bot/execution/loss_cooldown.py`
- Modified: `config.yaml`, `trading_bot/config.py`, `trading_bot/main.py`, `trading_bot/strategy/strategy_manager.py`, `trading_bot/strategy/strategies/{breakout,trend_following}.py`, `README.md`
- Tests: `trading_bot/tests/test_{event_calendar,loss_cooldown,strategy_manager_gates}.py`