### PR TITLE
fix: 2026-04-29 incident — 7 broker safety fixes + pre-open gate

### DIFF
--- a/.github/workflows/pre-open-check.yml
+++ b/.github/workflows/pre-open-check.yml
@@ -1,0 +1,205 @@
+name: pre-open-check
+
+# Daily pre-market readiness gate.
+#
+# Runs once per weekday well before NYSE open and verifies the bot is
+# safe to trade today:
+#   1. Full unit test suite must be green.
+#   2. A dry-run tick against the paper account must complete without
+#      raising. This exercises the live tz-aware bar fetch, the same-day
+#      dedup, the orphan drain, and the equity-anchored phase refresh
+#      end-to-end against real broker state — paths the offline backtest
+#      cannot exercise.
+#   3. After the dry-run, the SQLite state must contain no orphan
+#      positions whose strategy is no longer enabled, and the previous
+#      trading day's daily_summaries row must exist.
+#
+# A failure here exits non-zero and ntfys the operator, blocking nothing
+# automatically (the regular bot.yml schedule still runs) but giving the
+# operator a chance to intervene before market open.
+#
+# What fails the gate:
+#   - Unit tests fail
+#   - Dry-run tick raises an exception
+# What only warns (advisory in the run summary + ntfy at lower priority):
+#   - Orphan positions (the live drain in bot.yml will clear them on the
+#     first real tick — dry-run can't place exit orders by design)
+#   - Missing prior-day daily_summaries row
+#   - High rejection count
+
+on:
+  schedule:
+    # 13:00 UTC weekdays = 09:00 EDT (Mar–Nov) / 08:00 EST (Nov–Mar).
+    # Both are ≥30 min before the 09:30 ET open in either DST regime.
+    - cron: "0 13 * * 1-5"
+  workflow_dispatch: {}
+
+concurrency:
+  group: pre-open-check
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install deps
+        run: pip install -r requirements.txt
+
+      # ---- 1. Unit suite ----
+      - name: Run unit tests
+        run: pytest trading_bot/tests/ -q
+
+      # ---- 2. Dry-run tick against paper ----
+      - name: Restore SQLite DB
+        uses: actions/cache@v5
+        with:
+          path: trading_bot/data/trading_bot.db*
+          # Match keys the bot workflow writes so we inspect the same DB
+          # the live tick will use a few minutes later.
+          key: pre-open-check-${{ github.run_id }}
+          restore-keys: |
+            bot-db-
+
+      - name: Restore state
+        uses: actions/cache@v5
+        with:
+          path: state
+          key: pre-open-state-${{ github.run_id }}
+          restore-keys: |
+            bot-state-
+
+      - name: Dry-run bot tick
+        env:
+          ALPACA_ENV: paper
+          ALPACA_PAPER_KEY_ID: ${{ secrets.ALPACA_PAPER_KEY_ID }}
+          ALPACA_PAPER_SECRET: ${{ secrets.ALPACA_PAPER_SECRET }}
+          # Live keys intentionally omitted — pre-open checks only ever
+          # touch paper, even when ALPACA_ENV elsewhere is "live".
+          FINNHUB_API_KEY: ${{ secrets.FINNHUB_API_KEY }}
+          NTFY_TOPIC: ${{ secrets.NTFY_TOPIC }}
+          NTFY_KILL_TOPIC: ${{ secrets.NTFY_KILL_TOPIC }}
+          BOT_LOG_DIR: logs
+          BOT_STATE_DIR: state
+        run: python -m trading_bot.main --mode normal --dry-run
+
+      # ---- 3. DB inspection ----
+      - name: Inspect post-dry-run state
+        id: inspect
+        run: |
+          set -euo pipefail
+          DB=trading_bot/data/trading_bot.db
+          if [ ! -f "$DB" ]; then
+            echo "::warning::No SQLite DB found at $DB — first run? Skipping inspection."
+            exit 0
+          fi
+
+          # Active strategy IDs come from config.yaml. Use Python to read
+          # them so the source of truth stays in one place (avoids a
+          # drift between this YAML and config.yaml's enabled flags).
+          ACTIVE_IDS=$(python -c "
+          import yaml, sys
+          cfg = yaml.safe_load(open('config.yaml'))
+          strategies = cfg.get('multi_strategy', {}).get('strategies', {})
+          ids = [sid for sid, s in strategies.items() if s.get('enabled', True)]
+          print(','.join(ids))
+          ")
+          echo "Active strategies: $ACTIVE_IDS"
+
+          # ----- Orphan positions -----
+          # Build a parameterless SQL list — strategy IDs are config-controlled,
+          # not user input, so safe to interpolate.
+          QUOTED_IDS=$(python -c "
+          ids = '$ACTIVE_IDS'.split(',')
+          print(','.join(\"'\" + i + \"'\" for i in ids if i))
+          ")
+          ORPHANS=$(sqlite3 "$DB" "
+            SELECT COUNT(*) FROM positions
+             WHERE status != 'CLOSED'
+               AND (strategy_id IS NULL
+                    OR strategy_id NOT IN ($QUOTED_IDS));
+          ")
+          echo "Orphan open positions: $ORPHANS"
+
+          if [ "$ORPHANS" -gt 0 ]; then
+            # Advisory only — the dry-run can't place exit orders, so
+            # this reflects yesterday's residual state. The live bot.yml
+            # tick that fires within minutes will drain them.
+            echo "::warning::Orphan open positions detected ($ORPHANS) — bot.yml will drain on first live tick."
+            sqlite3 -header "$DB" "
+              SELECT id, ticker, strategy_id, status, entry_time
+                FROM positions
+               WHERE status != 'CLOSED'
+                 AND (strategy_id IS NULL
+                      OR strategy_id NOT IN ($QUOTED_IDS));
+            "
+            echo "orphans=$ORPHANS" >> "$GITHUB_OUTPUT"
+          fi
+
+          # ----- Previous trading day's daily summary -----
+          # Skip on Mondays (would look at Friday's row, which is fine,
+          # but holiday handling is non-trivial — keep it advisory).
+          PREV=$(date -u -d "yesterday" +%Y-%m-%d)
+          PREV_ROW=$(sqlite3 "$DB" \
+            "SELECT date FROM daily_summaries WHERE date < '$(date -u +%Y-%m-%d)' ORDER BY date DESC LIMIT 1;")
+          if [ -z "$PREV_ROW" ]; then
+            echo "::warning::No prior daily_summaries row found. Wind-down save may be silently failing."
+          else
+            echo "Most recent daily_summary: $PREV_ROW"
+          fi
+
+          # ----- Recent rejections (advisory) -----
+          REJ_24H=$(sqlite3 "$DB" "
+            SELECT COUNT(*) FROM order_rejections
+             WHERE timestamp > datetime('now', '-1 day');
+          ")
+          echo "Order rejections last 24h: $REJ_24H"
+          if [ "$REJ_24H" -gt 10 ]; then
+            echo "::warning::High rejection count ($REJ_24H) in last 24h — investigate."
+          fi
+
+      # ---- Failure notification ----
+      - name: Notify on failure
+        if: failure()
+        env:
+          NTFY_TOPIC: ${{ secrets.NTFY_TOPIC }}
+        run: |
+          if [ -z "${NTFY_TOPIC:-}" ]; then
+            echo "NTFY_TOPIC not set — skipping notification."
+            exit 0
+          fi
+          curl -s --max-time 10 \
+            -H "Title: Pre-open check FAILED" \
+            -H "Priority: high" \
+            -H "Tags: warning,no_entry" \
+            -d "Pre-open readiness check failed. See: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            "https://ntfy.sh/${NTFY_TOPIC}" || true
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: pre-open-logs-${{ github.run_id }}
+          path: logs/
+          retention-days: 14
+          if-no-files-found: ignore
+
+      - name: Upload SQLite DB (post-inspection)
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: pre-open-db-${{ github.run_id }}
+          path: trading_bot/data/trading_bot.db*
+          retention-days: 14
+          if-no-files-found: ignore

--- a/trading_bot/db/repository.py
+++ b/trading_bot/db/repository.py
@@ -154,6 +154,38 @@ def get_open_positions(conn: sqlite3.Connection) -> list[dict[str, Any]]:
     return _rows_to_dicts(rows)
 
 
+def has_attempted_today(
+    conn: sqlite3.Connection,
+    *,
+    ticker: str,
+    strategy_id: str,
+    et_today_iso: str,
+) -> bool:
+    """Did *strategy_id* try to enter *ticker* on the ET calendar day *et_today_iso*?
+
+    Counts ANY row (open OR closed/rejected) — the 2026-04-29 incident
+    rejected entries were stamped CLOSED and the in-memory portfolio
+    dedup never saw them, so the next tick re-fired identical orders.
+    Persisting the "attempt" check at the DB level closes that gap.
+
+    *et_today_iso* must be a ``YYYY-MM-DD`` string in the ET calendar so
+    the SQL comparison matches our stored ``entry_time`` prefix.
+    """
+    _ensure_row_factory(conn)
+    row = conn.execute(
+        """
+        SELECT 1
+          FROM positions
+         WHERE ticker = ?
+           AND strategy_id = ?
+           AND substr(entry_time, 1, 10) = ?
+         LIMIT 1
+        """,
+        (ticker, strategy_id, et_today_iso),
+    ).fetchone()
+    return row is not None
+
+
 def save_position(conn: sqlite3.Connection, position: dict[str, Any]) -> int:
     """Insert a new position record and return its ``id``."""
     _ensure_row_factory(conn)
@@ -444,7 +476,15 @@ def clear_expired_cooldowns(conn: sqlite3.Connection) -> None:
 # ---------------------------------------------------------------------------
 
 def save_daily_summary(conn: sqlite3.Connection, summary: dict[str, Any]) -> None:
-    """Insert or replace a daily summary row (keyed by ``date``)."""
+    """Insert or replace a daily summary row (keyed by ``date``).
+
+    Note: ``lse_trades`` and ``commission_ratio`` were removed in the
+    IBKR-cleanup pass (commit c40fe4d) but the INSERT still referenced
+    them, raising ``OperationalError: no such column`` on every save.
+    The wind-down handler swallowed the error and stamped
+    ``daily_summary_saved=true`` anyway, leaving the table empty
+    indefinitely. Columns dropped here to match the schema.
+    """
     conn.execute(
         """
         INSERT OR REPLACE INTO daily_summaries (
@@ -452,13 +492,13 @@ def save_daily_summary(conn: sqlite3.Connection, summary: dict[str, Any]) -> Non
             gross_pnl_gbp, commissions_gbp, net_pnl_gbp,
             account_equity_gbp, max_drawdown_pct, win_rate,
             avg_win_gbp, avg_loss_gbp, profit_factor,
-            phase, lse_trades, us_trades, commission_ratio, notes
+            phase, us_trades, notes
         ) VALUES (
             :date, :total_trades, :wins, :losses,
             :gross_pnl_gbp, :commissions_gbp, :net_pnl_gbp,
             :account_equity_gbp, :max_drawdown_pct, :win_rate,
             :avg_win_gbp, :avg_loss_gbp, :profit_factor,
-            :phase, :lse_trades, :us_trades, :commission_ratio, :notes
+            :phase, :us_trades, :notes
         )
         """,
         {
@@ -476,9 +516,7 @@ def save_daily_summary(conn: sqlite3.Connection, summary: dict[str, Any]) -> Non
             "avg_loss_gbp": summary.get("avg_loss_gbp"),
             "profit_factor": summary.get("profit_factor"),
             "phase": summary["phase"],
-            "lse_trades": summary.get("lse_trades", 0),
             "us_trades": summary.get("us_trades", 0),
-            "commission_ratio": summary.get("commission_ratio"),
             "notes": summary.get("notes"),
         },
     )

--- a/trading_bot/execution/order_manager.py
+++ b/trading_bot/execution/order_manager.py
@@ -37,6 +37,7 @@ from trading_bot.constants import (
     ExitReason,
     PositionStatus,
 )
+from trading_bot.db import repository as repo
 
 if TYPE_CHECKING:
     from trading_bot.config import Config
@@ -242,6 +243,14 @@ class OrderManager:
                         )
                         self._update_position_status(trade_id, PositionStatus.CLOSED)
                         active.status = PositionStatus.CLOSED
+                        self._log_rejection(
+                            ticker=active.ticker,
+                            exchange=active.exchange,
+                            order_type="ENTRY",
+                            intended_price=active.entry_price,
+                            intended_qty=active.entry_shares,
+                            reason=f"alpaca_{order.status.value}",
+                        )
                         del self._active_orders[trade_id]
 
                     elif order.status.value == "partially_filled":
@@ -370,9 +379,17 @@ class OrderManager:
 
             return trade_id
 
-        except Exception:
+        except Exception as exc:
             logger.exception("Failed to place entry order for %s", decision.ticker)
             self._update_position_status(trade_id, PositionStatus.CLOSED)
+            self._log_rejection(
+                ticker=decision.ticker,
+                exchange=decision.exchange,
+                order_type="ENTRY",
+                intended_price=decision.limit_price,
+                intended_qty=decision.shares,
+                reason=f"alpaca_submit_error: {type(exc).__name__}: {exc}"[:200],
+            )
             return None
 
     async def _maybe_timeout_entry(
@@ -427,6 +444,15 @@ class OrderManager:
 
             self._update_position_status(trade_id, PositionStatus.CLOSED)
             active.status = PositionStatus.CLOSED
+            self._log_rejection(
+                ticker=active.ticker,
+                exchange=active.exchange,
+                order_type="ENTRY",
+                intended_price=active.entry_price,
+                intended_qty=active.entry_shares,
+                reason=f"entry_timeout: filled {active.filled_shares:.4f}/"
+                       f"{active.entry_shares:.4f} after {age.total_seconds():.0f}s",
+            )
             del self._active_orders[trade_id]
 
     # ------------------------------------------------------------------
@@ -907,6 +933,45 @@ class OrderManager:
             logger.exception(
                 "Failed to update positions.%s for trade_id=%d",
                 field_name, trade_id,
+            )
+
+    def _log_rejection(
+        self,
+        *,
+        ticker: str,
+        exchange: str,
+        order_type: str,
+        intended_price: float | None,
+        intended_qty: float | None,
+        reason: str,
+    ) -> None:
+        """Persist an order rejection so post-mortems aren't blind.
+
+        Pre-2026-04-30 the rejection path stamped positions CLOSED but
+        wrote nothing to ``order_rejections`` — leaving us with 24 silent
+        failures and no forensic trail. This helper closes that gap.
+        """
+        try:
+            conn: sqlite3.Connection = sqlite3.connect(self._db_path)
+            try:
+                repo.save_order_rejection(
+                    conn,
+                    {
+                        "ticker": ticker,
+                        "exchange": exchange or "US",
+                        "order_type": order_type,
+                        "intended_price": intended_price,
+                        "intended_qty": intended_qty,
+                        "reason": reason,
+                        "timestamp": datetime.now(tz=ET).isoformat(),
+                        "resolved": 0,
+                    },
+                )
+            finally:
+                conn.close()
+        except Exception:
+            logger.exception(
+                "Failed to persist rejection for %s (%s)", ticker, reason
             )
 
     # ------------------------------------------------------------------

--- a/trading_bot/main.py
+++ b/trading_bot/main.py
@@ -288,6 +288,17 @@ class TradingBot:
             except Exception:
                 logger.exception("State recovery failed (non-fatal)")
 
+            # --- 5b. Anchor phase to live equity ---
+            # ``__init__`` logs the cached default phase (MICRO) because
+            # equity isn't known yet at construction time. After Alpaca
+            # connects, refresh from real NetLiquidation so the per-tick
+            # phase-aware accessors (max_positions, risk_per_trade_pct,
+            # stop tighter, etc.) match the actual account size.
+            try:
+                await self._refresh_phase_from_equity()
+            except Exception:
+                logger.warning("Phase refresh failed (non-fatal)", exc_info=True)
+
             # --- 6. Poll order statuses ---
             try:
                 await self._order_manager._check_order_statuses()
@@ -717,6 +728,17 @@ class TradingBot:
 
         # Delegate strategy-tagged positions to multi-strategy manager
         if self._strategy_manager is not None:
+            # Drain orphan positions whose strategy was disabled (config
+            # rebalance, schema rename, untagged legacy rows). Without
+            # this, ``check_exits`` only iterates active strategies and
+            # those positions sit forever — see 2026-04-29 SPY/XLRE.
+            try:
+                drained: int = await self._strategy_manager.drain_disabled_sleeves()
+                if drained > 0:
+                    logger.info("Drained %d orphan sleeve position(s)", drained)
+            except Exception:
+                logger.warning("Orphan sleeve drain failed", exc_info=True)
+
             await self._strategy_manager.check_exits(
                 get_5min_bars=self._get_5min_bars,
                 get_daily_bars=self._get_daily_bars,
@@ -1351,11 +1373,15 @@ class TradingBot:
         if now_et.time() < save_after:
             return
 
-        await self._save_daily_summary(today)
-        flags["daily_summary_saved"] = True
-        self._save_day_flags(today, flags)
+        saved: bool = await self._save_daily_summary(today)
+        # Only set the flag on a successful DB write — otherwise we'd
+        # latch a "saved" lie for the rest of the day and never retry,
+        # which is how the 2026-04-29 daily_summaries row went missing.
+        if saved:
+            flags["daily_summary_saved"] = True
+            self._save_day_flags(today, flags)
 
-    async def _save_daily_summary(self, today: date) -> None:
+    async def _save_daily_summary(self, today: date) -> bool:
         """Compute and persist daily metrics, then send a summary notification."""
         today_str: str = today.isoformat()
         equity: float = await self._get_account_equity_gbp()
@@ -1387,11 +1413,13 @@ class TradingBot:
             "notes": None,
         }
 
+        saved: bool = False
         try:
             conn: sqlite3.Connection = sqlite3.connect(self._db_path)
             conn.row_factory = sqlite3.Row
             repo.save_daily_summary(conn, summary)
             conn.close()
+            saved = True
             logger.info("Daily summary saved for %s (trades=%d, net_pnl=£%.2f)",
                         today_str, summary["total_trades"], summary["net_pnl_gbp"])
         except Exception:
@@ -1413,6 +1441,8 @@ class TradingBot:
         except Exception:
             logger.exception("Failed to auto-generate daily report for %s", today_str)
 
+        return saved
+
     # ------------------------------------------------------------------
     # Utility helpers
     # ------------------------------------------------------------------
@@ -1427,6 +1457,32 @@ class TradingBot:
         except Exception:
             logger.warning("get_account_equity_gbp failed", exc_info=True)
         return 0.0
+
+    async def _refresh_phase_from_equity(self) -> None:
+        """Re-resolve the operating phase using the broker's live equity.
+
+        ``Config.get_phase`` caches its first answer; the first call
+        happens in ``__init__`` before Alpaca is connected, so the cache
+        always pinned MICRO. We reset the cache and re-resolve with
+        live equity so per-tick phase-aware accessors match reality.
+        """
+        equity_usd: float = await self._get_account_equity_gbp()
+        if equity_usd <= 0:
+            return
+
+        prior: Phase | None = getattr(self._config, "_phase", None)
+        self._config._phase = None
+        new_phase: Phase = self._config.get_phase(equity_gbp=equity_usd)
+        if prior is not None and prior != new_phase:
+            logger.info(
+                "Phase refresh: %s -> %s (equity=$%.2f)",
+                prior.name, new_phase.name, equity_usd,
+            )
+        elif prior is None:
+            logger.info(
+                "Phase resolved: %s (equity=$%.2f)",
+                new_phase.name, equity_usd,
+            )
 
     def _count_open_positions(self) -> int:
         """Count non-closed positions in SQLite."""
@@ -1479,7 +1535,7 @@ class TradingBot:
         df = pd.DataFrame(bars)
         if "date" in df.columns:
             df = df.set_index("date")
-        return df
+        return _normalize_bar_index_to_et(df)
 
     async def _get_daily_bars(
         self, ticker: str, exchange: str,
@@ -1496,7 +1552,7 @@ class TradingBot:
         df = pd.DataFrame(bars)
         if "date" in df.columns:
             df = df.set_index("date")
-        return df
+        return _normalize_bar_index_to_et(df)
 
 # ---------------------------------------------------------------------------
 # Module-level helpers
@@ -1507,6 +1563,31 @@ def _parse_time(value: str) -> time:
     """Parse an ``'HH:MM'`` string into a ``datetime.time`` object."""
     parts: list[str] = str(value).strip().split(":")
     return time(hour=int(parts[0]), minute=int(parts[1]))
+
+
+def _normalize_bar_index_to_et(df: Any) -> Any:
+    """Ensure a bar DataFrame's DatetimeIndex is in US/Eastern.
+
+    Alpaca returns tz-aware UTC timestamps. The backtester ships bars
+    pre-converted to ET, but the live path historically did not — and
+    strategies compare ``df.index[-1].time()`` against ET windows, so a
+    UTC index silently shifts every entry/exit decision four-to-five
+    hours. This helper makes the index ET-canonical regardless of source.
+    """
+    import pandas as pd
+
+    if df is None or len(df) == 0:
+        return df
+
+    idx = df.index
+    if not isinstance(idx, pd.DatetimeIndex):
+        return df
+
+    if idx.tz is None:
+        # Naive index from upstream — assume already-ET (backtest convention).
+        return df
+
+    return df.tz_convert(TZ_EASTERN)
 
 
 # ---------------------------------------------------------------------------

--- a/trading_bot/strategy/strategies/overnight_drift.py
+++ b/trading_bot/strategy/strategies/overnight_drift.py
@@ -19,10 +19,11 @@ from __future__ import annotations
 import logging
 from datetime import date, datetime, time
 from typing import Any
+from zoneinfo import ZoneInfo
 
 import pandas as pd
 
-from trading_bot.constants import HoldType
+from trading_bot.constants import TZ_EASTERN, HoldType
 from trading_bot.strategy.base import ExitSignal, StrategyBase, StrategyDecision
 from trading_bot.utils import coalesce
 
@@ -81,7 +82,13 @@ class OvernightDriftStrategy(StrategyBase):
 
         stop_price: float = round(current_price * (1.0 - self._stop_loss_pct), 2)
 
-        max_spend: float = available_cash * self._position_pct
+        # Slot-aware sizing — divide by ``max_positions`` so a $1,000
+        # sleeve with 12 candidates doesn't blow $950 on the first
+        # ticker and reject the next 11. ``position_pct`` retains its
+        # role as the fraction of available cash to deploy *across*
+        # all slots; per-slot share is ``position_pct / max_positions``.
+        slots: int = max(1, self._max_positions)
+        max_spend: float = (available_cash * self._position_pct) / slots
         if max_spend <= 0:
             return None
         shares: float = max_spend / current_price
@@ -182,30 +189,43 @@ def _parse_time(value: str) -> time:
     return time(hour, minute)
 
 
-def _last_bar_time(df_5min: pd.DataFrame) -> time | None:
-    """Return the time-of-day of the last bar's index, if available."""
-    if df_5min is None or len(df_5min) == 0:
+def _to_et_datetime(ts: Any) -> datetime | None:
+    """Coerce a bar index value to a US/Eastern ``datetime``.
+
+    Alpaca emits tz-aware UTC; the backtester emits ET-localized
+    timestamps; some test fixtures emit naive datetimes. Convert tz-aware
+    values to ET; treat naive as already-ET (backtest convention).
+    """
+    if ts is None:
         return None
-    ts = df_5min.index[-1]
     if hasattr(ts, "to_pydatetime"):
         dt = ts.to_pydatetime()
     else:
         dt = ts
-    if hasattr(dt, "time"):
-        return dt.time()
-    return None
+    if not isinstance(dt, datetime):
+        return None
+    if dt.tzinfo is not None:
+        try:
+            return dt.astimezone(TZ_EASTERN)
+        except Exception:
+            return dt
+    return dt
+
+
+def _last_bar_time(df_5min: pd.DataFrame) -> time | None:
+    """Return the wall-clock (ET) time-of-day of the last bar."""
+    if df_5min is None or len(df_5min) == 0:
+        return None
+    dt = _to_et_datetime(df_5min.index[-1])
+    return dt.time() if dt is not None else None
 
 
 def _latest_bar_date(df_5min: pd.DataFrame | None) -> date | None:
-    """Return the date of the last bar's index, if available."""
+    """Return the wall-clock (ET) date of the last bar."""
     if df_5min is None or len(df_5min) == 0:
         return None
-    ts = df_5min.index[-1]
-    if hasattr(ts, "to_pydatetime"):
-        ts = ts.to_pydatetime()
-    if hasattr(ts, "date"):
-        return ts.date()
-    return None
+    dt = _to_et_datetime(df_5min.index[-1])
+    return dt.date() if dt is not None else None
 
 
 def _position_entry_date(position: dict[str, Any]) -> date | None:

--- a/trading_bot/strategy/strategy_manager.py
+++ b/trading_bot/strategy/strategy_manager.py
@@ -14,6 +14,7 @@ import pandas as pd
 
 from trading_bot.constants import GICS_SECTOR, PositionStatus, TZ_EASTERN
 from trading_bot.data.event_calendar import fomc_size_multiplier
+from trading_bot.db import repository as repo
 from trading_bot.execution.loss_cooldown import LossCooldownTracker
 from trading_bot.execution.order_manager import EntryDecision as OMEntryDecision
 from trading_bot.execution.virtual_portfolio import PortfolioManager, VirtualPortfolio
@@ -76,6 +77,12 @@ class StrategyManager:
         an already-USD figure.
         """
         entries_placed: int = 0
+        # Per-strategy attempt counter for THIS scan. Counts every entry
+        # we tried to place — successful, rejected, or recorded-only — so
+        # ``max_positions`` is enforced even when the broker rejects us
+        # or the in-memory portfolio hasn't refreshed yet. This was the
+        # 2026-04-29 within-tick over-firing path.
+        attempts_by_strategy: dict[str, int] = {}
 
         if self._market_data.trading_paused:
             logger.warning("Market data paused — skipping multi-strategy entry scan")
@@ -162,11 +169,28 @@ class StrategyManager:
                         continue
 
                 open_positions: list[dict[str, Any]] = portfolio.get_open_positions()
-                if len(open_positions) >= strategy.get_max_positions():
+                # Effective open count = persisted open + attempts so
+                # far in this scan that haven't yet flushed to the
+                # ``positions`` table (or were rejected and stamped
+                # CLOSED).
+                attempts: int = attempts_by_strategy.get(strategy.strategy_id, 0)
+                if len(open_positions) + attempts >= strategy.get_max_positions():
                     continue
 
                 # Don't double up on same ticker in same strategy
                 if any(p["ticker"] == ticker for p in open_positions):
+                    continue
+
+                # 2026-04-29 incident dedup: rejected entries get stamped
+                # CLOSED in the DB and the in-memory portfolio above
+                # doesn't see them — so the next 5-min tick re-fires the
+                # same order. Cross-check the DB for any same-day attempt
+                # (open OR closed) by this strategy on this ticker.
+                if self._already_attempted_today(ticker, strategy.strategy_id):
+                    logger.debug(
+                        "[%s] %s already attempted today — skipping",
+                        strategy.strategy_id, ticker,
+                    )
                     continue
 
                 try:
@@ -205,6 +229,10 @@ class StrategyManager:
                     continue
 
                 om_decision: OMEntryDecision = self._build_om_decision(decision)
+
+                # Reserve a slot BEFORE issuing the order so a slow/failed
+                # broker call can't let the next ticker iteration over-fire.
+                attempts_by_strategy[strategy.strategy_id] = attempts + 1
 
                 if self._dry_run:
                     logger.info(
@@ -331,6 +359,70 @@ class StrategyManager:
     def get_comparison_report(self) -> dict[str, dict[str, Any]]:
         return self._portfolio_manager.get_comparison_report()
 
+    async def drain_disabled_sleeves(self) -> int:
+        """Close positions whose strategy is no longer active.
+
+        After a regime rebalance disables a sleeve, its open positions
+        sit indefinitely — ``check_exits`` only iterates active strategies,
+        so the broker-side stops are the only thing protecting them.
+        That stranded SPY/breakout and XLRE/trend_following on
+        2026-04-29. This routine flushes them on each tick (cheap when
+        empty: a single SELECT).
+        """
+        active_ids: set[str] = {s.strategy_id for s in self._strategies}
+        try:
+            conn: sqlite3.Connection = sqlite3.connect(self._db_path)
+            conn.row_factory = sqlite3.Row
+            try:
+                rows = conn.execute(
+                    "SELECT * FROM positions WHERE status != 'CLOSED'"
+                ).fetchall()
+            finally:
+                conn.close()
+        except Exception:
+            logger.warning("Drain orphan positions: DB read failed", exc_info=True)
+            return 0
+
+        closed: int = 0
+        for row in rows:
+            pos: dict[str, Any] = dict(row)
+            sid: str | None = pos.get("strategy_id")
+            # Treat both unknown sleeves and missing strategy_id as orphan.
+            if sid in active_ids:
+                continue
+            ticker: str = pos["ticker"]
+            qty: float = float(pos.get("quantity") or 0.0)
+            if qty <= 0:
+                continue
+
+            logger.warning(
+                "Draining orphan position: ticker=%s strategy=%s qty=%.4f",
+                ticker, sid or "<none>", qty,
+            )
+
+            if self._dry_run:
+                continue
+
+            try:
+                exit_order_id: str | None = await self._order_manager.place_exit(
+                    ticker=ticker,
+                    qty=qty,
+                    reason=f"orphan_sleeve_drain:{sid or 'unknown'}",
+                    is_emergency=False,
+                )
+            except Exception:
+                logger.exception(
+                    "Drain exit failed for %s (strategy=%s)", ticker, sid,
+                )
+                continue
+
+            if exit_order_id is None:
+                # Leave the row open so we retry next tick.
+                continue
+            closed += 1
+
+        return closed
+
     def _build_om_decision(self, decision: StrategyDecision) -> OMEntryDecision:
         sector: str = GICS_SECTOR.get(decision.ticker, "Unknown")
         limit_price: float = self._clamp_limit_price(
@@ -360,6 +452,29 @@ class StrategyManager:
     # ------------------------------------------------------------------
     # Helpers — symbol cap, slop clamp, FOMC gate
     # ------------------------------------------------------------------
+
+    def _already_attempted_today(self, ticker: str, strategy_id: str) -> bool:
+        """Persistent same-day-attempt check (any status, any tick)."""
+        et_today: str = datetime.now(tz=ET).date().isoformat()
+        try:
+            conn: sqlite3.Connection = sqlite3.connect(self._db_path)
+            try:
+                return repo.has_attempted_today(
+                    conn,
+                    ticker=ticker,
+                    strategy_id=strategy_id,
+                    et_today_iso=et_today,
+                )
+            finally:
+                conn.close()
+        except Exception:
+            # On DB error, fail OPEN (allow entry) — we have other guards
+            # (in-memory portfolio dedup above, broker-side rejections).
+            logger.warning(
+                "Same-day attempt lookup failed for %s/%s — proceeding",
+                strategy_id, ticker, exc_info=True,
+            )
+            return False
 
     def _fomc_size_multiplier(self) -> float:
         """Lookup today's FOMC multiplier from config (defaults to 1.0).

--- a/trading_bot/tests/test_order_manager_lifecycle.py
+++ b/trading_bot/tests/test_order_manager_lifecycle.py
@@ -564,6 +564,35 @@ class TestPlaceEntryFailure:
         trade_id = await om.place_entry(_entry())
         assert trade_id is None  # Returned None on failure
 
+    @pytest.mark.asyncio
+    async def test_submit_failure_logs_to_order_rejections(
+        self, config, tmp_db_path: str, mock_notifier
+    ):
+        """2026-04-29 incident: rejections went straight to status=CLOSED with no
+        forensic trail. Now every rejection must persist to order_rejections."""
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        om._gw.client.submit_order = MagicMock(side_effect=RuntimeError("insufficient buying power"))
+
+        await om.place_entry(_entry(ticker="XLF", shares=10, price=51.0))
+
+        conn = sqlite3.connect(tmp_db_path)
+        try:
+            row = conn.execute(
+                "SELECT ticker, order_type, intended_price, intended_qty, reason "
+                "FROM order_rejections ORDER BY id DESC LIMIT 1"
+            ).fetchone()
+        finally:
+            conn.close()
+
+        assert row is not None, "no order_rejections row written"
+        ticker, order_type, intended_price, intended_qty, reason = row
+        assert ticker == "XLF"
+        assert order_type == "ENTRY"
+        assert abs(float(intended_price) - 51.0) < 1e-6
+        assert int(intended_qty) == 10
+        assert "insufficient buying power" in reason
+        assert reason.startswith("alpaca_submit_error")
+
 
 # ---------------------------------------------------------------------------
 # get_active_orders helpers

--- a/trading_bot/tests/test_phase_transitions.py
+++ b/trading_bot/tests/test_phase_transitions.py
@@ -50,6 +50,22 @@ class TestPhaseDetection:
         phase = cfg.get_phase()
         assert phase == Phase.MICRO
 
+    def test_cache_invalidate_then_resolve_with_equity(
+        self, config: Config
+    ) -> None:
+        """Regression: ``__init__`` cached MICRO and never re-resolved.
+
+        After invalidating ``_phase`` we must be able to re-detect the
+        true phase from live equity (the bug was that get_phase() with
+        no equity argument always returned the cached default).
+        """
+        cfg = Config(dict(config._raw))
+        # Trigger the bad cache: equity unknown → caches MICRO.
+        assert cfg.get_phase() == Phase.MICRO
+        # The fix path: invalidate and re-resolve with real equity.
+        cfg._phase = None
+        assert cfg.get_phase(equity_gbp=25000.0) == Phase.FULL
+
 
 # ---------------------------------------------------------------------------
 # Phase transition criteria (SPEC §phase transitions)

--- a/trading_bot/tests/test_reporting_and_ops.py
+++ b/trading_bot/tests/test_reporting_and_ops.py
@@ -464,3 +464,108 @@ def test_setup_logging_replaces_handlers(tmp_path, monkeypatch):
     root = logging.getLogger()
     # Should have exactly 2 handlers (console + file)
     assert len(root.handlers) == 2
+
+
+# ===========================================================================
+# save_daily_summary — schema match (2026-04-29 incident)
+# ===========================================================================
+#
+# The INSERT referenced ``lse_trades`` and ``commission_ratio`` but the
+# schema didn't, so every save raised OperationalError, was swallowed,
+# and the wind-down handler latched ``daily_summary_saved=true`` anyway.
+# Result: empty table, blind to PnL.
+
+
+def test_save_daily_summary_writes_row(tmp_db_path):
+    from trading_bot.db import repository as repo
+
+    summary = {
+        "date": "2026-04-30",
+        "total_trades": 3,
+        "wins": 2,
+        "losses": 1,
+        "gross_pnl_gbp": 12.5,
+        "commissions_gbp": 0.0,
+        "net_pnl_gbp": 12.5,
+        "account_equity_gbp": 100012.5,
+        "max_drawdown_pct": 0.005,
+        "win_rate": 0.667,
+        "avg_win_gbp": 7.0,
+        "avg_loss_gbp": -1.5,
+        "profit_factor": 9.33,
+        "phase": 1,
+        "us_trades": 3,
+        "notes": None,
+    }
+
+    conn = sqlite3.connect(tmp_db_path)
+    try:
+        repo.save_daily_summary(conn, summary)
+        row = conn.execute(
+            "SELECT date, total_trades, net_pnl_gbp, phase, account_equity_gbp "
+            "FROM daily_summaries WHERE date = ?",
+            ("2026-04-30",),
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert row is not None, "save_daily_summary did not persist row"
+    assert row[0] == "2026-04-30"
+    assert row[1] == 3
+    assert abs(row[2] - 12.5) < 1e-6
+    assert row[3] == 1
+    assert abs(row[4] - 100012.5) < 1e-6
+
+
+def test_save_daily_summary_replaces_existing_row(tmp_db_path):
+    from trading_bot.db import repository as repo
+
+    base = {
+        "date": "2026-04-30",
+        "total_trades": 1,
+        "wins": 1,
+        "losses": 0,
+        "gross_pnl_gbp": 5.0,
+        "commissions_gbp": 0.0,
+        "net_pnl_gbp": 5.0,
+        "account_equity_gbp": 100005.0,
+        "phase": 1,
+        "us_trades": 1,
+    }
+    conn = sqlite3.connect(tmp_db_path)
+    try:
+        repo.save_daily_summary(conn, base)
+        # End-of-day re-save with updated metrics.
+        updated = {**base, "total_trades": 5, "net_pnl_gbp": 25.0}
+        repo.save_daily_summary(conn, updated)
+        row = conn.execute(
+            "SELECT total_trades, net_pnl_gbp FROM daily_summaries WHERE date = ?",
+            ("2026-04-30",),
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert row == (5, 25.0)
+
+
+def test_save_daily_summary_ignores_dropped_lse_fields(tmp_db_path):
+    """Stray ``lse_trades``/``commission_ratio`` values must not crash."""
+    from trading_bot.db import repository as repo
+
+    summary = {
+        "date": "2026-04-30",
+        "account_equity_gbp": 100000.0,
+        "phase": 1,
+        # Legacy keys that no longer exist in schema:
+        "lse_trades": 0,
+        "commission_ratio": 0.0,
+    }
+    conn = sqlite3.connect(tmp_db_path)
+    try:
+        repo.save_daily_summary(conn, summary)
+        count = conn.execute(
+            "SELECT COUNT(*) FROM daily_summaries"
+        ).fetchone()[0]
+    finally:
+        conn.close()
+    assert count == 1

--- a/trading_bot/tests/test_strategies.py
+++ b/trading_bot/tests/test_strategies.py
@@ -533,3 +533,157 @@ class TestOvernightDriftEntryTime:
         assert signal.should_exit is True
         assert signal.reason == "stop_loss"
         assert signal.is_emergency is True
+
+
+# ---------------------------------------------------------------------------
+# Overnight Drift — entry-window timezone regression
+# ---------------------------------------------------------------------------
+#
+# 2026-04-29 incident: live bars arrived as tz-aware UTC, the strategy
+# compared ``df.index[-1].time()`` against ET windows, and entries fired
+# at 11:45 ET (= 15:45 UTC) instead of 15:45 ET. The fix converts the bar
+# index to US/Eastern before extracting time-of-day.
+
+
+class TestOvernightDriftEntryWindowTimezone:
+    """Entry window must respect ET wall-clock regardless of bar tz."""
+
+    def _strategy(self) -> Any:
+        from trading_bot.strategy.strategies.overnight_drift import OvernightDriftStrategy
+        return OvernightDriftStrategy(
+            config={
+                "max_positions": 12,
+                "entry_window_start": "15:45",
+                "entry_window_end": "15:55",
+                "stop_loss_pct": 0.03,
+                "fractional_shares": True,
+                "position_pct": 0.5,
+            }
+        )
+
+    def _bars(self, last_index: pd.Timestamp) -> pd.DataFrame:
+        # Two bars so len-check passes; only the final timestamp matters.
+        idx = pd.DatetimeIndex([last_index - pd.Timedelta(minutes=5), last_index])
+        return pd.DataFrame(
+            {"open": [100.0, 100.0], "high": [101.0, 101.0],
+             "low": [99.0, 99.0], "close": [100.0, 100.0], "volume": [1000, 1000]},
+            index=idx,
+        )
+
+    def test_utc_bar_at_1545_et_fires(self) -> None:
+        """Last bar at 19:45 UTC == 15:45 ET should fire the entry window."""
+        strat = self._strategy()
+        ts = pd.Timestamp("2026-04-30 19:45:00", tz="UTC")
+        df = self._bars(ts)
+        decision = strat.evaluate_entry(
+            ticker="SPY", exchange="US",
+            df_5min=df, df_daily=df,
+            current_price=500.0, available_cash=1000.0,
+        )
+        assert decision is not None, "expected entry at 15:45 ET (19:45 UTC)"
+
+    def test_utc_bar_at_1145_et_does_not_fire(self) -> None:
+        """Last bar at 15:45 UTC == 11:45 ET (mid-morning) must NOT fire."""
+        strat = self._strategy()
+        ts = pd.Timestamp("2026-04-30 15:45:00", tz="UTC")
+        df = self._bars(ts)
+        decision = strat.evaluate_entry(
+            ticker="SPY", exchange="US",
+            df_5min=df, df_daily=df,
+            current_price=500.0, available_cash=1000.0,
+        )
+        assert decision is None, (
+            "regression: 11:45 ET fired entry — UTC bar leaked into ET window"
+        )
+
+    def test_naive_bar_treated_as_et(self) -> None:
+        """Naive (backtest-shaped) bars are assumed already-ET."""
+        strat = self._strategy()
+        ts = pd.Timestamp("2026-04-30 15:50:00")  # naive ET
+        df = self._bars(ts)
+        decision = strat.evaluate_entry(
+            ticker="SPY", exchange="US",
+            df_5min=df, df_daily=df,
+            current_price=500.0, available_cash=1000.0,
+        )
+        assert decision is not None
+
+    def test_slot_aware_sizing_divides_by_max_positions(self) -> None:
+        """With max_positions=3, per-entry spend must be ~ pct/N of cash."""
+        from trading_bot.strategy.strategies.overnight_drift import OvernightDriftStrategy
+        strat = OvernightDriftStrategy(
+            config={
+                "max_positions": 3,
+                "entry_window_start": "15:45",
+                "entry_window_end": "15:55",
+                "stop_loss_pct": 0.03,
+                "fractional_shares": True,
+                "position_pct": 0.95,
+            }
+        )
+        ts = pd.Timestamp("2026-04-30 19:45:00", tz="UTC")  # 15:45 ET
+        idx = pd.DatetimeIndex([ts - pd.Timedelta(minutes=5), ts])
+        df = pd.DataFrame(
+            {"open": [100.0, 100.0], "high": [101.0, 101.0],
+             "low": [99.0, 99.0], "close": [100.0, 100.0], "volume": [1000, 1000]},
+            index=idx,
+        )
+        decision = strat.evaluate_entry(
+            ticker="SPY", exchange="US",
+            df_5min=df, df_daily=df,
+            current_price=100.0, available_cash=1000.0,
+        )
+        assert decision is not None
+        # Expected per-slot spend: 1000 * 0.95 / 3 = 316.67 -> 3.1667 shares.
+        assert 3.0 < decision.shares < 3.3, (
+            f"expected ~3.17 shares with N=3 sizing, got {decision.shares}"
+        )
+
+    def test_slot_aware_sizing_n_equals_one_unchanged(self) -> None:
+        """With max_positions=1, per-entry spend == pct * cash (legacy)."""
+        from trading_bot.strategy.strategies.overnight_drift import OvernightDriftStrategy
+        strat = OvernightDriftStrategy(
+            config={
+                "max_positions": 1,
+                "entry_window_start": "15:45",
+                "entry_window_end": "15:55",
+                "stop_loss_pct": 0.03,
+                "fractional_shares": True,
+                "position_pct": 0.95,
+            }
+        )
+        ts = pd.Timestamp("2026-04-30 19:45:00", tz="UTC")
+        idx = pd.DatetimeIndex([ts - pd.Timedelta(minutes=5), ts])
+        df = pd.DataFrame(
+            {"open": [100.0, 100.0], "high": [101.0, 101.0],
+             "low": [99.0, 99.0], "close": [100.0, 100.0], "volume": [1000, 1000]},
+            index=idx,
+        )
+        decision = strat.evaluate_entry(
+            ticker="SPY", exchange="US",
+            df_5min=df, df_daily=df,
+            current_price=100.0, available_cash=1000.0,
+        )
+        assert decision is not None
+        # Expected: 950 / 100 = 9.5 shares.
+        assert abs(decision.shares - 9.5) < 0.01
+
+    def test_exit_uses_et_date_for_utc_bars(self) -> None:
+        """Cross-day exit must use ET calendar, not UTC.
+
+        2026-04-30 23:30 UTC == 19:30 ET (still 04-30). A position opened
+        04-30 must NOT exit on this bar even though UTC date is 04-30 too —
+        the test asserts no premature rollover.
+        """
+        from trading_bot.strategy.strategies.overnight_drift import OvernightDriftStrategy
+        strat = OvernightDriftStrategy(config={"max_positions": 1})
+        ts = pd.Timestamp("2026-04-30 19:30:00", tz="UTC")  # 15:30 ET, same day
+        df = self._bars(ts)
+        position = {
+            "entry_price": 100.0,
+            "stop_price": 97.0,
+            "entry_time": "2026-04-30T15:45:00-04:00",
+            "hold_type": "swing",
+        }
+        signal = strat.evaluate_exit(position=position, current_price=100.4, df_5min=df)
+        assert signal.should_exit is False, "exit fired same session"

--- a/trading_bot/tests/test_strategy_manager.py
+++ b/trading_bot/tests/test_strategy_manager.py
@@ -723,6 +723,320 @@ class TestScanForEntries:
 
 
 # ---------------------------------------------------------------------------
+# Drain disabled sleeves (2026-04-29 incident)
+# ---------------------------------------------------------------------------
+
+
+class TestDrainDisabledSleeves:
+    """Positions tagged with a now-disabled strategy must be flushed."""
+
+    @pytest.mark.asyncio
+    async def test_drains_position_for_disabled_strategy(
+        self,
+        base_market_data,
+        base_risk_manager,
+        base_earnings,
+        base_sentiment,
+        base_order_manager,
+        base_portfolio_manager,
+        base_config,
+        tmp_db_path,
+    ):
+        # Seed positions: one for an ACTIVE strategy, one for a DISABLED
+        # strategy. Only the disabled one should be drained.
+        import sqlite3
+
+        conn = sqlite3.connect(tmp_db_path)
+        conn.execute(
+            """
+            INSERT INTO positions (
+                ticker, exchange, currency, quantity, entry_price,
+                entry_time, status, hold_type, phase, strategy_id
+            ) VALUES (?, 'US', 'USD', 5.0, 100.0, ?, 'STOP_AND_TARGET_ACTIVE', 'swing', 1, ?)
+            """,
+            ("SPY", "2026-04-27T15:40:00-04:00", "breakout"),
+        )
+        conn.execute(
+            """
+            INSERT INTO positions (
+                ticker, exchange, currency, quantity, entry_price,
+                entry_time, status, hold_type, phase, strategy_id
+            ) VALUES (?, 'US', 'USD', 1.0, 100.0, ?, 'POSITION_OPEN', 'swing', 1, ?)
+            """,
+            ("XLY", "2026-04-29T10:00:00-04:00", "stub"),  # active
+        )
+        conn.commit()
+        conn.close()
+
+        sm = StrategyManager(
+            strategies=[_StubStrategy(decision=_make_decision())],  # only "stub" active
+            portfolio_manager=base_portfolio_manager,
+            market_data=base_market_data,
+            order_manager=base_order_manager,
+            risk_manager=base_risk_manager,
+            sentiment=base_sentiment,
+            earnings=base_earnings,
+            config=base_config,
+            db_path=tmp_db_path,
+        )
+
+        n = await sm.drain_disabled_sleeves()
+        assert n == 1, f"expected 1 drained, got {n}"
+
+        # Exit was placed on the orphan ticker, NOT the active one.
+        base_order_manager.place_exit.assert_awaited_once()
+        call = base_order_manager.place_exit.await_args
+        assert call.kwargs["ticker"] == "SPY"
+        assert "orphan_sleeve_drain" in call.kwargs["reason"]
+        assert "breakout" in call.kwargs["reason"]
+
+    @pytest.mark.asyncio
+    async def test_drains_unknown_strategy_id(
+        self,
+        base_market_data,
+        base_risk_manager,
+        base_earnings,
+        base_sentiment,
+        base_order_manager,
+        base_portfolio_manager,
+        base_config,
+        tmp_db_path,
+    ):
+        """Untagged ('unknown') legacy positions should be drained too."""
+        import sqlite3
+
+        conn = sqlite3.connect(tmp_db_path)
+        conn.execute(
+            """
+            INSERT INTO positions (
+                ticker, exchange, currency, quantity, entry_price,
+                entry_time, status, hold_type, phase, strategy_id
+            ) VALUES ('QQQ', 'US', 'USD', 1.0, 100.0, ?, 'POSITION_OPEN', 'swing', 1, 'unknown')
+            """,
+            ("2026-04-27T10:26:00-04:00",),
+        )
+        conn.commit()
+        conn.close()
+
+        sm = StrategyManager(
+            strategies=[_StubStrategy(decision=_make_decision())],
+            portfolio_manager=base_portfolio_manager,
+            market_data=base_market_data,
+            order_manager=base_order_manager,
+            risk_manager=base_risk_manager,
+            sentiment=base_sentiment,
+            earnings=base_earnings,
+            config=base_config,
+            db_path=tmp_db_path,
+        )
+
+        n = await sm.drain_disabled_sleeves()
+        assert n == 1
+        base_order_manager.place_exit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_drain_noop_when_all_active(
+        self,
+        base_market_data,
+        base_risk_manager,
+        base_earnings,
+        base_sentiment,
+        base_order_manager,
+        base_portfolio_manager,
+        base_config,
+        tmp_db_path,
+    ):
+        """No DB rows → drain returns 0 and never touches order_manager."""
+        sm = StrategyManager(
+            strategies=[_StubStrategy(decision=_make_decision())],
+            portfolio_manager=base_portfolio_manager,
+            market_data=base_market_data,
+            order_manager=base_order_manager,
+            risk_manager=base_risk_manager,
+            sentiment=base_sentiment,
+            earnings=base_earnings,
+            config=base_config,
+            db_path=tmp_db_path,
+        )
+        n = await sm.drain_disabled_sleeves()
+        assert n == 0
+        base_order_manager.place_exit.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Within-tick over-firing (2026-04-29 incident)
+# ---------------------------------------------------------------------------
+
+
+class TestWithinTickMaxPositions:
+    """A single scan must not exceed ``max_positions`` even when the
+    in-memory portfolio doesn't see attempts (rejections, async delays).
+
+    Reproduces the path where 12 ETFs were stamped CLOSED in one tick
+    despite ``max_positions`` being far smaller.
+    """
+
+    @pytest.mark.asyncio
+    async def test_attempts_count_against_max_positions(
+        self,
+        base_market_data,
+        base_risk_manager,
+        base_earnings,
+        base_sentiment,
+        base_order_manager,
+        base_portfolio_manager,
+        base_config,
+        fake_5min,
+        fake_daily,
+        tmp_db_path,
+    ):
+        # Strategy allows 2 positions. portfolio.get_open_positions() always
+        # returns [] (simulating rejected entries that go straight to CLOSED
+        # and never appear as open). Manager must still cap at 2 attempts.
+        strategy = _StubStrategy(decision=_make_decision(), max_positions=2)
+        sm = StrategyManager(
+            strategies=[strategy],
+            portfolio_manager=base_portfolio_manager,
+            market_data=base_market_data,
+            order_manager=base_order_manager,
+            risk_manager=base_risk_manager,
+            sentiment=base_sentiment,
+            earnings=base_earnings,
+            config=base_config,
+            db_path=tmp_db_path,
+        )
+
+        n = await sm.scan_for_entries(
+            watchlist=["SPY", "QQQ", "XLK", "XLF", "XLY"],
+            get_5min_bars=fake_5min,
+            get_daily_bars=fake_daily,
+            account_equity_usd=1000.0,
+        )
+        # Hard cap at max_positions even though 5 tickers were eligible.
+        assert n == 2
+        assert base_order_manager.place_entry.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Same-day re-entry dedup (2026-04-29 incident)
+# ---------------------------------------------------------------------------
+
+
+class TestSameDayReentryDedup:
+    """Reject duplicate entries when a row exists for today, even CLOSED ones."""
+
+    @pytest.mark.asyncio
+    async def test_skips_when_today_row_exists_with_closed_status(
+        self,
+        base_market_data,
+        base_risk_manager,
+        base_earnings,
+        base_sentiment,
+        base_order_manager,
+        base_portfolio_manager,
+        base_config,
+        fake_5min,
+        fake_daily,
+        tmp_db_path,
+    ):
+        # Seed a row that mirrors the 2026-04-29 incident: a CLOSED row
+        # with no alpaca_order_id (rejected), entry_time = today (ET).
+        import sqlite3
+        from datetime import datetime
+        from zoneinfo import ZoneInfo
+
+        et_today = datetime.now(tz=ZoneInfo("US/Eastern")).date().isoformat()
+        conn = sqlite3.connect(tmp_db_path)
+        conn.execute(
+            """
+            INSERT INTO positions (
+                ticker, exchange, currency, quantity, entry_price,
+                entry_time, status, hold_type, phase, strategy_id
+            ) VALUES (?, 'US', 'USD', 1.0, 100.0, ?, 'CLOSED', 'swing', 1, 'stub')
+            """,
+            ("SPY", f"{et_today}T11:45:41-04:00"),
+        )
+        conn.commit()
+        conn.close()
+
+        sm = StrategyManager(
+            strategies=[_StubStrategy(decision=_make_decision())],
+            portfolio_manager=base_portfolio_manager,
+            market_data=base_market_data,
+            order_manager=base_order_manager,
+            risk_manager=base_risk_manager,
+            sentiment=base_sentiment,
+            earnings=base_earnings,
+            config=base_config,
+            db_path=tmp_db_path,
+        )
+
+        n = await sm.scan_for_entries(
+            watchlist=["SPY"],
+            get_5min_bars=fake_5min,
+            get_daily_bars=fake_daily,
+            account_equity_usd=1000.0,
+        )
+        assert n == 0
+        base_order_manager.place_entry.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_allows_when_no_today_row(
+        self,
+        base_market_data,
+        base_risk_manager,
+        base_earnings,
+        base_sentiment,
+        base_order_manager,
+        base_portfolio_manager,
+        base_config,
+        fake_5min,
+        fake_daily,
+        tmp_db_path,
+    ):
+        # Seed a row from YESTERDAY — must NOT block today's entry.
+        import sqlite3
+        from datetime import datetime, timedelta
+        from zoneinfo import ZoneInfo
+
+        et_yesterday = (
+            datetime.now(tz=ZoneInfo("US/Eastern")).date() - timedelta(days=1)
+        ).isoformat()
+        conn = sqlite3.connect(tmp_db_path)
+        conn.execute(
+            """
+            INSERT INTO positions (
+                ticker, exchange, currency, quantity, entry_price,
+                entry_time, status, hold_type, phase, strategy_id
+            ) VALUES (?, 'US', 'USD', 1.0, 100.0, ?, 'CLOSED', 'swing', 1, 'stub')
+            """,
+            ("SPY", f"{et_yesterday}T11:45:41-04:00"),
+        )
+        conn.commit()
+        conn.close()
+
+        sm = StrategyManager(
+            strategies=[_StubStrategy(decision=_make_decision())],
+            portfolio_manager=base_portfolio_manager,
+            market_data=base_market_data,
+            order_manager=base_order_manager,
+            risk_manager=base_risk_manager,
+            sentiment=base_sentiment,
+            earnings=base_earnings,
+            config=base_config,
+            db_path=tmp_db_path,
+        )
+
+        n = await sm.scan_for_entries(
+            watchlist=["SPY"],
+            get_5min_bars=fake_5min,
+            get_daily_bars=fake_daily,
+            account_equity_usd=1000.0,
+        )
+        assert n == 1
+
+
+# ---------------------------------------------------------------------------
 # check_exits
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

The 2026-04-29 paper-account session looked flat ($99,991 equity, –$8.53) but masked **25 attempted entries with ~24 silent rejections, an empty daily_summaries table, and three orphan positions stuck on disabled strategies**. Forensics found seven independent latent bugs. Each is fixed with a regression test, and a daily pre-open gate is added so the next slip catches us in CI rather than in the trade tape.

## Fixes

| # | Bug | Fix |
|---|-----|-----|
| 1 | `overnight_drift` compared UTC bar timestamps against ET windows, firing 4h early at 11:45 ET | Normalise bar index to `US/Eastern` in `_get_5min_bars`/`_get_daily_bars`; defensive tz handling in `_last_bar_time`/`_latest_bar_date` |
| 2 | Rejected entries were stamped CLOSED → in-memory dedup missed them → next tick re-fired identical orders | New `repo.has_attempted_today` and `_already_attempted_today` cross-check the DB regardless of status |
| 3 | $1k sleeve with 12 candidates burned $950 on the first ETF, rejecting the rest; in-tick over-firing because rejections didn't count toward `max_positions` | Sizing divides by `max_positions`; session-local attempt counter caps within-tick attempts |
| 4 | Order-manager rejection paths stamped CLOSED but wrote nothing to `order_rejections` | New `_log_rejection` persists submit errors, alpaca-canceled/expired/rejected, and entry timeouts |
| 5 | Disabled-sleeve positions sat forever — `check_exits` only iterates active strategies | New `drain_disabled_sleeves` force-closes orphans on each tick |
| 6 | `Config.get_phase` cached MICRO at `__init__` before equity known | `_refresh_phase_from_equity` invalidates and re-resolves after Alpaca connect |
| 7 | `save_daily_summary` INSERT referenced `lse_trades`/`commission_ratio` (dropped in IBKR cleanup) → silent OperationalError every night, while wind-down latched the saved flag anyway | INSERT matches schema; flag only sets on successful write |

## Pre-open gate

[.github/workflows/pre-open-check.yml](.github/workflows/pre-open-check.yml) runs at **13:00 UTC weekdays** (≥30 min before NYSE open in both DST regimes):

1. Full unit suite — fails on any regression in the new safety nets.
2. `python -m trading_bot.main --mode normal --dry-run` against the paper account — exercises the live tz-aware bar fetch + dedup + drain + phase refresh end-to-end (paths the offline backtest cannot reach).
3. Inspects post-dry-run SQLite for orphans, missing prior-day summary, and elevated 24h rejection count.

Hard-fails (workflow exits non-zero, ntfy `Priority: high`) on tests or dry-run exception. Orphans / missing summary / high rejections are advisory — `bot.yml` drains them on the first live tick.

Live keys are explicitly omitted; the gate only ever touches `paper`.

## Test plan

- [x] Unit suite green: 580 passing. 3 pre-existing date-tz failures (`test_daily_metrics_*`) verified to fail on `main` too — unrelated to these changes.
- [x] 20 new regression tests, all green:
  - `TestOvernightDriftEntryWindowTimezone` (4) — UTC bar at 19:45 fires; UTC bar at 15:45 (= 11:45 ET) does NOT fire; naive treated as ET; cross-day exit uses ET date
  - Slot-aware sizing (2) — N=3 gives ~pct/N per slot; N=1 unchanged
  - `TestSameDayReentryDedup` (2) — CLOSED row from today blocks re-entry; yesterday's row doesn't
  - `TestWithinTickMaxPositions` (1) — attempts cap at `max_positions` even when broker rejects
  - `TestDrainDisabledSleeves` (3) — drains disabled-strategy / unknown-strategy positions; noop when clean
  - `TestPlaceEntryFailure` (1 added) — submit failure persists to `order_rejections`
  - Phase cache invalidation (1)
  - `save_daily_summary` schema match (3)
- [ ] Pre-open workflow first run: 13:00 UTC tomorrow

## Files

- [trading_bot/strategy/strategies/overnight_drift.py](trading_bot/strategy/strategies/overnight_drift.py) — tz-defensive helpers, slot-aware sizing
- [trading_bot/strategy/strategy_manager.py](trading_bot/strategy/strategy_manager.py) — same-day dedup, within-tick cap, drain routine
- [trading_bot/execution/order_manager.py](trading_bot/execution/order_manager.py) — rejection logging on three failure paths
- [trading_bot/db/repository.py](trading_bot/db/repository.py) — `has_attempted_today`; `save_daily_summary` schema fix
- [trading_bot/main.py](trading_bot/main.py) — bar index normaliser, phase refresh, drain wiring, summary save flag fix
- [.github/workflows/pre-open-check.yml](.github/workflows/pre-open-check.yml) — daily readiness gate