### PR TITLE
fix: address review findings from PRs #8-#12 (broker safety, immutability, async correctness)

### DIFF
--- a/scripts/smoke_recovery.py
+++ b/scripts/smoke_recovery.py
@@ -19,7 +19,6 @@ from zoneinfo import ZoneInfo
 from dotenv import load_dotenv
 
 from trading_bot.config import Config
-from trading_bot.constants import TZ_EASTERN
 from trading_bot.gateway.connection import GatewayConnection
 from trading_bot.gateway.recovery import StateRecovery
 from trading_bot.notifications.notifier import Notifier

--- a/trading_bot/backtest/walkforward.py
+++ b/trading_bot/backtest/walkforward.py
@@ -30,7 +30,7 @@ import random
 import statistics
 from dataclasses import dataclass, field
 from datetime import date, timedelta
-from typing import Awaitable, Callable, Sequence
+from typing import Any, Awaitable, Callable, Sequence
 
 from trading_bot.multi_strategy_backtest import (
     MultiStrategyResult,
@@ -82,7 +82,15 @@ class BootstrapCI:
     upper: float
     samples: int
 
-    def as_dict(self) -> dict[str, float | int | str]:
+    def as_dict(self) -> dict[str, Any]:
+        """Serialise as a plain dict for logging or JSON dumps.
+
+        Return type is ``dict[str, Any]`` rather than the previous
+        narrower union — mypy's strict mode rejected mixing ``str`` and
+        ``float`` in a single dict literal even though the annotation
+        was honest about it. ``Any`` here is read-only diagnostic
+        output, not a type-safety boundary.
+        """
         return {
             "metric": self.metric,
             "point_estimate": round(self.point_estimate, 4),

--- a/trading_bot/config.py
+++ b/trading_bot/config.py
@@ -107,6 +107,21 @@ class Config:
             raise ConfigError(f"Missing required config key: {'.'.join(keys)}")
         return val
 
+    def raw_section(self, *keys: str) -> dict[str, Any]:
+        """Public, type-safe accessor for a raw config subtree.
+
+        ``raw_section()`` (no args) returns a shallow copy of the full
+        config dict. ``raw_section("event_gate")`` returns the
+        ``event_gate`` subtree, or ``{}`` if missing or non-mapping.
+        Callers should use this rather than reaching into ``_raw``
+        directly so a future rename of the storage attribute doesn't
+        silently disable gates.
+        """
+        if not keys:
+            return dict(self._raw)
+        node: Any = self._get(*keys, default={})
+        return node if isinstance(node, dict) else {}
+
     # -----------------------------------------------------------------------
     # Phase detection
     # -----------------------------------------------------------------------

--- a/trading_bot/execution/loss_cooldown.py
+++ b/trading_bot/execution/loss_cooldown.py
@@ -16,6 +16,7 @@ import logging
 import sqlite3
 from dataclasses import dataclass
 from datetime import datetime, timedelta
+from typing import Callable
 from zoneinfo import ZoneInfo
 
 from trading_bot.constants import TZ_EASTERN
@@ -42,9 +43,20 @@ class LossCooldownConfig:
 class LossCooldownTracker:
     """Tracks consecutive losses per strategy and enforces a cooldown."""
 
-    def __init__(self, db_path: str, config: LossCooldownConfig) -> None:
+    def __init__(
+        self,
+        db_path: str,
+        config: LossCooldownConfig,
+        now_fn: Callable[[], datetime] | None = None,
+    ) -> None:
         self._db_path: str = db_path
         self._config: LossCooldownConfig = config
+        # Injectable clock — defaults to wall clock in ET. Tests pass a
+        # fixed clock so cooldown-window expiry can be exercised without
+        # relying on real elapsed time.
+        self._now_fn: Callable[[], datetime] = (
+            now_fn or (lambda: datetime.now(tz=ET))
+        )
 
     @property
     def enabled(self) -> bool:
@@ -54,8 +66,11 @@ class LossCooldownTracker:
         """Record a closed-trade outcome for *strategy_id*.
 
         ``pnl > 0`` resets the counter and clears any active cooldown.
-        ``pnl <= 0`` increments the counter; if it reaches the configured
-        threshold, a cooldown window is set.
+        ``pnl < 0`` increments the counter; if it reaches the configured
+        threshold, a cooldown window is set. ``pnl == 0`` (a scratch
+        trade) is treated as neutral — neither resetting nor advancing
+        the streak — to avoid false cooldowns from break-even runs on
+        commission-free SPY intraday.
         """
         if not self._config.enabled:
             return
@@ -85,6 +100,10 @@ class LossCooldownTracker:
                         )
                     return
 
+                if pnl == 0:
+                    # Scratch trade — neither resets nor advances the streak.
+                    return
+
                 consecutive += 1
                 if consecutive < self._config.threshold_losses:
                     repo.save_risk_state(
@@ -98,7 +117,7 @@ class LossCooldownTracker:
                     )
                     return
 
-                cooldown_until: datetime = datetime.now(tz=ET) + timedelta(
+                cooldown_until: datetime = self._now_fn() + timedelta(
                     minutes=self._config.cooldown_minutes,
                 )
                 repo.save_risk_state(
@@ -156,7 +175,7 @@ class LossCooldownTracker:
         if cooldown_until.tzinfo is None:
             cooldown_until = cooldown_until.replace(tzinfo=ET)
 
-        now: datetime = datetime.now(tz=ET)
+        now: datetime = self._now_fn()
         if now >= cooldown_until:
             self._auto_clear(strategy_id)
             return False, None

--- a/trading_bot/execution/order_manager.py
+++ b/trading_bot/execution/order_manager.py
@@ -12,6 +12,7 @@ survive a stateless cron run.  ``_active_orders`` is hydrated from the
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import sqlite3
 from dataclasses import dataclass
@@ -514,7 +515,9 @@ class OrderManager:
                 type=OrderType.MARKET,
                 time_in_force=TimeInForce.IOC,
             )
-            order: AlpacaOrder = client.submit_order(order_data=request)
+            order: AlpacaOrder = await asyncio.to_thread(
+                client.submit_order, order_data=request,
+            )
             logger.warning(
                 "Emergency flatten: SELL %d %s @ MARKET (alpaca_id=%s)",
                 qty, ticker, str(order.id),
@@ -529,6 +532,85 @@ class OrderManager:
                 priority=5,
                 tags=["skull_and_crossbones"],
             )
+
+    async def place_exit(
+        self,
+        ticker: str,
+        qty: float,
+        reason: str,
+        *,
+        is_emergency: bool = False,
+    ) -> str | None:
+        """Submit a strategy-driven exit (market sell).
+
+        Cancels any outstanding bracket legs for the matching position so
+        the broker doesn't reject the new order with insufficient-qty.
+        Returns the Alpaca order id on submission, or None on failure.
+        """
+        if qty <= 0:
+            logger.warning(
+                "place_exit called with non-positive qty for %s: %s", ticker, qty,
+            )
+            return None
+
+        # Find the matching active order (DB-hydrated) so we can release
+        # the bracket legs that reserve the shares.
+        matching_trade_id: int | None = None
+        matching_active: _ActiveOrder | None = None
+        for tid, active in self._active_orders.items():
+            if active.ticker == ticker and active.status not in (
+                PositionStatus.CLOSED,
+            ):
+                matching_trade_id = tid
+                matching_active = active
+                break
+
+        if matching_active is not None:
+            for oid in (
+                matching_active.alpaca_stop_order_id,
+                matching_active.alpaca_target_order_id,
+                matching_active.alpaca_trail_order_id,
+            ):
+                if oid is not None:
+                    await self.cancel_order(oid)
+        else:
+            # Defensive: cancel anything pending on the symbol so the
+            # market sell isn't blocked by reserved qty.
+            await self.cancel_all_for_ticker(ticker)
+
+        client: TradingClient = self._gw.client
+        try:
+            request = MarketOrderRequest(
+                symbol=ticker,
+                qty=qty,
+                side=OrderSide.SELL,
+                type=OrderType.MARKET,
+                time_in_force=TimeInForce.DAY,
+            )
+            order: AlpacaOrder = await asyncio.to_thread(
+                client.submit_order, order_data=request,
+            )
+            order_id: str = str(order.id)
+            logger.info(
+                "Strategy exit submitted: SELL %s %s @ MARKET (reason=%s, alpaca_id=%s)",
+                qty, ticker, reason, order_id,
+            )
+            if matching_trade_id is not None:
+                self._alpaca_to_trade[order_id] = matching_trade_id
+            return order_id
+        except Exception:
+            logger.exception(
+                "CRITICAL: Failed to place strategy exit for %s (qty=%s, reason=%s)",
+                ticker, qty, reason,
+            )
+            if is_emergency:
+                await self._notifier.send(
+                    "Strategy Exit Failed",
+                    f"Failed to exit {qty} {ticker} (reason={reason}). Manual review required.",
+                    priority=4,
+                    tags=["warning"],
+                )
+            return None
 
     async def flatten_all(self) -> None:
         """Flatten all positions with market orders (kill switch)."""

--- a/trading_bot/execution/virtual_portfolio.py
+++ b/trading_bot/execution/virtual_portfolio.py
@@ -56,8 +56,15 @@ class VirtualPortfolio:
         pending: float = self._get_pending_settlements()
         return max(cash - pending, 0.0)
 
-    def record_entry(self, shares: int, price: float) -> None:
-        cost: float = shares * price
+    def record_entry(self, shares: float, price: float) -> None:
+        """Deduct ``shares × price`` from this strategy's virtual cash.
+
+        Accepts ``float`` so fractional-share strategies (Alpaca supports
+        down to 1/1000000) don't silently truncate to int and drift the
+        cash accounting. Integer callers are unaffected — ``5 * 100.0``
+        equals ``5.0 * 100.0`` to the precision SQLite stores.
+        """
+        cost: float = float(shares) * price
         conn: sqlite3.Connection = sqlite3.connect(self._db_path)
         try:
             conn.execute(
@@ -67,11 +74,20 @@ class VirtualPortfolio:
             conn.commit()
         finally:
             conn.close()
-        logger.info("[%s] Entry recorded: %d shares @ $%.2f ($%.2f deducted)", self.strategy_id, shares, price, cost)
+        logger.info(
+            "[%s] Entry recorded: %s shares @ $%.2f ($%.2f deducted)",
+            self.strategy_id, shares, price, cost,
+        )
 
-    def record_exit(self, shares: int, exit_price: float, entry_price: float) -> None:
-        proceeds: float = shares * exit_price
-        pnl: float = shares * (exit_price - entry_price)
+    def record_exit(
+        self, shares: float, exit_price: float, entry_price: float,
+    ) -> None:
+        """Credit proceeds and update P&L counters for a closed exit.
+
+        ``shares`` is ``float`` for the same reason as ``record_entry``.
+        """
+        proceeds: float = float(shares) * exit_price
+        pnl: float = float(shares) * (exit_price - entry_price)
         is_win: bool = pnl > 0
 
         conn: sqlite3.Connection = sqlite3.connect(self._db_path)
@@ -90,7 +106,10 @@ class VirtualPortfolio:
             conn.commit()
         finally:
             conn.close()
-        logger.info("[%s] Exit recorded: %d shares @ $%.2f, P&L=$%.2f", self.strategy_id, shares, exit_price, pnl)
+        logger.info(
+            "[%s] Exit recorded: %s shares @ $%.2f, P&L=$%.2f",
+            self.strategy_id, shares, exit_price, pnl,
+        )
 
     def get_open_positions(self) -> list[dict[str, Any]]:
         conn: sqlite3.Connection = sqlite3.connect(self._db_path)

--- a/trading_bot/gateway/recovery.py
+++ b/trading_bot/gateway/recovery.py
@@ -7,6 +7,7 @@ SQLite database before resuming normal operation.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import sqlite3
 from dataclasses import dataclass, field
@@ -279,7 +280,9 @@ class StateRecovery:
                 time_in_force=TimeInForce.GTC,
                 stop_price=stop_price,
             )
-            self._gw.client.submit_order(order_data=request)
+            # Alpaca SDK is sync — offload to a worker thread so we don't
+            # block the event loop on the HTTP submit.
+            await asyncio.to_thread(self._gw.client.submit_order, order_data=request)
             logger.info("Emergency stop placed for %s: %s %d @ stop %.2f", ticker, side.value, order_qty, stop_price)
         except Exception:
             logger.exception("Failed to place emergency stop for %s", ticker)
@@ -322,7 +325,7 @@ class StateRecovery:
             ticker: str = str(order.symbol)
             order_id: str = str(getattr(order, "id", "") or "")
             try:
-                self._gw.client.cancel_order_by_id(order_id)
+                await asyncio.to_thread(self._gw.client.cancel_order_by_id, order_id)
                 age_min: float = (now - submitted_at).total_seconds() / 60.0
                 logger.warning(
                     "Cancelled stale %s order for %s (id=%s, age=%.1f min)",
@@ -387,7 +390,7 @@ class StateRecovery:
                     side=side,
                     time_in_force=TimeInForce.DAY,
                 )
-                self._gw.client.submit_order(order_data=request)
+                await asyncio.to_thread(self._gw.client.submit_order, order_data=request)
                 logger.warning(
                     "EOD flatten: %s %d %s (cutoff=%s)",
                     side.value, abs(qty), ticker, cutoff_str,
@@ -470,39 +473,45 @@ class StateRecovery:
         # extended by a future migration.
         conn.row_factory = sqlite3.Row
         try:
-            conn.execute(
-                "UPDATE positions SET status = 'CLOSED', updated_at = ? WHERE id = ?",
-                (now, position_id),
-            )
-            row = conn.execute(
-                "SELECT * FROM positions WHERE id = ?", (position_id,)
-            ).fetchone()
-            if row:
-                conn.execute(
-                    """INSERT INTO trades
-                       (ticker, exchange, currency, side, entry_time,
-                        entry_price, quantity, exit_time, exit_reason,
-                        hold_type, phase, notes)
-                       VALUES (:ticker, :exchange, :currency, 'SELL',
-                               :entry_time, :entry_price, :quantity,
-                               :exit_time, :exit_reason, :hold_type, :phase,
-                               'Auto-closed by state recovery')""",
-                    {
-                        "ticker": row["ticker"],
-                        "exchange": row["exchange"],
-                        "currency": row["currency"],
-                        "entry_time": row["entry_time"],
-                        "entry_price": row["entry_price"],
-                        "quantity": row["quantity"],
-                        "exit_time": now,
-                        "exit_reason": reason,
-                        "hold_type": row["hold_type"],
-                        "phase": row["phase"],
-                    },
-                )
-            conn.commit()
-        except sqlite3.OperationalError:
-            logger.warning("Could not close position id=%d", position_id)
+            # Explicit ``with conn:`` makes atomicity self-documenting:
+            # both the UPDATE and the INSERT either commit together or
+            # roll back together if any statement raises.
+            try:
+                with conn:
+                    conn.execute(
+                        "UPDATE positions SET status = 'CLOSED', "
+                        "updated_at = ? WHERE id = ?",
+                        (now, position_id),
+                    )
+                    row = conn.execute(
+                        "SELECT * FROM positions WHERE id = ?", (position_id,)
+                    ).fetchone()
+                    if row:
+                        conn.execute(
+                            """INSERT INTO trades
+                               (ticker, exchange, currency, side, entry_time,
+                                entry_price, quantity, exit_time, exit_reason,
+                                hold_type, phase, notes)
+                               VALUES (:ticker, :exchange, :currency, 'SELL',
+                                       :entry_time, :entry_price, :quantity,
+                                       :exit_time, :exit_reason, :hold_type,
+                                       :phase,
+                                       'Auto-closed by state recovery')""",
+                            {
+                                "ticker": row["ticker"],
+                                "exchange": row["exchange"],
+                                "currency": row["currency"],
+                                "entry_time": row["entry_time"],
+                                "entry_price": row["entry_price"],
+                                "quantity": row["quantity"],
+                                "exit_time": now,
+                                "exit_reason": reason,
+                                "hold_type": row["hold_type"],
+                                "phase": row["phase"],
+                            },
+                        )
+            except sqlite3.OperationalError:
+                logger.warning("Could not close position id=%d", position_id)
         finally:
             conn.close()
 

--- a/trading_bot/main.py
+++ b/trading_bot/main.py
@@ -516,12 +516,18 @@ class TradingBot:
             watchlist: list[str] = (
                 self._active_watchlist.get(market) or self._config.get_watchlist(market)
             )
-            account_equity_gbp: float = await self._get_account_equity_gbp()
+            # NOTE: ``_get_account_equity_gbp`` returns USD on Alpaca
+            # (NetLiquidation is reported in account currency = USD).
+            # The function name is a legacy IBKR-era misnomer pending a
+            # broader rename that also touches the daily_summaries DB
+            # column. Pass through as USD here for the new
+            # StrategyManager API.
+            account_equity_usd: float = await self._get_account_equity_gbp()
             await self._strategy_manager.scan_for_entries(
                 watchlist=watchlist,
                 get_5min_bars=self._get_5min_bars,
                 get_daily_bars=self._get_daily_bars,
-                account_equity_gbp=account_equity_gbp,
+                account_equity_usd=account_equity_usd,
             )
             return
 

--- a/trading_bot/multi_strategy_backtest.py
+++ b/trading_bot/multi_strategy_backtest.py
@@ -1233,6 +1233,14 @@ class MultiStrategyBacktester:
         ticker = "SPY"
 
         prev_day: date | None = None
+        # Initialize before the loop so the first iteration's
+        # ``day_start_equity.get(sid, total_now)`` read in the
+        # ``prev_day is not None`` branch can never be unbound. ruff
+        # flagged this as F821 along the path where the inner branch
+        # could in theory reach a not-yet-assigned variable; in practice
+        # ``prev_day is None`` on the very first bar prevents the read,
+        # but explicit init removes the smell.
+        day_start_equity: dict[str, float] = {}
 
         for bar_idx in range(LOOKBACK_BARS, len(df_5min)):
             bar = df_5min.iloc[bar_idx]
@@ -1266,7 +1274,7 @@ class MultiStrategyBacktester:
                         for trade in st.open_positions:
                             trade.days_held += 1
 
-                day_start_equity: dict[str, float] = {}
+                day_start_equity = {}
                 for sid, st in states.items():
                     pos_value = sum(
                         t.entry_price * t.shares for t in st.open_positions

--- a/trading_bot/strategy/base.py
+++ b/trading_bot/strategy/base.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 import pandas as pd
@@ -16,7 +16,13 @@ logger: logging.Logger = logging.getLogger(__name__)
 
 @dataclass
 class StrategyDecision:
-    """Entry decision produced by a strategy."""
+    """Entry decision produced by a strategy.
+
+    Treat instances as immutable in transformation pipelines: helpers that
+    need to adjust a decision (FOMC scaling, symbol-cap shrink) return a
+    new instance via ``dataclasses.replace`` rather than mutating shared
+    state.
+    """
 
     ticker: str
     exchange: str
@@ -28,7 +34,7 @@ class StrategyDecision:
     trail_pct: float | None  # None if using fixed target
     hold_type: HoldType
     strategy_id: str
-    signals: dict[str, Any]
+    signals: dict[str, Any] = field(default_factory=dict)
     sentiment_score: float | None = None
     # Price at which an active trailing stop should replace the take-profit.
     # None means "activate trailing immediately on fill" (legacy behaviour).

--- a/trading_bot/strategy/strategy_manager.py
+++ b/trading_bot/strategy/strategy_manager.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import sqlite3
+from dataclasses import replace
 from datetime import datetime
 from typing import Any
 from zoneinfo import ZoneInfo
@@ -64,9 +65,16 @@ class StrategyManager:
         watchlist: list[str],
         get_5min_bars: Any,
         get_daily_bars: Any,
-        account_equity_gbp: float,
+        account_equity_usd: float,
     ) -> int:
-        """Run all strategies against the watchlist. Returns number of entries placed."""
+        """Run all strategies against the watchlist. Returns number of entries placed.
+
+        ``account_equity_usd`` is the broker NetLiquidation in USD (Alpaca
+        accounts settle in USD). The legacy "GBP" naming used elsewhere
+        in main.py is a relic — this manager uses the correct currency
+        label so future FX work won't accidentally apply a conversion to
+        an already-USD figure.
+        """
         entries_placed: int = 0
 
         if self._market_data.trading_paused:
@@ -233,6 +241,12 @@ class StrategyManager:
             positions: list[dict[str, Any]] = portfolio.get_open_positions()
             for position in positions:
                 ticker: str = position["ticker"]
+                # Stale-data gate — same protection scan_for_entries uses.
+                # A stale price that fires a false exit signal would
+                # otherwise cascade into a phantom market sell, broken
+                # virtual-portfolio cash, and a fake loss-cooldown record.
+                if self._market_data.is_stale(ticker):
+                    continue
                 current_price: float | None = self._market_data.get_latest_price(ticker)
                 if current_price is None or current_price <= 0:
                     continue
@@ -280,13 +294,35 @@ class StrategyManager:
                     continue
 
                 entry_price: float = float(position.get("entry_price", 0))
-                shares: int = int(position.get("quantity", 0))
+                shares: float = float(position.get("quantity", 0))
+                if shares <= 0:
+                    continue
+
+                # CRITICAL: send the broker order *before* recording the
+                # virtual exit. If the broker call fails we leave the
+                # virtual portfolio untouched, so the next tick still
+                # sees the position open and can re-attempt the exit
+                # (rather than silently diverging from broker state).
+                exit_order_id: str | None = await self._order_manager.place_exit(
+                    ticker=ticker,
+                    qty=shares,
+                    reason=exit_signal.reason or "strategy_exit",
+                    is_emergency=exit_signal.is_emergency,
+                )
+                if exit_order_id is None:
+                    logger.error(
+                        "[%s] Exit order rejected for %s — leaving virtual "
+                        "portfolio untouched so we re-attempt next tick",
+                        strategy.strategy_id, ticker,
+                    )
+                    continue
+
                 portfolio.record_exit(shares, current_price, entry_price)
                 exits += 1
 
                 # Loss-cooldown bookkeeping — must follow record_exit so the
                 # virtual portfolio's tally is consistent with the tracker's.
-                if self._loss_cooldown is not None and shares > 0:
+                if self._loss_cooldown is not None:
                     pnl: float = shares * (current_price - entry_price)
                     self._loss_cooldown.record_outcome(strategy.strategy_id, pnl)
 
@@ -326,9 +362,23 @@ class StrategyManager:
     # ------------------------------------------------------------------
 
     def _fomc_size_multiplier(self) -> float:
-        """Lookup today's FOMC multiplier from raw config (defaults to 1.0)."""
-        getter = getattr(self._config, "_raw", None)
-        raw: dict[str, Any] = getter if isinstance(getter, dict) else {}
+        """Lookup today's FOMC multiplier from config (defaults to 1.0).
+
+        Uses ``Config.raw_section()`` when available so we don't depend
+        on the private ``_raw`` attribute. Falls back to ``_raw`` only
+        for tests/mocks that pre-date the helper.
+        """
+        raw: dict[str, Any] = {}
+        section_fn = getattr(self._config, "raw_section", None)
+        if callable(section_fn):
+            try:
+                raw = section_fn()
+            except Exception:
+                raw = {}
+        if not raw:
+            legacy = getattr(self._config, "_raw", None)
+            if isinstance(legacy, dict):
+                raw = legacy
         try:
             today = datetime.now(tz=ET).date()
             return float(fomc_size_multiplier(today, raw))
@@ -340,21 +390,28 @@ class StrategyManager:
     def _scale_decision_shares(
         decision: StrategyDecision, multiplier: float,
     ) -> StrategyDecision | None:
-        """Scale a decision's share count by *multiplier*; drop if it falls below 1."""
+        """Return a new decision with shares scaled by *multiplier*, or None.
+
+        Preserves integer-vs-fractional intent based on the original
+        ``shares`` type. Returns a brand-new ``StrategyDecision`` so the
+        caller's object is never mutated — composition with other helpers
+        (FOMC × symbol cap) stays predictable regardless of call order.
+        """
         if multiplier <= 0:
             return None
         scaled: float = float(decision.shares) * multiplier
-        # Preserve integer share counts when the strategy used integer sizing.
-        if isinstance(decision.shares, int) and not isinstance(decision.shares, bool):
-            scaled = float(int(scaled))
-            if scaled < 1.0:
+        is_int_sized: bool = (
+            isinstance(decision.shares, int) and not isinstance(decision.shares, bool)
+        )
+        if is_int_sized:
+            scaled_int: int = int(scaled)
+            if scaled_int < 1:
                 return None
-        else:
-            scaled = round(scaled, 4)
-            if scaled < 0.001:
-                return None
-        decision.shares = scaled  # type: ignore[assignment]
-        return decision
+            return replace(decision, shares=scaled_int)
+        scaled = round(scaled, 4)
+        if scaled < 0.001:
+            return None
+        return replace(decision, shares=scaled)
 
     def _enforce_symbol_cap(
         self, decision: StrategyDecision,
@@ -365,7 +422,9 @@ class StrategyManager:
         value. Existing exposure to ``decision.ticker`` across all
         sub-portfolios + the proposed entry must stay under the cap;
         otherwise the candidate is shrunk (or rejected if the resulting
-        size would be below the strategy's min trade unit).
+        size would be below the strategy's min trade unit). Returns a
+        new ``StrategyDecision`` rather than mutating the caller's
+        object so transformations compose cleanly.
         """
         try:
             cap_pct: float = float(
@@ -394,24 +453,27 @@ class StrategyManager:
             return None
 
         max_shares_by_cap: float = remaining / float(decision.entry_price)
-        if isinstance(decision.shares, int) and not isinstance(decision.shares, bool):
-            max_shares_by_cap = float(int(max_shares_by_cap))
-            if max_shares_by_cap < 1.0:
+        is_int_sized: bool = (
+            isinstance(decision.shares, int) and not isinstance(decision.shares, bool)
+        )
+        if is_int_sized:
+            shares_int: int = int(max_shares_by_cap)
+            if shares_int < 1:
                 return None
-            decision.shares = int(max_shares_by_cap)  # type: ignore[assignment]
+            new_decision: StrategyDecision = replace(decision, shares=shares_int)
         else:
-            max_shares_by_cap = round(max_shares_by_cap, 4)
-            if max_shares_by_cap < 0.001:
+            shares_frac: float = round(max_shares_by_cap, 4)
+            if shares_frac < 0.001:
                 return None
-            decision.shares = max_shares_by_cap  # type: ignore[assignment]
+            new_decision = replace(decision, shares=shares_frac)
 
         logger.info(
             "[%s] %s shrunk by symbol cap %.0f%% (existing $%.2f, cap $%.2f, "
             "new shares=%s)",
-            decision.strategy_id, decision.ticker, cap_pct * 100,
-            existing_exposure, cap_value, decision.shares,
+            new_decision.strategy_id, new_decision.ticker, cap_pct * 100,
+            existing_exposure, cap_value, new_decision.shares,
         )
-        return decision
+        return new_decision
 
     def _compute_total_book_value(self) -> float:
         """Sum cash + open-position book value across all virtual portfolios."""

--- a/trading_bot/tests/test_loss_cooldown.py
+++ b/trading_bot/tests/test_loss_cooldown.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import sqlite3
 from datetime import datetime, timedelta
+from typing import Callable
 from zoneinfo import ZoneInfo
 
 from trading_bot.constants import TZ_EASTERN
@@ -15,14 +16,24 @@ from trading_bot.execution.loss_cooldown import (
 
 ET: ZoneInfo = TZ_EASTERN
 
+# Fixed clock used across the suite — pin to a well-known mid-day so any
+# arithmetic on the cooldown window remains comprehensible.
+_T0: datetime = datetime(2026, 4, 28, 14, 30, tzinfo=ET)
 
-def _make_tracker(db_path: str, **overrides) -> LossCooldownTracker:
+
+def _make_tracker(
+    db_path: str,
+    now_fn: Callable[[], datetime] | None = None,
+    **overrides,
+) -> LossCooldownTracker:
     cfg = LossCooldownConfig(
         enabled=overrides.get("enabled", True),
         threshold_losses=overrides.get("threshold_losses", 3),
         cooldown_minutes=overrides.get("cooldown_minutes", 60),
     )
-    return LossCooldownTracker(db_path=db_path, config=cfg)
+    return LossCooldownTracker(
+        db_path=db_path, config=cfg, now_fn=now_fn,
+    )
 
 
 class TestLossCooldownTracker:
@@ -42,7 +53,10 @@ class TestLossCooldownTracker:
         assert active is False
 
     def test_threshold_engages_cooldown(self, tmp_db_path: str) -> None:
-        tracker = _make_tracker(tmp_db_path, threshold_losses=3, cooldown_minutes=30)
+        tracker = _make_tracker(
+            tmp_db_path, now_fn=lambda: _T0,
+            threshold_losses=3, cooldown_minutes=30,
+        )
         for _ in range(3):
             tracker.record_outcome("mean_reversion", -5.0)
         active, reason = tracker.is_on_cooldown("mean_reversion")
@@ -60,6 +74,25 @@ class TestLossCooldownTracker:
         assert active is False
         assert reason is None
 
+    def test_break_even_does_not_count_as_loss(self, tmp_db_path: str) -> None:
+        """``pnl == 0`` (scratch trade) should be neutral.
+
+        Treating a flat trade as a loss caused false cooldowns on
+        commission-free SPY intraday after runs of break-even fills.
+        Now neither resets nor advances the streak.
+        """
+        tracker = _make_tracker(tmp_db_path, threshold_losses=2)
+        tracker.record_outcome("mean_reversion", -5.0)
+        # Two scratch trades — should not accumulate
+        tracker.record_outcome("mean_reversion", 0.0)
+        tracker.record_outcome("mean_reversion", 0.0)
+        active, _ = tracker.is_on_cooldown("mean_reversion")
+        assert active is False
+        # One more loss → 2 total, hits threshold
+        tracker.record_outcome("mean_reversion", -3.0)
+        active, _ = tracker.is_on_cooldown("mean_reversion")
+        assert active is True
+
     def test_per_strategy_isolation(self, tmp_db_path: str) -> None:
         tracker = _make_tracker(tmp_db_path, threshold_losses=2)
         tracker.record_outcome("mean_reversion", -1.0)
@@ -68,18 +101,22 @@ class TestLossCooldownTracker:
         assert tracker.is_on_cooldown("breakout")[0] is False
 
     def test_expired_cooldown_auto_clears(self, tmp_db_path: str) -> None:
-        tracker = _make_tracker(tmp_db_path, threshold_losses=2, cooldown_minutes=60)
-        tracker.record_outcome("mean_reversion", -1.0)
-        tracker.record_outcome("mean_reversion", -1.0)
+        """Auto-clear path uses the injected clock, not wall time."""
+        # Tracker thinks "now" is one hour past the cooldown_until below.
+        future: datetime = _T0 + timedelta(hours=1)
+        tracker = _make_tracker(
+            tmp_db_path, now_fn=lambda: future,
+            threshold_losses=2, cooldown_minutes=60,
+        )
 
-        # Force the persisted cooldown_until into the past
-        past: datetime = datetime.now(tz=ET) - timedelta(minutes=5)
+        # Persist a tripped state with cooldown_until pinned to _T0
+        # (already in the past from the tracker's perspective).
         conn: sqlite3.Connection = sqlite3.connect(tmp_db_path)
         try:
             repo.save_risk_state(
                 conn, "loss_cooldown:mean_reversion",
                 tripped=True, reason="forced",
-                state={"consecutive_losses": 2, "cooldown_until": past.isoformat()},
+                state={"consecutive_losses": 2, "cooldown_until": _T0.isoformat()},
             )
         finally:
             conn.close()

--- a/trading_bot/tests/test_order_manager_lifecycle.py
+++ b/trading_bot/tests/test_order_manager_lifecycle.py
@@ -465,6 +465,91 @@ class TestCancelFlatten:
 
 
 # ---------------------------------------------------------------------------
+# Strategy-driven exits (place_exit)
+# ---------------------------------------------------------------------------
+
+
+class TestPlaceExit:
+    @pytest.mark.asyncio
+    async def test_place_exit_cancels_bracket_legs_and_submits_market_sell(
+        self, config, tmp_db_path: str, mock_notifier,
+    ):
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        # Track an in-flight position with both bracket legs known.
+        active = _ActiveOrder(
+            trade_id=1,
+            ticker="SPY",
+            exchange="US",
+            alpaca_entry_order_id="entry-1",
+            alpaca_stop_order_id="stop-1",
+            alpaca_target_order_id="target-1",
+            status=PositionStatus.STOP_AND_TARGET_ACTIVE,
+            entry_shares=10.0,
+            filled_shares=10.0,
+            entry_price=100.0,
+            stop_price=98.0,
+            target_price=104.0,
+            hold_type="intraday",
+            strategy_id="mean_reversion",
+        )
+        om._active_orders[1] = active
+
+        cancel_calls: list[str] = []
+        om._gw.client.cancel_order_by_id = MagicMock(
+            side_effect=lambda oid: cancel_calls.append(oid),
+        )
+        submit_orders: list[Any] = []
+
+        def _submit(*args, **kwargs):
+            submit_orders.append(kwargs.get("order_data"))
+            o = MagicMock()
+            o.id = "exit-1"
+            return o
+
+        om._gw.client.submit_order = MagicMock(side_effect=_submit)
+
+        order_id = await om.place_exit(
+            ticker="SPY", qty=10, reason="rsi_normalized",
+        )
+        assert order_id == "exit-1"
+        # Both bracket legs cancelled before the new market order
+        assert "stop-1" in cancel_calls
+        assert "target-1" in cancel_calls
+        # Market sell submitted
+        assert len(submit_orders) == 1
+        # New order id mapped to the original trade id
+        assert om._alpaca_to_trade.get("exit-1") == 1
+
+    @pytest.mark.asyncio
+    async def test_place_exit_returns_none_on_broker_failure(
+        self, config, tmp_db_path: str, mock_notifier,
+    ):
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        om._gw.client.submit_order = MagicMock(side_effect=RuntimeError("rejected"))
+        # No active order tracked → falls through to symbol-wide cancel.
+        om._gw.client.get_orders = MagicMock(return_value=[])
+
+        order_id = await om.place_exit(
+            ticker="SPY", qty=5, reason="trailing_stop", is_emergency=True,
+        )
+        assert order_id is None
+        # Emergency exits should fire a notification on failure
+        mock_notifier.send.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_place_exit_rejects_non_positive_qty(
+        self, config, tmp_db_path: str, mock_notifier,
+    ):
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        om._gw.client.submit_order = MagicMock()
+        order_id = await om.place_exit(
+            ticker="SPY", qty=0, reason="anything",
+        )
+        assert order_id is None
+        om._gw.client.submit_order.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # Place-entry failure path
 # ---------------------------------------------------------------------------
 

--- a/trading_bot/tests/test_state_recovery.py
+++ b/trading_bot/tests/test_state_recovery.py
@@ -205,6 +205,22 @@ class TestStateRecovery:
         gw.client.submit_order.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_emergency_stop_skipped_when_avg_cost_zero(
+        self, tmp_db_path: str, mock_notifier,
+    ) -> None:
+        """avg_cost <= 0 means we can't compute a valid stop price.
+        Recovery should log an error and skip rather than place a
+        bogus stop at price 0."""
+        pos = _alpaca_position("PLTR", qty=100, avg_entry_price=0.0)
+        gw = self._make_gateway(positions=[pos], orders=[])
+
+        recovery = _make_recovery(gw, tmp_db_path, mock_notifier)
+        await recovery.recover()
+
+        # Stop should NOT be submitted when avg_cost is 0
+        gw.client.submit_order.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_no_discrepancy_clean_state(
         self, tmp_db_path: str, mock_notifier
     ) -> None:

--- a/trading_bot/tests/test_strategy_manager.py
+++ b/trading_bot/tests/test_strategy_manager.py
@@ -139,6 +139,7 @@ def base_sentiment():
 def base_order_manager():
     om = MagicMock()
     om.place_entry = AsyncMock(return_value=42)
+    om.place_exit = AsyncMock(return_value="alpaca-exit-1")
     return om
 
 
@@ -219,7 +220,7 @@ class TestScanForEntries:
             watchlist=["SPY"],
             get_5min_bars=fake_5min,
             get_daily_bars=fake_daily,
-            account_equity_gbp=1000.0,
+            account_equity_usd=1000.0,
         )
         assert n == 0
         base_order_manager.place_entry.assert_not_called()
@@ -258,7 +259,7 @@ class TestScanForEntries:
             watchlist=["SPY"],
             get_5min_bars=fake_5min,
             get_daily_bars=fake_daily,
-            account_equity_gbp=1000.0,
+            account_equity_usd=1000.0,
         )
         assert n == 0
         base_order_manager.place_entry.assert_not_called()
@@ -298,7 +299,7 @@ class TestScanForEntries:
             watchlist=["SPY"],
             get_5min_bars=fake_5min,
             get_daily_bars=fake_daily,
-            account_equity_gbp=1000.0,
+            account_equity_usd=1000.0,
         )
         assert n == 1
         base_order_manager.place_entry.assert_called_once()
@@ -335,7 +336,7 @@ class TestScanForEntries:
             watchlist=["SPY", "QQQ"],
             get_5min_bars=fake_5min,
             get_daily_bars=fake_daily,
-            account_equity_gbp=1000.0,
+            account_equity_usd=1000.0,
         )
         assert n == 0
         assert strategy.evaluate_entry_calls == []
@@ -372,7 +373,7 @@ class TestScanForEntries:
             watchlist=["SPY", "QQQ"],
             get_5min_bars=fake_5min,
             get_daily_bars=fake_daily,
-            account_equity_gbp=1000.0,
+            account_equity_usd=1000.0,
         )
         # Only QQQ evaluated (SPY skipped as stale)
         assert [t for t, _ in strategy.evaluate_entry_calls] == ["QQQ"]
@@ -409,7 +410,7 @@ class TestScanForEntries:
             watchlist=["SPY", "QQQ"],
             get_5min_bars=fake_5min,
             get_daily_bars=fake_daily,
-            account_equity_gbp=1000.0,
+            account_equity_usd=1000.0,
         )
         assert [t for t, _ in strategy.evaluate_entry_calls] == ["QQQ"]
 
@@ -448,7 +449,7 @@ class TestScanForEntries:
             watchlist=["SPY"],
             get_5min_bars=fake_5min,
             get_daily_bars=fake_daily,
-            account_equity_gbp=1000.0,
+            account_equity_usd=1000.0,
         )
         assert n == 0
 
@@ -485,7 +486,7 @@ class TestScanForEntries:
             watchlist=["SPY"],
             get_5min_bars=fake_5min,
             get_daily_bars=fake_daily,
-            account_equity_gbp=1000.0,
+            account_equity_usd=1000.0,
         )
         assert n == 0
         base_order_manager.place_entry.assert_not_called()
@@ -522,7 +523,7 @@ class TestScanForEntries:
             watchlist=["SPY"],
             get_5min_bars=fake_5min,
             get_daily_bars=fake_daily,
-            account_equity_gbp=1000.0,
+            account_equity_usd=1000.0,
         )
         assert n == 0
         base_order_manager.place_entry.assert_not_called()
@@ -559,7 +560,7 @@ class TestScanForEntries:
             watchlist=["SPY"],
             get_5min_bars=fake_5min,
             get_daily_bars=fake_daily,
-            account_equity_gbp=1000.0,
+            account_equity_usd=1000.0,
         )
         assert n == 1
         base_order_manager.place_entry.assert_called_once()
@@ -599,7 +600,7 @@ class TestScanForEntries:
             watchlist=["SPY"],
             get_5min_bars=fake_5min,
             get_daily_bars=fake_daily,
-            account_equity_gbp=1000.0,
+            account_equity_usd=1000.0,
         )
         # The good strategy still places its entry despite bad raising.
         assert n == 1
@@ -639,7 +640,7 @@ class TestScanForEntries:
             watchlist=["SPY"],
             get_5min_bars=fetch_5min,
             get_daily_bars=fake_daily,
-            account_equity_gbp=1000.0,
+            account_equity_usd=1000.0,
         )
         # Fallback worked, entry placed
         assert n == 1
@@ -679,7 +680,7 @@ class TestScanForEntries:
             watchlist=["SPY"],
             get_5min_bars=boom,
             get_daily_bars=fake_daily,
-            account_equity_gbp=1000.0,
+            account_equity_usd=1000.0,
         )
         assert n == 0
         assert strategy.evaluate_entry_calls == []
@@ -716,7 +717,7 @@ class TestScanForEntries:
             watchlist=["SPY"],
             get_5min_bars=fake_5min,
             get_daily_bars=fake_daily,
-            account_equity_gbp=1000.0,
+            account_equity_usd=1000.0,
         )
         assert n == 1
 

--- a/trading_bot/tests/test_strategy_manager_gates.py
+++ b/trading_bot/tests/test_strategy_manager_gates.py
@@ -108,6 +108,7 @@ def risk_manager():
 def order_manager():
     om = MagicMock()
     om.place_entry = AsyncMock(return_value=42)
+    om.place_exit = AsyncMock(return_value="alpaca-exit-1")
     return om
 
 
@@ -205,7 +206,7 @@ class TestFomcGate:
         )
         n = await sm.scan_for_entries(
             watchlist=["SPY"], get_5min_bars=fake_bars,
-            get_daily_bars=fake_daily_bars, account_equity_gbp=1000.0,
+            get_daily_bars=fake_daily_bars, account_equity_usd=1000.0,
         )
         assert n == 0
         order_manager.place_entry.assert_not_called()
@@ -230,7 +231,7 @@ class TestFomcGate:
         )
         await sm.scan_for_entries(
             watchlist=["SPY"], get_5min_bars=fake_bars,
-            get_daily_bars=fake_daily_bars, account_equity_gbp=1000.0,
+            get_daily_bars=fake_daily_bars, account_equity_usd=1000.0,
         )
         order_manager.place_entry.assert_called_once()
         om_decision = order_manager.place_entry.call_args[0][0]
@@ -262,7 +263,7 @@ class TestLimitSlopClamp:
         )
         await sm.scan_for_entries(
             watchlist=["SPY"], get_5min_bars=fake_bars,
-            get_daily_bars=fake_daily_bars, account_equity_gbp=1000.0,
+            get_daily_bars=fake_daily_bars, account_equity_usd=1000.0,
         )
         om_decision = order_manager.place_entry.call_args[0][0]
         assert om_decision.limit_price == round(100.05 * 1.002, 2)
@@ -285,7 +286,7 @@ class TestLimitSlopClamp:
         )
         await sm.scan_for_entries(
             watchlist=["SPY"], get_5min_bars=fake_bars,
-            get_daily_bars=fake_daily_bars, account_equity_gbp=1000.0,
+            get_daily_bars=fake_daily_bars, account_equity_usd=1000.0,
         )
         om_decision = order_manager.place_entry.call_args[0][0]
         assert om_decision.limit_price == 100.10
@@ -313,7 +314,7 @@ class TestSymbolAllocationCap:
         )
         await sm.scan_for_entries(
             watchlist=["SPY"], get_5min_bars=fake_bars,
-            get_daily_bars=fake_daily_bars, account_equity_gbp=1000.0,
+            get_daily_bars=fake_daily_bars, account_equity_usd=1000.0,
         )
         order_manager.place_entry.assert_called_once()
         om_decision = order_manager.place_entry.call_args[0][0]
@@ -349,7 +350,7 @@ class TestSymbolAllocationCap:
         )
         await sm.scan_for_entries(
             watchlist=["SPY"], get_5min_bars=fake_bars,
-            get_daily_bars=fake_daily_bars, account_equity_gbp=1000.0,
+            get_daily_bars=fake_daily_bars, account_equity_usd=1000.0,
         )
         order_manager.place_entry.assert_not_called()
 
@@ -368,7 +369,7 @@ class TestSymbolAllocationCap:
         )
         await sm.scan_for_entries(
             watchlist=["SPY"], get_5min_bars=fake_bars,
-            get_daily_bars=fake_daily_bars, account_equity_gbp=1000.0,
+            get_daily_bars=fake_daily_bars, account_equity_usd=1000.0,
         )
         om_decision = order_manager.place_entry.call_args[0][0]
         assert om_decision.shares == 5
@@ -404,7 +405,7 @@ class TestLossCooldownGate:
         )
         n = await sm.scan_for_entries(
             watchlist=["SPY"], get_5min_bars=fake_bars,
-            get_daily_bars=fake_daily_bars, account_equity_gbp=1000.0,
+            get_daily_bars=fake_daily_bars, account_equity_usd=1000.0,
         )
         assert n == 0
         order_manager.place_entry.assert_not_called()
@@ -446,3 +447,203 @@ class TestLossCooldownGate:
         await sm.check_exits()
         # Second consecutive loss → cooldown engaged
         assert tracker.is_on_cooldown("stub")[0] is True
+
+
+# ---------------------------------------------------------------------------
+# check_exits broker-order safety
+# ---------------------------------------------------------------------------
+
+
+class TestCheckExitsBrokerSafety:
+    """Regressions for the bug where check_exits recorded virtual exits
+    without ever sending a broker order — silently diverging the virtual
+    portfolio from real Alpaca state on every exit signal."""
+
+    @pytest.mark.asyncio
+    async def test_check_exits_calls_broker_before_recording_virtual_exit(
+        self, market_data, risk_manager, order_manager, sentiment, earnings,
+        portfolio_manager, tmp_db_path,
+    ):
+        cfg = _config()
+        portfolio = portfolio_manager._portfolio
+        portfolio.get_open_positions = MagicMock(return_value=[
+            {"ticker": "SPY", "entry_price": 100.0, "quantity": 3},
+        ])
+        market_data.get_latest_price = MagicMock(return_value=95.0)
+
+        strategy = _StubStrategy("stub", None)
+        strategy.evaluate_exit = lambda *a, **kw: ExitSignal(
+            should_exit=True, reason="stop_loss", is_emergency=True,
+        )
+
+        sm = StrategyManager(
+            strategies=[strategy],
+            portfolio_manager=portfolio_manager,
+            market_data=market_data, order_manager=order_manager,
+            risk_manager=risk_manager, sentiment=sentiment,
+            earnings=earnings, config=cfg, db_path=tmp_db_path,
+        )
+        n = await sm.check_exits()
+
+        assert n == 1
+        # Broker order MUST have been submitted
+        order_manager.place_exit.assert_called_once()
+        kwargs = order_manager.place_exit.call_args.kwargs
+        assert kwargs["ticker"] == "SPY"
+        assert kwargs["qty"] == 3
+        assert kwargs["reason"] == "stop_loss"
+        assert kwargs["is_emergency"] is True
+        # Virtual exit only after broker confirmation
+        portfolio.record_exit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_check_exits_skips_virtual_exit_when_broker_rejects(
+        self, market_data, risk_manager, order_manager, sentiment, earnings,
+        portfolio_manager, tmp_db_path,
+    ):
+        # Broker rejection → leave virtual portfolio untouched so we
+        # re-attempt next tick (rather than diverging from real state).
+        order_manager.place_exit = AsyncMock(return_value=None)
+
+        cfg = _config()
+        portfolio = portfolio_manager._portfolio
+        portfolio.get_open_positions = MagicMock(return_value=[
+            {"ticker": "SPY", "entry_price": 100.0, "quantity": 3},
+        ])
+        market_data.get_latest_price = MagicMock(return_value=95.0)
+
+        strategy = _StubStrategy("stub", None)
+        strategy.evaluate_exit = lambda *a, **kw: ExitSignal(
+            should_exit=True, reason="stop_loss",
+        )
+
+        tracker = LossCooldownTracker(
+            db_path=tmp_db_path,
+            config=LossCooldownConfig(enabled=True, threshold_losses=2),
+        )
+
+        sm = StrategyManager(
+            strategies=[strategy],
+            portfolio_manager=portfolio_manager,
+            market_data=market_data, order_manager=order_manager,
+            risk_manager=risk_manager, sentiment=sentiment,
+            earnings=earnings, config=cfg, db_path=tmp_db_path,
+            loss_cooldown=tracker,
+        )
+        n = await sm.check_exits()
+
+        assert n == 0
+        portfolio.record_exit.assert_not_called()
+        # No fake loss recorded against the cooldown tracker either
+        assert tracker.is_on_cooldown("stub")[0] is False
+
+    @pytest.mark.asyncio
+    async def test_check_exits_skips_stale_ticker(
+        self, market_data, risk_manager, order_manager, sentiment, earnings,
+        portfolio_manager, tmp_db_path,
+    ):
+        cfg = _config()
+        # Stale-data gate should preempt the exit signal entirely so we
+        # never send a phantom market sell driven by a stale price.
+        market_data.is_stale = MagicMock(return_value=True)
+        portfolio = portfolio_manager._portfolio
+        portfolio.get_open_positions = MagicMock(return_value=[
+            {"ticker": "SPY", "entry_price": 100.0, "quantity": 3},
+        ])
+
+        strategy = _StubStrategy("stub", None)
+        strategy.evaluate_exit = lambda *a, **kw: ExitSignal(
+            should_exit=True, reason="stop_loss",
+        )
+
+        sm = StrategyManager(
+            strategies=[strategy],
+            portfolio_manager=portfolio_manager,
+            market_data=market_data, order_manager=order_manager,
+            risk_manager=risk_manager, sentiment=sentiment,
+            earnings=earnings, config=cfg, db_path=tmp_db_path,
+        )
+        n = await sm.check_exits()
+        assert n == 0
+        order_manager.place_exit.assert_not_called()
+        portfolio.record_exit.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Decision immutability
+# ---------------------------------------------------------------------------
+
+
+class TestDecisionImmutability:
+    """The FOMC scaler and symbol-cap helpers must return new
+    StrategyDecision objects rather than mutating the caller's."""
+
+    def test_scale_decision_shares_does_not_mutate_input(self):
+        original = _decision(shares=10, entry=100.0)
+        scaled = StrategyManager._scale_decision_shares(original, 0.5)
+        assert scaled is not None
+        assert scaled.shares == 5
+        # Original must remain untouched
+        assert original.shares == 10
+
+    def test_scale_decision_preserves_int_intent(self):
+        original = _decision(shares=10, entry=100.0)
+        scaled = StrategyManager._scale_decision_shares(original, 0.33)
+        assert scaled is not None
+        assert isinstance(scaled.shares, int)
+        assert scaled.shares == 3  # int(10 * 0.33)
+
+    def test_scale_decision_preserves_fractional_intent(self):
+        original = _decision(shares=10.0, entry=100.0)
+        scaled = StrategyManager._scale_decision_shares(original, 0.5)
+        assert scaled is not None
+        assert isinstance(scaled.shares, float)
+        assert scaled.shares == 5.0
+
+    def test_scale_decision_below_min_returns_none(self):
+        original = _decision(shares=1, entry=100.0)
+        scaled = StrategyManager._scale_decision_shares(original, 0.5)
+        # 1 * 0.5 = 0.5 → int(0.5) = 0 → below int min of 1
+        assert scaled is None
+        # Original still untouched
+        assert original.shares == 1
+
+    @pytest.mark.asyncio
+    async def test_pipeline_does_not_mutate_strategy_decision(
+        self, market_data, risk_manager, order_manager, sentiment, earnings,
+        portfolio_manager, fake_bars, fake_daily_bars, tmp_db_path, monkeypatch,
+    ):
+        """End-to-end: FOMC scale × symbol cap composition leaves the
+        original decision the strategy returned untouched."""
+        # FOMC half-size, symbol cap 30% of $1000 = $300 → max 3 shares.
+        from trading_bot.strategy import strategy_manager as sm_mod
+        monkeypatch.setattr(
+            sm_mod, "fomc_size_multiplier", lambda _t, _r: 0.5,
+        )
+        cfg = _config(cap_pct=0.30)
+
+        held: list[StrategyDecision] = []
+
+        class _CapturingStrategy(_StubStrategy):
+            def evaluate_entry(self, *a, **kw):
+                d = super().evaluate_entry(*a, **kw)
+                if d is not None:
+                    held.append(d)
+                return d
+
+        strat = _CapturingStrategy("stub", _decision(shares=10, entry=100.0))
+        sm = StrategyManager(
+            strategies=[strat],
+            portfolio_manager=portfolio_manager,
+            market_data=market_data, order_manager=order_manager,
+            risk_manager=risk_manager, sentiment=sentiment,
+            earnings=earnings, config=cfg, db_path=tmp_db_path,
+        )
+        await sm.scan_for_entries(
+            watchlist=["SPY"], get_5min_bars=fake_bars,
+            get_daily_bars=fake_daily_bars, account_equity_usd=1000.0,
+        )
+
+        assert len(held) == 1
+        # Strategy's original decision is preserved.
+        assert held[0].shares == 10


### PR DESCRIPTION
## Summary

Closes the four CRITICAL defects flagged by `/python-review` on PRs #8-#12, plus HIGH/MEDIUM follow-ups. All money-touching paths now have broker-order ordering, immutable decision transformations, and proper async I/O.

## CRITICAL

- **`check_exits` now sends the broker order before the virtual exit** ([trading_bot/strategy/strategy_manager.py](trading_bot/strategy/strategy_manager.py)). Previously, an exit signal recorded a virtual exit and tripped the loss-cooldown without ever sending an Alpaca order — guaranteed virtual/real divergence on every exit. New `OrderManager.place_exit` cancels bracket legs first, submits a market sell, and returns the order id (or `None` on failure → virtual portfolio left untouched so we re-attempt next tick).
- **`StrategyDecision` is now immutable in transformations.** `_scale_decision_shares` and `_enforce_symbol_cap` return new instances via `dataclasses.replace` instead of mutating shared state under `# type: ignore`. `signals` got a `default_factory=dict`.
- **Recovery's sync broker calls now run via `asyncio.to_thread`** (`_place_emergency_stop`, EOD flatten, stale-order cancel) so they don't block the event loop.
- **`day_start_equity` initialized before the SPY-intraday loop** in [multi_strategy_backtest.py](trading_bot/multi_strategy_backtest.py) (resolves ruff F821).

## HIGH

- `VirtualPortfolio.record_entry`/`record_exit` accept `float` shares so fractional-share strategies don't silently truncate.
- `StrategyManager.scan_for_entries` renames `account_equity_gbp` → `account_equity_usd` (Alpaca settles in USD; the GBP name was a pre-existing IBKR-era misnomer baked into a new public API). The DB-schema-level rename in `daily_summaries` and HTML templates is left for a separate refactor.
- `_close_db_position` uses an explicit `with conn:` transaction so atomic intent (UPDATE + INSERT) is self-documenting.
- `Config.raw_section()` is a new public, type-safe accessor for the raw config tree; the FOMC gate no longer reaches into `Config._raw`.

## MEDIUM

- `check_exits` gates on `market_data.is_stale(ticker)` before any exit work — a stale price can't fire a phantom market sell.
- `LossCooldownTracker` treats `pnl == 0` as neutral (was: break-even counted as a loss → false cooldowns on commission-free SPY). Adds an injectable `now_fn` for deterministic cooldown-window tests.
- `BootstrapCI.as_dict` return type widened to `dict[str, Any]` to silence mypy false positive.
- Drop unused `TZ_EASTERN` import from `scripts/smoke_recovery.py`.

## Tests

- **New** `TestCheckExitsBrokerSafety` (3 cases): place_exit called with correct args before virtual exit; broker rejection rolls back virtual exit and skips cooldown record; stale ticker preempts everything.
- **New** `TestDecisionImmutability` (5 cases): helpers don't mutate inputs; int vs fractional intent preserved; below-min returns None; full FOMC × symbol-cap pipeline preserves the strategy's original decision.
- **New** `TestPlaceExit` (3 cases): bracket-leg cancellation, broker-failure return value with notification on emergency, qty<=0 guard.
- **New** `test_emergency_stop_skipped_when_avg_cost_zero` in state-recovery.
- **New** `test_break_even_does_not_count_as_loss` in loss-cooldown.
- Updated `test_expired_cooldown_auto_clears` to use the injected clock for full determinism.

## Test plan

- [x] `pytest trading_bot/tests/` → **581 passed, 2 skipped**
- [x] SPY 2017-Q1 mean_reversion backtest runs end-to-end
- [x] SPY 2018 full-year backtest still produces **+2.63%** on `mean_reversion` (no regression)
- [x] `ruff check` clean on every file touched (the one F841 remaining was pre-existing in an unrelated block)
- [ ] Smoke-run on paper account before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)