### PR TITLE
feat: daily self-improvement research agent + Alpaca backfill

### DIFF
--- a/.github/workflows/daily-review.yml
+++ b/.github/workflows/daily-review.yml
@@ -1,0 +1,126 @@
+name: daily-review
+
+# Self-improvement research agent. Runs after market close on weekdays,
+# pulls the day's trades from the cached SQLite, computes a postmortem,
+# proposes config tweaks (rule-based, deterministic), validates them on
+# a recent backtest window, and opens a draft PR with a markdown report.
+#
+# The agent never edits config.yaml. The PR only adds a file under
+# self_improve_reports/. Humans review and apply patches by hand.
+
+on:
+  # NOTE: scheduled cron deliberately disabled until the data layer is
+  # fixed. The agent's postmortem reads from the `trades` table, but the
+  # live bot is not currently persisting closed trades correctly (see
+  # docs/self_improve_followups.md tasks #2 and #3). Running on cron
+  # would just open empty draft PRs every weekday. Re-enable the schedule
+  # below once those tasks are resolved and a real trade history exists.
+  workflow_dispatch: {}
+  # schedule:
+  #   - cron: "30 21 * * 1-5"
+
+concurrency:
+  group: daily-review
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install deps
+        run: pip install -r requirements.txt
+
+      - name: Restore SQLite DB
+        # Same key prefix bot.yml writes to — we read the latest cached DB
+        # so the postmortem sees today's trades.
+        uses: actions/cache@v5
+        with:
+          path: trading_bot/data/trading_bot.db*
+          key: daily-review-db-${{ github.run_id }}
+          restore-keys: |
+            bot-db-
+
+      - name: Compute date window
+        id: dates
+        run: |
+          # Backtest window: last 60 calendar days ending yesterday.
+          # Postmortem window: last 20 days inside the agent.
+          BT_TO=$(date -u -d "yesterday" +%Y-%m-%d)
+          BT_FROM=$(date -u -d "61 days ago" +%Y-%m-%d)
+          REPORT_DATE=$(date -u +%Y-%m-%d)
+          BRANCH="daily-review/${REPORT_DATE}"
+          echo "bt_from=${BT_FROM}" >> "$GITHUB_OUTPUT"
+          echo "bt_to=${BT_TO}" >> "$GITHUB_OUTPUT"
+          echo "report_date=${REPORT_DATE}" >> "$GITHUB_OUTPUT"
+          echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
+
+      - name: Run self-improvement agent
+        env:
+          ALPACA_ENV: ${{ vars.ALPACA_ENV || 'paper' }}
+          ALPACA_PAPER_KEY_ID: ${{ secrets.ALPACA_PAPER_KEY_ID }}
+          ALPACA_PAPER_SECRET: ${{ secrets.ALPACA_PAPER_SECRET }}
+          ALPACA_LIVE_KEY_ID: ${{ secrets.ALPACA_LIVE_KEY_ID }}
+          ALPACA_LIVE_SECRET: ${{ secrets.ALPACA_LIVE_SECRET }}
+          BOT_LOG_DIR: logs
+        run: |
+          python -m trading_bot.self_improve \
+            --window-days 20 \
+            --bt-from "${{ steps.dates.outputs.bt_from }}" \
+            --bt-to "${{ steps.dates.outputs.bt_to }}" \
+            --tickers SPY,QQQ,XLF,XLK,XLE,XLV,XLI,XLY,XLP,XLU,XLB,XLRE,XLC \
+            --out self_improve_reports
+
+      - name: Open draft PR if a report was written
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          REPORT="self_improve_reports/${{ steps.dates.outputs.report_date }}.md"
+          if [ ! -f "$REPORT" ]; then
+            echo "No report file produced; nothing to do."
+            exit 0
+          fi
+
+          BRANCH="${{ steps.dates.outputs.branch }}"
+          git config user.name "ai-broker-bot"
+          git config user.email "ai-broker-bot@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add "$REPORT"
+          if git diff --cached --quiet; then
+            echo "Report file unchanged — no PR needed."
+            exit 0
+          fi
+          git commit -m "daily-review: research report ${{ steps.dates.outputs.report_date }}"
+          git push -u origin "$BRANCH"
+
+          gh pr create \
+            --draft \
+            --base main \
+            --head "$BRANCH" \
+            --title "daily-review: ${{ steps.dates.outputs.report_date }}" \
+            --body "Automated self-improvement research report. **Advisory only — apply suggested patches by hand.** See \`$REPORT\`."
+
+      - name: Upload report artifact
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: daily-review-${{ steps.dates.outputs.report_date }}
+          path: |
+            self_improve_reports/
+            logs/
+          retention-days: 60
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ dist/
 build/
 backtest_results/
 reports/
+self_improve_reports/
 logs/
 .DS_Store
 state/local_*.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,33 @@ python -m trading_bot.data.alpaca_downloader --from 2020-01-01 --to 2020-12-31 \
 
 # Local pre-flight + launch (manual run, not used by GHA)
 bash start_bot.sh
+
+# Daily self-improvement review — postmortem + rule-based proposals + backtest A/B
+python -m trading_bot.self_improve \
+    --window-days 20 \
+    --bt-from 2026-02-20 --bt-to 2026-04-29 \
+    --tickers SPY,QQQ,XLF,XLK,XLE,XLV,XLI,XLY,XLP,XLU,XLB,XLRE,XLC \
+    --out self_improve_reports
+
+# Same, but skip the backtest gate (postmortem-only smoke test)
+python -m trading_bot.self_improve \
+    --window-days 20 --bt-from 2026-04-01 --bt-to 2026-04-29 --dry-run
 ```
+
+## Self-improvement agent
+
+`trading_bot/self_improve/` is a research-only agent that runs after market
+close (via `.github/workflows/daily-review.yml`, 21:30 UTC weekdays). It:
+
+1. Reads recent closed trades from SQLite, computes per-strategy stats.
+2. Runs rule-based hypotheses (each requires ≥ 20 trades of evidence and
+   proposes a single, bounded ±10% parameter step).
+3. Validates each proposal with an in-process A/B backtest. Pass requires
+   no Sharpe drop > 0.10, no drawdown increase > 2pp, and ≥ 95% of
+   baseline return.
+4. Writes a markdown report to `self_improve_reports/YYYY-MM-DD.md` and
+   opens a draft PR. **The agent never edits config.yaml** — patches in
+   the report are advisory text the human applies by hand.
 
 ## Code Conventions
 

--- a/docs/self_improve_followups.md
+++ b/docs/self_improve_followups.md
@@ -1,0 +1,235 @@
+# Self-improvement agent — follow-up tasks
+
+These are real problems uncovered while building the daily-review agent
+(see PR adding `trading_bot/self_improve/`). They are deliberately scoped
+out of that PR because they touch live order logic and your CLAUDE.md
+says "exercise extreme care with all order logic."
+
+## How they were found
+
+- **Date:** 2026-04-30
+- **Method:** Pulled `bot-db-25135914687` from GitHub Actions, ran the
+  self-improve agent against it, postmortem returned 0 closed trades.
+- **Root cause investigation:** `trades` table has 54 rows but every
+  row has `strategy_id`, `exit_time`, `exit_reason`, `net_pnl` = NULL.
+  `positions` table has 50 closed `overnight_drift` + 2 closed
+  `mean_reversion` rows with intact strategy attribution but no exit
+  data columns at all. `daily_summaries` and `order_rejections` are
+  empty.
+
+## Task #2 — Live bot is not persisting exit data
+
+### Symptom
+
+Closed positions never appear as complete rows in `trades`. The
+self-improve agent's postmortem can never see real P&L. Daily summaries
+also never get written.
+
+### Evidence (from `bot-db-25135914687`)
+
+```sql
+-- trades: 54 entries, 0 closures
+SELECT COUNT(*) FROM trades;                                  -- 54
+SELECT COUNT(*) FROM trades WHERE exit_time IS NOT NULL;      -- 0
+SELECT COUNT(*) FROM trades WHERE strategy_id IS NOT NULL;    -- 0
+SELECT COUNT(*) FROM trades WHERE net_pnl IS NOT NULL;        -- 0
+
+-- positions: 52 closed, strategy_id present
+SELECT status, COUNT(*) FROM positions GROUP BY status;
+-- CLOSED                  52
+-- POSITION_OPEN            1
+-- STOP_AND_TARGET_ACTIVE   2
+
+-- positions schema has NO exit_price / exit_time / exit_reason / net_pnl columns
+PRAGMA table_info(positions);
+
+-- daily_summaries: never written
+SELECT COUNT(*) FROM daily_summaries;                         -- 0
+```
+
+### What the code claims to do
+
+- `trading_bot/db/repository.py:57` — `save_trade(conn, trade)` — inserts
+  a complete row including `strategy_id`, `exit_time`, `exit_price`,
+  `exit_reason`, `net_pnl`.
+- `trading_bot/db/repository.py:110` — `update_trade_exit(conn, trade_id, ...)`
+  — UPDATE statement that fills exit data on an existing row.
+- `trading_bot/execution/order_manager.py:284` — fill-detection loop
+  that maps Alpaca order ids back to active positions and calls into
+  the trade-update path.
+- `trading_bot/execution/order_manager.py:791-805` — direct UPDATE
+  statement: `... exit_reason = ? WHERE id = ?`.
+
+So the write path exists. What's broken is which insert path is being
+called on entry, and whether the same row is being updated on exit.
+
+### Investigation starting points
+
+1. **Find the entry insert path.** The 54 NULL-strategy rows in `trades`
+   were inserted by *something*. Grep for INSERTs into trades that
+   don't include strategy_id:
+
+   ```bash
+   grep -rn "INSERT INTO trades" trading_bot/
+   ```
+
+   Compare against `save_trade()` in repository.py — there may be a
+   second, abbreviated insert path that's writing entry-only rows
+   without ever calling `update_trade_exit`.
+
+2. **Verify exit path is reached.** Add a log at
+   `order_manager.py:803` (just before the UPDATE) and run a tick that
+   closes a position. If the log never fires, fill detection isn't
+   triggering for these positions; if it fires but the UPDATE matches
+   0 rows, the `WHERE id = ?` is matching the wrong primary key.
+
+3. **Check for a row-id mismatch.** The `update_trade_exit` query takes
+   a `trade_id`. If the entry path inserted a row but the exit path
+   looks up by Alpaca order id (or some other key), the UPDATE will
+   silently match nothing. Verify the entry insert and exit update
+   agree on the join key.
+
+4. **Cross-check `positions`.** The 52 closed positions have correct
+   `strategy_id`. Whatever code closes a position knows the strategy.
+   If the trades-update path is downstream of the position-close path,
+   it should be inheriting that attribution — figure out why it isn't.
+
+### Schema gap to consider
+
+`positions` has no `exit_price`, `exit_time`, `exit_reason`, or `pnl`
+columns. So even if you fix the write path, the historical 52 rows in
+`positions` carry no exit info — that's why I had to build the
+Alpaca backfill. Going forward you have two options:
+
+- **Treat `trades` as source of truth** — keep `positions` as
+  in-flight state only, and ensure the close path always writes to
+  `trades` before deleting/updating the position row.
+- **Extend `positions`** — add exit columns and write closure data
+  there too. Doubles the storage but means each table is self-contained.
+
+I'd pick option (a) — `trades` is already the audit log; `positions`
+should stay a working set.
+
+### Acceptance criteria
+
+- After a position closes, `trades` has a row with all of: strategy_id,
+  exit_time, exit_price, exit_reason, net_pnl populated.
+- `daily_summaries` gets a row at end of day.
+- A regression test inserts a fake fill, runs the close path, and
+  asserts the trades row is complete.
+- Existing `bot-db-*` artifacts can be backfilled via
+  `python -m trading_bot.self_improve.backfill_cli` (already shipped).
+
+## Task #3 — Orphaned positions on disabled strategies
+
+### Symptom
+
+```sql
+SELECT strategy_id, status, COUNT(*) FROM positions
+WHERE status != 'CLOSED' GROUP BY strategy_id, status;
+
+-- breakout            STOP_AND_TARGET_ACTIVE   1
+-- trend_following     STOP_AND_TARGET_ACTIVE   1
+-- unknown             POSITION_OPEN            1
+```
+
+Both `breakout` and `trend_following` were disabled in
+[`config.yaml:626,654`](../config.yaml) on 2026-04-28 after the evening
+walkforward. Their allocations were set to `$0` and routed to
+mean_reversion + overnight_drift. But two positions on those strategies
+are still open with `STOP_AND_TARGET_ACTIVE` status — meaning Alpaca is
+still holding shares with active stop and target orders that the live
+bot is no longer managing.
+
+There's also a `POSITION_OPEN` row with `strategy_id='unknown'` — that's
+a position the bot inherited or couldn't attribute. Same problem in
+miniature.
+
+### Why this matters
+
+- The disabled strategies have `enabled: false` in config, so
+  `create_strategies()` skips them — no code path is monitoring those
+  positions on every tick. The stop/target orders Alpaca holds will
+  fire eventually, but the bot won't react to fills, won't update
+  state, won't write the trade row.
+- If those orders get cancelled by Alpaca (e.g. inactivity), the
+  position becomes naked.
+- The `unknown` position is even worse — no strategy means no exit
+  policy, no risk gate review, no postmortem coverage.
+
+### Investigation starting points
+
+1. **Identify the actual symbols and Alpaca order ids.**
+
+   ```sql
+   SELECT id, ticker, strategy_id, status, quantity, entry_price,
+          alpaca_order_id, alpaca_stop_order_id, alpaca_target_order_id,
+          alpaca_trail_order_id, entry_time
+   FROM positions
+   WHERE status != 'CLOSED';
+   ```
+
+2. **Verify the orders are still live on Alpaca.**
+
+   ```python
+   from alpaca.trading.client import TradingClient
+   from alpaca.trading.requests import GetOrdersRequest
+   from alpaca.trading.enums import QueryOrderStatus
+   client = TradingClient(KEY, SECRET, paper=True)
+   for oid in ["<stop_id>", "<target_id>"]:
+       print(client.get_order_by_id(oid))
+   ```
+
+3. **Decide the policy.** Three options, in order of preference:
+
+   - **Adopt-and-flatten.** Re-enable the strategies just long enough
+     for the next tick to manage them out (let stop/target hit naturally
+     OR explicitly close at next open). Then re-disable. Lowest risk;
+     no manual order ops.
+   - **Manual flatten via Alpaca.** Cancel stop/target orders, market
+     sell. Quick but bypasses the bot's accounting.
+   - **Permanent orphan handler.** Add a tick-time pass that, for any
+     position whose `strategy_id` maps to a disabled or missing
+     strategy, takes ownership — cancels related orders, places a
+     market exit, writes the trade row. This is the right long-term
+     fix; the previous two are incident response.
+
+4. **Add a guard.** Before disabling a strategy, the config-validation
+   path should refuse if there are open positions on it (or warn
+   loudly). A regression test would assert this.
+
+### Acceptance criteria
+
+- The 2 STOP_AND_TARGET_ACTIVE and 1 POSITION_OPEN rows in the live
+  paper DB are all flattened, their trade rows are complete, and
+  cash is reconciled.
+- `config.validate()` (or the next-best entry point) surfaces an error
+  when disabling a strategy with open positions.
+- An orphan-handling code path exists for the case where a strategy
+  goes missing from `STRATEGY_REGISTRY` (config rename, code deletion).
+
+## Files referenced
+
+- [trading_bot/execution/order_manager.py](../trading_bot/execution/order_manager.py)
+- [trading_bot/db/repository.py](../trading_bot/db/repository.py)
+- [trading_bot/db/schema.py](../trading_bot/db/schema.py)
+- [trading_bot/strategy/strategies/__init__.py](../trading_bot/strategy/strategies/__init__.py)
+- [trading_bot/self_improve/alpaca_backfill.py](../trading_bot/self_improve/alpaca_backfill.py)
+- [config.yaml](../config.yaml)
+
+## Useful queries
+
+```sql
+-- All open exposure
+SELECT id, ticker, strategy_id, status, quantity, entry_price, alpaca_order_id
+FROM positions WHERE status != 'CLOSED';
+
+-- Closed positions missing exit data (would-be backfill candidates)
+SELECT COUNT(*) FROM positions p
+WHERE p.status = 'CLOSED' AND p.strategy_id IS NOT NULL AND p.strategy_id != 'unknown'
+  AND NOT EXISTS (SELECT 1 FROM trades t WHERE t.notes = 'backfill:position:' || p.id);
+
+-- Empty trade rows (entry-only, never closed in DB)
+SELECT id, ticker, entry_time FROM trades
+WHERE exit_time IS NULL OR strategy_id IS NULL ORDER BY entry_time DESC LIMIT 20;
+```

--- a/trading_bot/self_improve/__init__.py
+++ b/trading_bot/self_improve/__init__.py
@@ -1,0 +1,25 @@
+"""Self-improvement research agent.
+
+Runs at end of trading day. Produces a markdown report containing:
+  1. Postmortem of recent trades (per-strategy stats over rolling window)
+  2. Hypotheses for config tweaks (deterministic, rule-based, bounded steps)
+  3. Backtest A/B results validating each hypothesis on historical data
+
+The report is committed via a draft PR. Humans review and apply the patch
+manually. The agent never edits ``config.yaml`` directly.
+"""
+
+from trading_bot.self_improve.postmortem import StrategyStats, compute_window_stats
+from trading_bot.self_improve.hypotheses import Proposal, propose
+from trading_bot.self_improve.backtest_gate import BacktestComparison, evaluate
+from trading_bot.self_improve.report import render_markdown
+
+__all__ = [
+    "StrategyStats",
+    "compute_window_stats",
+    "Proposal",
+    "propose",
+    "BacktestComparison",
+    "evaluate",
+    "render_markdown",
+]

--- a/trading_bot/self_improve/__main__.py
+++ b/trading_bot/self_improve/__main__.py
@@ -1,0 +1,148 @@
+"""CLI entrypoint: orchestrates postmortem, hypotheses, backtest gate, report.
+
+Usage:
+    python -m trading_bot.self_improve \\
+        --window-days 20 \\
+        --bt-from 2026-02-01 --bt-to 2026-04-29 \\
+        --tickers SPY,QQQ,XLF,XLK,XLE,XLV,XLI,XLY,XLP,XLU,XLB,XLRE,XLC \\
+        --out self_improve_reports
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import sqlite3
+import sys
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+from trading_bot.config import Config
+from trading_bot.log_setup import setup_logging
+from trading_bot.self_improve.backtest_gate import (
+    evaluate,
+    make_multi_intraday_runner,
+)
+from trading_bot.self_improve.hypotheses import propose
+from trading_bot.self_improve.postmortem import summarize_all
+from trading_bot.self_improve.report import render_markdown
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Daily self-improvement research agent for the trading bot.",
+    )
+    parser.add_argument("--config", default="config.yaml", help="Path to config.yaml")
+    parser.add_argument(
+        "--db", default=None,
+        help="Path to SQLite DB (default: config's database.path)",
+    )
+    parser.add_argument(
+        "--window-days", type=int, default=20,
+        help="Postmortem window in days (default: 20)",
+    )
+    parser.add_argument(
+        "--bt-from", type=date.fromisoformat, required=True,
+        help="Backtest window start date (YYYY-MM-DD)",
+    )
+    parser.add_argument(
+        "--bt-to", type=date.fromisoformat, required=True,
+        help="Backtest window end date (YYYY-MM-DD)",
+    )
+    parser.add_argument(
+        "--tickers", default="SPY,QQQ,XLF,XLK,XLE,XLV,XLI,XLY,XLP,XLU,XLB,XLRE,XLC",
+        help="Comma-separated tickers for the multi-ticker intraday backtest",
+    )
+    parser.add_argument(
+        "--cash-per-strategy", type=float, default=2500.0,
+        help="USD allocated per strategy in the backtest (default: 2500)",
+    )
+    parser.add_argument(
+        "--out", default="self_improve_reports",
+        help="Output directory for the report file (default: self_improve_reports)",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Skip the backtest gate (postmortem + proposals only)",
+    )
+    return parser.parse_args(argv)
+
+
+async def _async_main(args: argparse.Namespace) -> int:
+    config = Config.load(args.config)
+    db_path = args.db or config.db_path
+    if not Path(db_path).exists():
+        logger.error("DB not found at %s", db_path)
+        return 2
+
+    strategy_configs = config.get_strategy_configs()
+    active_strategy_ids = [
+        sid for sid, cfg in strategy_configs.items()
+        if cfg.get("enabled", True)
+    ]
+    if not active_strategy_ids:
+        logger.error("No enabled strategies in config; nothing to review")
+        return 2
+
+    conn = sqlite3.connect(db_path)
+    try:
+        stats_by_strategy = summarize_all(
+            conn, active_strategy_ids, args.window_days,
+            now=datetime.now(timezone.utc),
+        )
+    finally:
+        conn.close()
+
+    for sid, s in stats_by_strategy.items():
+        logger.info(
+            "Postmortem %s: n=%d wr=%.1f%% pf=%s pnl=%.2f",
+            sid, s.n_trades, s.win_rate * 100,
+            f"{s.profit_factor:.2f}" if s.profit_factor else "n/a",
+            s.total_pnl_usd,
+        )
+
+    proposals = propose(stats_by_strategy, strategy_configs)
+    logger.info("Generated %d proposals", len(proposals))
+
+    comparisons = []
+    if proposals and not args.dry_run:
+        tickers = [t.strip() for t in args.tickers.split(",") if t.strip()]
+        runner = make_multi_intraday_runner(
+            tickers, args.bt_from, args.bt_to,
+            cash_per_strategy_usd=args.cash_per_strategy,
+        )
+        comparisons = await evaluate(proposals, config, runner)
+
+    report_md = render_markdown(
+        report_date=date.today(),
+        window_days=args.window_days,
+        stats_by_strategy=stats_by_strategy,
+        proposals=proposals,
+        comparisons=comparisons,
+        backtest_window=(args.bt_from, args.bt_to) if not args.dry_run else None,
+        backtest_universe=(
+            [t.strip() for t in args.tickers.split(",") if t.strip()]
+            if not args.dry_run else None
+        ),
+    )
+
+    out_dir = Path(args.out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / f"{date.today().isoformat()}.md"
+    out_path.write_text(report_md, encoding="utf-8")
+    logger.info("Report written to %s", out_path)
+    print(str(out_path))
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    setup_logging("self_improve")
+    args = _parse_args(argv)
+    return asyncio.run(_async_main(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/trading_bot/self_improve/alpaca_backfill.py
+++ b/trading_bot/self_improve/alpaca_backfill.py
@@ -1,0 +1,312 @@
+"""One-shot backfill: reconstruct closed trades from Alpaca order history.
+
+The live bot writes entries into the ``trades`` table but does not currently
+persist exit data (see follow-up doc ``docs/self_improve_followups.md``).
+Strategy attribution survives in the ``positions`` table, which holds
+``alpaca_*_order_id`` for the entry, stop, target, and trailing orders.
+
+This script:
+  1. Loads closed positions with a known strategy_id.
+  2. Skips positions that already have a backfilled ``trades`` row
+     (idempotent — re-running is safe).
+  3. Pulls Alpaca order history for each ticker around the entry time.
+  4. Pairs the entry with its first matching SELL fill (FIFO, by quantity).
+  5. Infers ``exit_reason`` by matching the SELL order id against the
+     position's stop/target/trail order ids.
+  6. Writes a complete row into ``trades`` with a ``notes`` marker so it
+     can be detected on subsequent runs.
+
+Net P&L is gross P&L (Alpaca equities are commission-free). FX rate is
+1.0 (USD account). Slippage is left null — entry price is from the
+position record, exit from the Alpaca fill.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Iterable
+
+logger = logging.getLogger(__name__)
+
+
+# Window after entry_time within which we look for the matching exit fill.
+# Overnight drift positions exit on the next session's open (~18 hours);
+# mean reversion exits intraday or by wind_down. 7 days is a comfortable
+# upper bound — anything older than that is a stale position the
+# reconciliation path should surface separately.
+EXIT_LOOKBACK_DAYS: int = 7
+
+# Notes-column marker so we can detect already-backfilled rows. Format:
+# ``backfill:position:{position_id}``.
+BACKFILL_MARKER_PREFIX: str = "backfill:position:"
+
+
+@dataclass(frozen=True)
+class ClosedPositionRow:
+    """Row from the ``positions`` table that needs a matching ``trades`` row."""
+
+    position_id: int
+    ticker: str
+    exchange: str
+    currency: str
+    strategy_id: str
+    quantity: int
+    entry_price: float
+    entry_time: datetime
+    hold_type: str
+    phase: int
+    alpaca_order_id: str | None
+    alpaca_stop_order_id: str | None
+    alpaca_target_order_id: str | None
+    alpaca_trail_order_id: str | None
+
+
+@dataclass(frozen=True)
+class ExitFill:
+    """The Alpaca SELL fill paired to a closed position."""
+
+    order_id: str
+    filled_at: datetime
+    filled_avg_price: float
+    filled_qty: float
+
+
+@dataclass(frozen=True)
+class BackfillReport:
+    """Summary of a single backfill invocation."""
+
+    candidates_found: int
+    already_backfilled: int
+    no_exit_found: int
+    inserted: int
+    dry_run: bool
+
+
+def _parse_iso(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        if value.endswith("Z"):
+            value = value[:-1] + "+00:00"
+        dt = datetime.fromisoformat(value)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt
+    except (ValueError, TypeError):
+        return None
+
+
+def load_candidates(conn: sqlite3.Connection) -> list[ClosedPositionRow]:
+    """Closed positions with a strategy_id, not yet backfilled."""
+    cur = conn.execute(
+        f"""
+        SELECT p.id, p.ticker, p.exchange, p.currency, p.strategy_id,
+               p.quantity, p.entry_price, p.entry_time, p.hold_type, p.phase,
+               p.alpaca_order_id, p.alpaca_stop_order_id,
+               p.alpaca_target_order_id, p.alpaca_trail_order_id
+          FROM positions p
+         WHERE p.status = 'CLOSED'
+           AND p.strategy_id IS NOT NULL
+           AND p.strategy_id != 'unknown'
+           AND NOT EXISTS (
+                 SELECT 1 FROM trades t
+                  WHERE t.notes = '{BACKFILL_MARKER_PREFIX}' || p.id
+               )
+         ORDER BY p.entry_time
+        """
+    )
+    out: list[ClosedPositionRow] = []
+    for row in cur.fetchall():
+        entry_dt = _parse_iso(row[7])
+        if entry_dt is None:
+            logger.warning("Position %d has unparseable entry_time %r — skipping",
+                           row[0], row[7])
+            continue
+        out.append(
+            ClosedPositionRow(
+                position_id=row[0],
+                ticker=row[1],
+                exchange=row[2],
+                currency=row[3],
+                strategy_id=row[4],
+                quantity=int(row[5]),
+                entry_price=float(row[6]),
+                entry_time=entry_dt,
+                hold_type=row[8],
+                phase=int(row[9]),
+                alpaca_order_id=row[10],
+                alpaca_stop_order_id=row[11],
+                alpaca_target_order_id=row[12],
+                alpaca_trail_order_id=row[13],
+            )
+        )
+    return out
+
+
+def _infer_exit_reason(exit_order_id: str, position: ClosedPositionRow) -> str:
+    """Map a SELL order id back to its semantic exit reason.
+
+    Returns ``manual`` when no match — the live bot also flattens via
+    market sells in wind-down and emergency paths, which would not match
+    any of the precomputed bracket-order ids.
+    """
+    if position.alpaca_stop_order_id and exit_order_id == position.alpaca_stop_order_id:
+        return "stop_loss"
+    if position.alpaca_target_order_id and exit_order_id == position.alpaca_target_order_id:
+        return "take_profit"
+    if position.alpaca_trail_order_id and exit_order_id == position.alpaca_trail_order_id:
+        return "trailing_stop"
+    return "manual"
+
+
+async def find_exit_fill(
+    client,  # alpaca.trading.client.TradingClient
+    position: ClosedPositionRow,
+    *,
+    lookback_days: int = EXIT_LOOKBACK_DAYS,
+) -> ExitFill | None:
+    """Pull SELL fills for ``position.ticker`` after entry, return first match.
+
+    "Matches" = side=SELL, filled, and ``filled_qty`` is at least the
+    position's quantity (Alpaca may split a sell across fills, but
+    ``get_orders`` returns the parent order with rolled-up totals).
+    """
+    from alpaca.trading.requests import GetOrdersRequest
+    from alpaca.trading.enums import QueryOrderStatus, OrderSide
+
+    after = position.entry_time
+    until = after + timedelta(days=lookback_days)
+    request = GetOrdersRequest(
+        status=QueryOrderStatus.CLOSED,
+        symbols=[position.ticker],
+        after=after,
+        until=until,
+        side=OrderSide.SELL,
+        limit=50,
+    )
+    try:
+        orders = await asyncio.to_thread(client.get_orders, filter=request)
+    except Exception:
+        logger.exception("Alpaca get_orders failed for position %d (%s)",
+                         position.position_id, position.ticker)
+        return None
+
+    for order in orders:
+        if str(getattr(order, "status", "")) not in ("OrderStatus.FILLED", "filled"):
+            # alpaca-py returns enum values; tolerate both .value and str()
+            status_str = str(getattr(order, "status", "")).lower()
+            if "filled" not in status_str:
+                continue
+        filled_qty_raw = getattr(order, "filled_qty", None)
+        filled_price_raw = getattr(order, "filled_avg_price", None)
+        filled_at_raw = getattr(order, "filled_at", None)
+        if filled_qty_raw is None or filled_price_raw is None or filled_at_raw is None:
+            continue
+        try:
+            filled_qty = float(filled_qty_raw)
+            filled_price = float(filled_price_raw)
+        except (TypeError, ValueError):
+            continue
+        if filled_qty + 1e-6 < position.quantity:
+            continue
+        filled_at = filled_at_raw if isinstance(filled_at_raw, datetime) else _parse_iso(str(filled_at_raw))
+        if filled_at is None:
+            continue
+        return ExitFill(
+            order_id=str(order.id),
+            filled_at=filled_at,
+            filled_avg_price=filled_price,
+            filled_qty=filled_qty,
+        )
+
+    return None
+
+
+def insert_backfilled_trade(
+    conn: sqlite3.Connection,
+    position: ClosedPositionRow,
+    exit_fill: ExitFill,
+) -> None:
+    """Write a complete trades row, idempotent via the notes marker."""
+    gross_pnl = (exit_fill.filled_avg_price - position.entry_price) * position.quantity
+    exit_reason = _infer_exit_reason(exit_fill.order_id, position)
+    note = f"{BACKFILL_MARKER_PREFIX}{position.position_id}"
+
+    conn.execute(
+        """
+        INSERT INTO trades (
+            ticker, exchange, currency, side,
+            entry_time, entry_price, quantity,
+            exit_time, exit_price, exit_reason,
+            gross_pnl, net_pnl, pnl_gbp, fx_rate,
+            hold_type, phase, strategy_id, notes
+        )
+        VALUES (?, ?, ?, 'long',
+                ?, ?, ?,
+                ?, ?, ?,
+                ?, ?, ?, 1.0,
+                ?, ?, ?, ?)
+        """,
+        (
+            position.ticker, position.exchange, position.currency,
+            position.entry_time.strftime("%Y-%m-%d %H:%M:%S"),
+            position.entry_price, position.quantity,
+            exit_fill.filled_at.strftime("%Y-%m-%d %H:%M:%S"),
+            exit_fill.filled_avg_price, exit_reason,
+            gross_pnl, gross_pnl, gross_pnl,
+            position.hold_type, position.phase, position.strategy_id, note,
+        ),
+    )
+
+
+async def backfill(
+    conn: sqlite3.Connection,
+    client,  # alpaca.trading.client.TradingClient
+    *,
+    dry_run: bool = False,
+    fill_finder=None,  # injectable for tests
+) -> BackfillReport:
+    """Pair every eligible closed position with its Alpaca exit fill."""
+    candidates = load_candidates(conn)
+    logger.info("Found %d candidate position(s) to backfill", len(candidates))
+
+    finder = fill_finder or find_exit_fill
+    inserted = 0
+    no_exit = 0
+
+    for c in candidates:
+        exit_fill = await finder(client, c)
+        if exit_fill is None:
+            logger.warning(
+                "No exit fill found for position %d (%s entered %s)",
+                c.position_id, c.ticker, c.entry_time.isoformat(),
+            )
+            no_exit += 1
+            continue
+
+        gross_pnl = (exit_fill.filled_avg_price - c.entry_price) * c.quantity
+        exit_reason = _infer_exit_reason(exit_fill.order_id, c)
+        logger.info(
+            "Position %d %s qty=%d entry=%.4f exit=%.4f pnl=%+.2f reason=%s%s",
+            c.position_id, c.ticker, c.quantity,
+            c.entry_price, exit_fill.filled_avg_price, gross_pnl, exit_reason,
+            " (dry-run)" if dry_run else "",
+        )
+        if not dry_run:
+            insert_backfilled_trade(conn, c, exit_fill)
+            inserted += 1
+
+    if not dry_run:
+        conn.commit()
+
+    return BackfillReport(
+        candidates_found=len(candidates),
+        already_backfilled=0,  # excluded at SQL level
+        no_exit_found=no_exit,
+        inserted=inserted,
+        dry_run=dry_run,
+    )

--- a/trading_bot/self_improve/backfill_cli.py
+++ b/trading_bot/self_improve/backfill_cli.py
@@ -1,0 +1,84 @@
+"""CLI wrapper around alpaca_backfill.
+
+Usage:
+    python -m trading_bot.self_improve.backfill_cli --dry-run
+    python -m trading_bot.self_improve.backfill_cli
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import sqlite3
+import sys
+from pathlib import Path
+
+from trading_bot.config import Config
+from trading_bot.env import resolve_alpaca_env
+from trading_bot.log_setup import setup_logging
+from trading_bot.self_improve.alpaca_backfill import backfill
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="One-shot: backfill closed-trade rows from Alpaca order history.",
+    )
+    parser.add_argument("--config", default="config.yaml", help="Path to config.yaml")
+    parser.add_argument(
+        "--db", default=None,
+        help="SQLite path (default: config's database.path)",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Pair candidates and log what would be inserted; do not write to the DB",
+    )
+    return parser.parse_args(argv)
+
+
+async def _async_main(args: argparse.Namespace) -> int:
+    config = Config.load(args.config)
+    db_path = args.db or config.db_path
+    if not Path(db_path).exists():
+        logger.error("DB not found at %s", db_path)
+        return 2
+
+    api_key, secret_key, is_paper = resolve_alpaca_env()
+    if not api_key or not secret_key:
+        logger.error(
+            "Alpaca credentials not found. Set ALPACA_PAPER_KEY_ID + "
+            "ALPACA_PAPER_SECRET (or ALPACA_API_KEY + ALPACA_SECRET_KEY) "
+            "in your environment or .env file."
+        )
+        return 2
+
+    from alpaca.trading.client import TradingClient
+    client = TradingClient(api_key, secret_key, paper=is_paper)
+    logger.info("Connected to Alpaca (%s)", "paper" if is_paper else "live")
+
+    conn = sqlite3.connect(db_path)
+    try:
+        report = await backfill(conn, client, dry_run=args.dry_run)
+    finally:
+        conn.close()
+
+    logger.info(
+        "Backfill complete: candidates=%d inserted=%d no_exit_found=%d dry_run=%s",
+        report.candidates_found, report.inserted,
+        report.no_exit_found, report.dry_run,
+    )
+    if report.candidates_found == 0:
+        logger.info("No candidates — either nothing to backfill or all rows already done.")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    setup_logging("alpaca_backfill")
+    args = _parse_args(argv)
+    return asyncio.run(_async_main(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/trading_bot/self_improve/backtest_gate.py
+++ b/trading_bot/self_improve/backtest_gate.py
@@ -1,0 +1,264 @@
+"""Backtest gate: validate each proposal against historical data.
+
+Runs the existing ``MultiStrategyBacktester`` in-process. For each proposal:
+  1. Builds a candidate ``Config`` with the single parameter mutated.
+  2. Runs both baseline and candidate over the same window.
+  3. Compares ``StrategyResult`` for the affected strategy.
+  4. Marks the proposal pass/fail based on relative-regression thresholds.
+
+The comparison is intentionally strict on regression (no Sharpe drop,
+no material drawdown increase) and only mildly demanding on improvement
+(the candidate must at least not be worse). The agent surfaces all
+results — pass and fail — and the human picks.
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+from dataclasses import dataclass
+from datetime import date
+from typing import Any, Awaitable, Callable
+
+from trading_bot.config import Config
+from trading_bot.multi_strategy_backtest import (
+    MultiStrategyBacktester,
+    MultiStrategyResult,
+    StrategyResult,
+)
+from trading_bot.self_improve.hypotheses import Proposal
+
+logger = logging.getLogger(__name__)
+
+
+# Pass criteria (strict on regression, lenient on improvement). All must hold
+# for a proposal to be marked passed.
+MAX_SHARPE_DROP: float = 0.10
+MAX_DRAWDOWN_INCREASE_PCT: float = 2.0     # absolute percentage points
+MIN_RETURN_RATIO: float = 0.95              # candidate >= 95% of baseline return
+
+
+@dataclass(frozen=True)
+class StrategyMetrics:
+    """Subset of ``StrategyResult`` we use for A/B comparison."""
+
+    strategy_id: str
+    n_trades: int
+    return_pct: float
+    max_drawdown_pct: float
+    win_rate: float
+    profit_factor: float | None
+    sharpe_approx: float
+    total_pnl_usd: float
+
+    @classmethod
+    def from_result(cls, r: StrategyResult) -> StrategyMetrics:
+        return cls(
+            strategy_id=r.strategy_id,
+            n_trades=r.total_trades,
+            return_pct=r.return_pct,
+            max_drawdown_pct=r.max_drawdown_pct,
+            win_rate=r.win_rate,
+            profit_factor=r.profit_factor,
+            sharpe_approx=r.sharpe_approx,
+            total_pnl_usd=r.total_pnl_usd,
+        )
+
+
+@dataclass(frozen=True)
+class BacktestComparison:
+    """Result of validating a single proposal against historical data."""
+
+    proposal: Proposal
+    baseline: StrategyMetrics
+    candidate: StrategyMetrics
+    passed: bool
+    reason: str
+
+
+# A backtest runner: takes a Config and returns a MultiStrategyResult. The
+# CLI passes one bound to the chosen mode (multi-intraday / spy / daily)
+# and date window. Tests can supply a stub.
+BacktestRunner = Callable[[Config], Awaitable[MultiStrategyResult]]
+
+
+def _mutate_config(
+    base_raw: dict[str, Any],
+    strategy_id: str,
+    param_path: tuple[str, ...],
+    new_value: float,
+) -> dict[str, Any]:
+    """Return a deep-copy of ``base_raw`` with one strategy param replaced."""
+    new_raw = copy.deepcopy(base_raw)
+    strategies = new_raw.get("trading", {}).get("strategies", {})
+    if strategy_id not in strategies:
+        raise KeyError(
+            f"Strategy {strategy_id} not found in config "
+            f"(have: {list(strategies.keys())})"
+        )
+    target = strategies[strategy_id]
+    for key in param_path[:-1]:
+        if key not in target:
+            raise KeyError(
+                f"Param path {'.'.join(param_path)} broken at '{key}' "
+                f"under {strategy_id}"
+            )
+        target = target[key]
+    leaf = param_path[-1]
+    if leaf not in target:
+        raise KeyError(
+            f"Leaf param '{leaf}' not present under {strategy_id}; "
+            f"refusing to add a new key"
+        )
+    # Preserve int-ness where possible (RSI thresholds are ints in YAML).
+    if isinstance(target[leaf], int) and float(new_value).is_integer():
+        target[leaf] = int(new_value)
+    else:
+        target[leaf] = new_value
+    return new_raw
+
+
+def _judge(
+    proposal: Proposal,
+    baseline: StrategyMetrics,
+    candidate: StrategyMetrics,
+) -> tuple[bool, str]:
+    """Return (passed, human-readable reason)."""
+    notes: list[str] = []
+    failed = False
+
+    sharpe_delta = candidate.sharpe_approx - baseline.sharpe_approx
+    if sharpe_delta < -MAX_SHARPE_DROP:
+        failed = True
+        notes.append(
+            f"Sharpe dropped {sharpe_delta:+.2f} (max allowed {-MAX_SHARPE_DROP:+.2f})"
+        )
+
+    dd_delta = candidate.max_drawdown_pct - baseline.max_drawdown_pct
+    if dd_delta > MAX_DRAWDOWN_INCREASE_PCT:
+        failed = True
+        notes.append(
+            f"Max drawdown worsened by {dd_delta:+.2f}pp "
+            f"(max allowed {MAX_DRAWDOWN_INCREASE_PCT:+.2f}pp)"
+        )
+
+    if baseline.return_pct > 0:
+        ratio = candidate.return_pct / baseline.return_pct
+        if ratio < MIN_RETURN_RATIO:
+            failed = True
+            notes.append(
+                f"Return dropped to {ratio:.0%} of baseline "
+                f"(min {MIN_RETURN_RATIO:.0%})"
+            )
+
+    if candidate.n_trades == 0:
+        failed = True
+        notes.append("Candidate produced zero trades over the window")
+
+    if failed:
+        return False, "; ".join(notes)
+    return True, (
+        f"sharpe {sharpe_delta:+.2f}, drawdown {dd_delta:+.2f}pp, "
+        f"return {(candidate.return_pct - baseline.return_pct):+.2f}pp"
+    )
+
+
+async def evaluate(
+    proposals: list[Proposal],
+    base_config: Config,
+    runner: BacktestRunner,
+) -> list[BacktestComparison]:
+    """Run baseline + per-proposal candidates, return judged comparisons.
+
+    The baseline is run once and reused across all proposals — they share
+    the same window and starting state, so the baseline metrics are
+    invariant.
+    """
+    if not proposals:
+        return []
+
+    logger.info("Running baseline backtest...")
+    baseline_result = await runner(base_config)
+    baseline_by_sid: dict[str, StrategyMetrics] = {
+        r.strategy_id: StrategyMetrics.from_result(r)
+        for r in baseline_result.strategies
+    }
+
+    comparisons: list[BacktestComparison] = []
+    for proposal in proposals:
+        if proposal.strategy_id not in baseline_by_sid:
+            logger.warning(
+                "Baseline did not include strategy %s — skipping proposal %s",
+                proposal.strategy_id, proposal.rule_id,
+            )
+            continue
+
+        try:
+            mutated_raw = _mutate_config(
+                base_config._raw,
+                proposal.strategy_id,
+                proposal.param_path,
+                proposal.proposed_value,
+            )
+        except KeyError as exc:
+            logger.error("Cannot apply proposal %s: %s", proposal.rule_id, exc)
+            continue
+
+        candidate_config = Config(mutated_raw)
+        logger.info(
+            "Running candidate for %s (%s: %s -> %s)",
+            proposal.rule_id, ".".join(proposal.param_path),
+            proposal.current_value, proposal.proposed_value,
+        )
+        candidate_result = await runner(candidate_config)
+        candidate_metrics_by_sid = {
+            r.strategy_id: StrategyMetrics.from_result(r)
+            for r in candidate_result.strategies
+        }
+        if proposal.strategy_id not in candidate_metrics_by_sid:
+            logger.warning(
+                "Candidate did not produce a result for %s — skipping",
+                proposal.strategy_id,
+            )
+            continue
+
+        baseline = baseline_by_sid[proposal.strategy_id]
+        candidate = candidate_metrics_by_sid[proposal.strategy_id]
+        passed, reason = _judge(proposal, baseline, candidate)
+        comparisons.append(
+            BacktestComparison(
+                proposal=proposal,
+                baseline=baseline,
+                candidate=candidate,
+                passed=passed,
+                reason=reason,
+            )
+        )
+
+    n_passed = sum(1 for c in comparisons if c.passed)
+    logger.info("%d/%d proposals passed the backtest gate", n_passed, len(comparisons))
+    return comparisons
+
+
+# Convenience adapter for the multi-ticker intraday mode the live bot uses.
+def make_multi_intraday_runner(
+    tickers: list[str],
+    from_date: date,
+    to_date: date,
+    *,
+    cash_per_strategy_usd: float = 2500.0,
+    regime_filter: bool = True,
+) -> BacktestRunner:
+    """Build a runner bound to multi-ticker intraday mode + date window."""
+
+    async def _runner(config: Config) -> MultiStrategyResult:
+        engine = MultiStrategyBacktester(config)
+        return await engine.run_multi_ticker_intraday(
+            from_date,
+            to_date,
+            tickers=tickers,
+            cash_per_strategy_usd=cash_per_strategy_usd,
+            regime_filter=regime_filter,
+        )
+
+    return _runner

--- a/trading_bot/self_improve/hypotheses.py
+++ b/trading_bot/self_improve/hypotheses.py
@@ -1,0 +1,291 @@
+"""Rule-based hypothesis generator.
+
+Each rule is deterministic, requires a minimum evidence threshold, and
+produces a single bounded parameter step. Rules are written defensively:
+they only fire on patterns the human reviewer can verify in the postmortem
+table, and they only touch parameters that the validated strategies expose.
+
+The agent never proposes changes to safety-critical parameters (risk gates,
+circuit breakers, position sizing). Proposals are scoped to per-strategy
+signal/exit thresholds.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from trading_bot.self_improve.postmortem import StrategyStats
+
+logger = logging.getLogger(__name__)
+
+
+# Validated baselines (see config.yaml comments + tune_history memory).
+# Used only to detect material regressions, never to drive auto-tuning to
+# match a target.
+BASELINES: dict[str, dict[str, float]] = {
+    "mean_reversion": {"win_rate": 0.527, "profit_factor": 1.201},
+    "overnight_drift": {"win_rate": 0.55, "profit_factor": 1.052},
+}
+
+# Minimum number of closed trades in the window before any rule may fire.
+# Below this, the noise on win-rate / PF is too large to act on.
+MIN_TRADES_FOR_PROPOSAL: int = 20
+
+# Maximum number of proposals to surface in a single report. Keeps each
+# day's review focused; avoids overwhelming the human reviewer.
+MAX_PROPOSALS_PER_RUN: int = 3
+
+
+@dataclass(frozen=True)
+class Proposal:
+    """A single proposed config change.
+
+    ``param_path`` is the YAML key path under
+    ``trading.strategies.<strategy_id>``, e.g. ``("rsi_oversold",)`` or
+    ``("atr_stop_mult",)``. ``current_value`` and ``proposed_value`` are
+    plain Python scalars (int or float).
+    """
+
+    rule_id: str
+    strategy_id: str
+    param_path: tuple[str, ...]
+    current_value: float
+    proposed_value: float
+    rationale: str
+    evidence: dict[str, float | int | str]
+
+
+Rule = Callable[
+    [StrategyStats, dict[str, Any], dict[str, float]],
+    Proposal | None,
+]
+
+
+# ---------------------------------------------------------------------------
+# Rules
+# ---------------------------------------------------------------------------
+
+
+def _rule_mr_rsi_tighten(
+    stats: StrategyStats,
+    cfg: dict[str, Any],
+    baseline: dict[str, float],
+) -> Proposal | None:
+    if stats.strategy_id != "mean_reversion":
+        return None
+    if stats.n_trades < MIN_TRADES_FOR_PROPOSAL:
+        return None
+    pf = stats.profit_factor
+    if pf is None:
+        return None
+    wr_drop = baseline["win_rate"] - stats.win_rate
+    pf_ratio = pf / baseline["profit_factor"]
+    if wr_drop < 0.05 or pf_ratio >= 0.85:
+        return None
+
+    current = int(cfg.get("rsi_oversold", 28))
+    proposed = max(20, current - 2)
+    if proposed == current:
+        return None
+
+    return Proposal(
+        rule_id="MR-RSI-TIGHTEN",
+        strategy_id=stats.strategy_id,
+        param_path=("rsi_oversold",),
+        current_value=float(current),
+        proposed_value=float(proposed),
+        rationale=(
+            f"Win rate {stats.win_rate:.1%} is {wr_drop * 100:.1f}pp below baseline "
+            f"({baseline['win_rate']:.1%}) and PF {pf:.2f} is {(1 - pf_ratio) * 100:.0f}% "
+            f"below baseline ({baseline['profit_factor']:.2f}). Signal quality has "
+            f"degraded — tighten RSI oversold threshold to require deeper dips."
+        ),
+        evidence={
+            "n_trades": stats.n_trades,
+            "win_rate": round(stats.win_rate, 4),
+            "profit_factor": round(pf, 4),
+            "baseline_win_rate": baseline["win_rate"],
+            "baseline_profit_factor": baseline["profit_factor"],
+        },
+    )
+
+
+def _rule_mr_atr_tighten(
+    stats: StrategyStats,
+    cfg: dict[str, Any],
+    baseline: dict[str, float],
+) -> Proposal | None:
+    if stats.strategy_id != "mean_reversion":
+        return None
+    if stats.n_trades < MIN_TRADES_FOR_PROPOSAL:
+        return None
+    stop_share = stats.exit_share("stop_loss")
+    if stop_share <= 0.55:
+        return None
+
+    current = float(cfg.get("atr_stop_mult", 2.0))
+    proposed = round(current * 0.9, 2)
+    if proposed >= current or proposed < 1.0:
+        return None
+
+    return Proposal(
+        rule_id="MR-ATR-TIGHTEN",
+        strategy_id=stats.strategy_id,
+        param_path=("atr_stop_mult",),
+        current_value=current,
+        proposed_value=proposed,
+        rationale=(
+            f"{stop_share:.0%} of trades exited at stop_loss (>55% threshold). "
+            f"Stops are absorbing trades that drift before recovering — tighten ATR "
+            f"stop multiplier 10% to cut average loss size."
+        ),
+        evidence={
+            "n_trades": stats.n_trades,
+            "stop_loss_share": round(stop_share, 4),
+            "avg_loss_usd": round(stats.avg_loss_usd, 2),
+            "avg_win_usd": round(stats.avg_win_usd, 2),
+        },
+    )
+
+
+def _rule_mr_lwr_earlier(
+    stats: StrategyStats,
+    cfg: dict[str, Any],
+    baseline: dict[str, float],
+) -> Proposal | None:
+    if stats.strategy_id != "mean_reversion":
+        return None
+    if stats.n_trades < MIN_TRADES_FOR_PROPOSAL:
+        return None
+    if not cfg.get("let_winners_run", False):
+        return None
+    take_profit_share = stats.exit_share("take_profit")
+    trailing_share = stats.exit_share("trailing_stop")
+    if take_profit_share + trailing_share > 0.20:
+        return None
+    if stats.avg_hold_minutes >= 60:
+        return None
+
+    current = float(cfg.get("let_winners_run_up_pct", 0.03))
+    proposed = round(current * 0.8, 4)
+    if proposed >= current or proposed < 0.005:
+        return None
+
+    return Proposal(
+        rule_id="MR-LWR-EARLIER",
+        strategy_id=stats.strategy_id,
+        param_path=("let_winners_run_up_pct",),
+        current_value=current,
+        proposed_value=proposed,
+        rationale=(
+            f"let_winners_run is on but only {(take_profit_share + trailing_share):.0%} "
+            f"of exits engaged the trailing stop, and avg hold is "
+            f"{stats.avg_hold_minutes:.0f}min. Lower the activation threshold so "
+            f"the trail engages earlier in winning trades."
+        ),
+        evidence={
+            "n_trades": stats.n_trades,
+            "take_profit_share": round(take_profit_share, 4),
+            "trailing_stop_share": round(trailing_share, 4),
+            "avg_hold_minutes": round(stats.avg_hold_minutes, 1),
+        },
+    )
+
+
+def _rule_od_stop_tighten(
+    stats: StrategyStats,
+    cfg: dict[str, Any],
+    baseline: dict[str, float],
+) -> Proposal | None:
+    if stats.strategy_id != "overnight_drift":
+        return None
+    if stats.n_trades < MIN_TRADES_FOR_PROPOSAL:
+        return None
+    stop_share = stats.exit_share("stop_loss")
+    # Overnight drift's natural stop_loss share should be tiny (~5% of nights
+    # see >3% gap-downs). Anything above 15% suggests the disaster stop is
+    # eating more trades than the strategy archetype tolerates.
+    if stop_share <= 0.15:
+        return None
+
+    current = float(cfg.get("stop_loss_pct", 0.03))
+    proposed = round(current * 0.9, 4)
+    if proposed >= current or proposed < 0.01:
+        return None
+
+    return Proposal(
+        rule_id="OD-STOP-TIGHTEN",
+        strategy_id=stats.strategy_id,
+        param_path=("stop_loss_pct",),
+        current_value=current,
+        proposed_value=proposed,
+        rationale=(
+            f"{stop_share:.0%} of overnight trades exited at the disaster stop. "
+            f"Tail risk is materializing more often than the archetype expects — "
+            f"tighten the stop 10% to cap individual gap-down losses."
+        ),
+        evidence={
+            "n_trades": stats.n_trades,
+            "stop_loss_share": round(stop_share, 4),
+            "avg_loss_usd": round(stats.avg_loss_usd, 2),
+        },
+    )
+
+
+ALL_RULES: tuple[Rule, ...] = (
+    _rule_mr_rsi_tighten,
+    _rule_mr_atr_tighten,
+    _rule_mr_lwr_earlier,
+    _rule_od_stop_tighten,
+)
+
+
+# ---------------------------------------------------------------------------
+# Entrypoint
+# ---------------------------------------------------------------------------
+
+
+def propose(
+    stats_by_strategy: dict[str, StrategyStats],
+    strategy_configs: dict[str, dict[str, Any]],
+    *,
+    baselines: dict[str, dict[str, float]] | None = None,
+    rules: tuple[Rule, ...] | None = None,
+    max_proposals: int = MAX_PROPOSALS_PER_RUN,
+) -> list[Proposal]:
+    """Run all rules, return up to ``max_proposals`` candidates.
+
+    Returns an empty list if no rule fires — the report should make this
+    explicit rather than fabricating proposals.
+    """
+    baselines_used = baselines or BASELINES
+    rules_used = rules or ALL_RULES
+
+    proposals: list[Proposal] = []
+    for sid, stats in stats_by_strategy.items():
+        cfg = strategy_configs.get(sid, {})
+        baseline = baselines_used.get(sid)
+        if baseline is None:
+            logger.debug("No baseline for %s — skipping rules", sid)
+            continue
+        for rule in rules_used:
+            try:
+                p = rule(stats, cfg, baseline)
+            except Exception:
+                logger.exception("Rule %s raised on %s", rule.__name__, sid)
+                continue
+            if p is not None:
+                proposals.append(p)
+
+    if len(proposals) > max_proposals:
+        # Prefer proposals from strategies with the most trades (more signal).
+        proposals.sort(
+            key=lambda p: stats_by_strategy[p.strategy_id].n_trades,
+            reverse=True,
+        )
+        proposals = proposals[:max_proposals]
+
+    logger.info("Generated %d proposals", len(proposals))
+    return proposals

--- a/trading_bot/self_improve/postmortem.py
+++ b/trading_bot/self_improve/postmortem.py
@@ -1,0 +1,156 @@
+"""Per-strategy statistics over a rolling window of closed trades.
+
+Pulls from the ``trades`` table. Pure aggregation — no judgement calls,
+no proposals. The hypothesis layer reads these stats and decides whether
+anything is worth proposing.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from collections import Counter
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class StrategyStats:
+    """Aggregate stats for a single strategy over a closed-trade window."""
+
+    strategy_id: str
+    window_days: int
+    n_trades: int
+    win_rate: float            # 0..1
+    profit_factor: float | None
+    total_pnl_usd: float
+    avg_win_usd: float
+    avg_loss_usd: float        # negative or zero
+    avg_hold_minutes: float
+    exit_reason_counts: dict[str, int] = field(default_factory=dict)
+
+    def exit_share(self, reason: str) -> float:
+        """Fraction of trades exited for ``reason`` (0 if none)."""
+        if self.n_trades == 0:
+            return 0.0
+        return self.exit_reason_counts.get(reason, 0) / self.n_trades
+
+
+def _parse_iso(value: str) -> datetime | None:
+    try:
+        # SQLite stores ISO 8601; tolerate trailing 'Z' or naive timestamps.
+        if value.endswith("Z"):
+            value = value[:-1] + "+00:00"
+        dt = datetime.fromisoformat(value)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt
+    except (ValueError, TypeError):
+        return None
+
+
+def compute_window_stats(
+    conn: sqlite3.Connection,
+    strategy_id: str,
+    window_days: int,
+    *,
+    now: datetime | None = None,
+) -> StrategyStats:
+    """Compute stats for closed trades belonging to ``strategy_id``.
+
+    A trade is "closed" when ``exit_time IS NOT NULL`` and ``net_pnl IS NOT NULL``.
+    The window is the last ``window_days`` calendar days ending at ``now``
+    (UTC), inclusive of the start.
+    """
+    if window_days <= 0:
+        raise ValueError(f"window_days must be positive, got {window_days}")
+
+    now_utc = now or datetime.now(timezone.utc)
+    cutoff = now_utc - timedelta(days=window_days)
+    cutoff_iso = cutoff.strftime("%Y-%m-%d %H:%M:%S")
+
+    cur = conn.execute(
+        """
+        SELECT entry_time, exit_time, exit_reason, net_pnl
+          FROM trades
+         WHERE strategy_id = ?
+           AND exit_time IS NOT NULL
+           AND net_pnl IS NOT NULL
+           AND exit_time >= ?
+        """,
+        (strategy_id, cutoff_iso),
+    )
+    rows = cur.fetchall()
+
+    if not rows:
+        return StrategyStats(
+            strategy_id=strategy_id,
+            window_days=window_days,
+            n_trades=0,
+            win_rate=0.0,
+            profit_factor=None,
+            total_pnl_usd=0.0,
+            avg_win_usd=0.0,
+            avg_loss_usd=0.0,
+            avg_hold_minutes=0.0,
+        )
+
+    wins: list[float] = []
+    losses: list[float] = []
+    hold_minutes: list[float] = []
+    exit_counts: Counter[str] = Counter()
+    total_pnl = 0.0
+
+    for entry_time_str, exit_time_str, exit_reason, net_pnl in rows:
+        pnl = float(net_pnl)
+        total_pnl += pnl
+        if pnl > 0:
+            wins.append(pnl)
+        else:
+            losses.append(pnl)
+        exit_counts[exit_reason or "unknown"] += 1
+
+        entry_dt = _parse_iso(entry_time_str)
+        exit_dt = _parse_iso(exit_time_str)
+        if entry_dt and exit_dt and exit_dt > entry_dt:
+            hold_minutes.append((exit_dt - entry_dt).total_seconds() / 60.0)
+
+    n = len(rows)
+    gross_wins = sum(wins)
+    gross_losses_abs = abs(sum(losses))
+    profit_factor: float | None
+    if gross_losses_abs > 0:
+        profit_factor = gross_wins / gross_losses_abs
+    elif gross_wins > 0:
+        profit_factor = float("inf")
+    else:
+        profit_factor = None
+
+    return StrategyStats(
+        strategy_id=strategy_id,
+        window_days=window_days,
+        n_trades=n,
+        win_rate=len(wins) / n,
+        profit_factor=profit_factor,
+        total_pnl_usd=total_pnl,
+        avg_win_usd=(gross_wins / len(wins)) if wins else 0.0,
+        avg_loss_usd=(sum(losses) / len(losses)) if losses else 0.0,
+        avg_hold_minutes=(sum(hold_minutes) / len(hold_minutes)) if hold_minutes else 0.0,
+        exit_reason_counts=dict(exit_counts),
+    )
+
+
+def summarize_all(
+    conn: sqlite3.Connection,
+    strategy_ids: list[str],
+    window_days: int,
+    *,
+    now: datetime | None = None,
+) -> dict[str, StrategyStats]:
+    """Compute stats for several strategies in one pass."""
+    return {
+        sid: compute_window_stats(conn, sid, window_days, now=now)
+        for sid in strategy_ids
+    }

--- a/trading_bot/self_improve/report.py
+++ b/trading_bot/self_improve/report.py
@@ -1,0 +1,173 @@
+"""Render the daily self-improvement report as Markdown.
+
+The report is the entire artifact the agent produces. The PR adds a single
+file under ``self_improve_reports/YYYY-MM-DD.md`` containing:
+  - Postmortem table per strategy
+  - Each proposal: rule, rationale, evidence
+  - A/B backtest result (baseline vs candidate)
+  - A "Suggested patch" YAML block the human can apply by hand
+
+The agent never edits config.yaml directly — patches are advisory text.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Iterable
+
+from trading_bot.self_improve.backtest_gate import BacktestComparison, StrategyMetrics
+from trading_bot.self_improve.hypotheses import Proposal
+from trading_bot.self_improve.postmortem import StrategyStats
+
+
+def _fmt_pf(pf: float | None) -> str:
+    if pf is None:
+        return "n/a"
+    if pf == float("inf"):
+        return "inf"
+    return f"{pf:.2f}"
+
+
+def _render_postmortem_table(stats_by_strategy: dict[str, StrategyStats]) -> str:
+    if not stats_by_strategy:
+        return "_No strategies evaluated._\n"
+
+    lines = [
+        "| Strategy | Trades | Win rate | PF | Net P&L (USD) | Avg win | Avg loss | Avg hold (min) |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|",
+    ]
+    for sid, s in stats_by_strategy.items():
+        lines.append(
+            f"| `{sid}` | {s.n_trades} | {s.win_rate:.1%} | {_fmt_pf(s.profit_factor)} | "
+            f"{s.total_pnl_usd:+,.2f} | {s.avg_win_usd:+,.2f} | {s.avg_loss_usd:+,.2f} | "
+            f"{s.avg_hold_minutes:.0f} |"
+        )
+
+    parts = ["\n".join(lines), ""]
+    parts.append("**Exit reasons:**\n")
+    for sid, s in stats_by_strategy.items():
+        if s.n_trades == 0:
+            parts.append(f"- `{sid}`: no closed trades in window")
+            continue
+        breakdown = ", ".join(
+            f"{reason}={count}" for reason, count in sorted(s.exit_reason_counts.items())
+        )
+        parts.append(f"- `{sid}`: {breakdown}")
+    parts.append("")
+    return "\n".join(parts)
+
+
+def _render_metrics_row(label: str, m: StrategyMetrics) -> str:
+    return (
+        f"| {label} | {m.n_trades} | {m.return_pct:+.2f}% | "
+        f"{m.max_drawdown_pct:.2f}% | {m.win_rate:.1%} | "
+        f"{_fmt_pf(m.profit_factor)} | {m.sharpe_approx:+.2f} |"
+    )
+
+
+def _render_comparison(comp: BacktestComparison) -> str:
+    p = comp.proposal
+    status = "PASS" if comp.passed else "FAIL"
+    param_str = ".".join(p.param_path)
+    lines = [
+        f"### {p.rule_id} — `{p.strategy_id}.{param_str}`: "
+        f"{p.current_value} -> {p.proposed_value}  [{status}]",
+        "",
+        f"**Rationale.** {p.rationale}",
+        "",
+        "**Evidence (postmortem window):**",
+        "",
+    ]
+    for k, v in p.evidence.items():
+        lines.append(f"- `{k}`: {v}")
+    lines.append("")
+
+    lines.append("**Backtest A/B (same window for both runs):**")
+    lines.append("")
+    lines.append(
+        "| Run | Trades | Return | Max DD | Win rate | PF | Sharpe |"
+    )
+    lines.append("|---|---:|---:|---:|---:|---:|---:|")
+    lines.append(_render_metrics_row("Baseline", comp.baseline))
+    lines.append(_render_metrics_row("Candidate", comp.candidate))
+    lines.append("")
+    lines.append(f"**Gate decision:** {comp.reason}")
+    lines.append("")
+
+    if comp.passed:
+        lines.append("**Suggested patch** (apply by hand if you agree):")
+        lines.append("")
+        lines.append("```yaml")
+        lines.append(f"# trading.strategies.{p.strategy_id}")
+        lines.append(f"{param_str}: {_yaml_value(p.proposed_value)}  # was {_yaml_value(p.current_value)}")
+        lines.append("```")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def _yaml_value(v: float) -> str:
+    if float(v).is_integer():
+        return str(int(v))
+    return f"{v:g}"
+
+
+def render_markdown(
+    *,
+    report_date: date,
+    window_days: int,
+    stats_by_strategy: dict[str, StrategyStats],
+    proposals: list[Proposal],
+    comparisons: list[BacktestComparison],
+    backtest_window: tuple[date, date] | None = None,
+    backtest_universe: Iterable[str] | None = None,
+) -> str:
+    """Render the full report as a single Markdown string."""
+    parts: list[str] = [
+        f"# Self-improvement review — {report_date.isoformat()}",
+        "",
+        f"_Postmortem window: last {window_days} days._",
+    ]
+    if backtest_window is not None:
+        bt_from, bt_to = backtest_window
+        parts.append(
+            f"_Backtest window: {bt_from.isoformat()} to {bt_to.isoformat()}._"
+        )
+    if backtest_universe is not None:
+        parts.append(f"_Backtest universe: {', '.join(backtest_universe)}._")
+    parts.append("")
+
+    parts.append("## Postmortem")
+    parts.append("")
+    parts.append(_render_postmortem_table(stats_by_strategy))
+
+    parts.append("## Proposals")
+    parts.append("")
+    if not proposals:
+        parts.append(
+            "_No rule fired. Either the postmortem is within tolerance of "
+            "validated baselines, or there isn't enough trade evidence yet "
+            "(minimum trades-per-window threshold not met)._"
+        )
+        parts.append("")
+    elif not comparisons:
+        parts.append(
+            "_Proposals were generated but the backtest gate did not run. "
+            "Check the agent log._"
+        )
+        parts.append("")
+        for p in proposals:
+            parts.append(f"- {p.rule_id} on `{p.strategy_id}`: {p.rationale}")
+        parts.append("")
+    else:
+        for comp in comparisons:
+            parts.append(_render_comparison(comp))
+
+    parts.append("---")
+    parts.append("")
+    parts.append(
+        "_This report is advisory. The agent never edits `config.yaml`. "
+        "Apply suggested patches by hand only after independent review._"
+    )
+    parts.append("")
+    return "\n".join(parts)

--- a/trading_bot/tests/test_self_improve_alpaca_backfill.py
+++ b/trading_bot/tests/test_self_improve_alpaca_backfill.py
@@ -1,0 +1,263 @@
+"""Tests for trading_bot.self_improve.alpaca_backfill.
+
+The Alpaca client is a stub — we never hit the network. The interesting
+behaviour to test is candidate selection (idempotency, status filter,
+strategy attribution), exit_reason inference, and the trades-row insert.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from trading_bot.self_improve.alpaca_backfill import (
+    BACKFILL_MARKER_PREFIX,
+    ClosedPositionRow,
+    ExitFill,
+    _infer_exit_reason,
+    backfill,
+    insert_backfilled_trade,
+    load_candidates,
+)
+
+
+def _insert_position(
+    conn,
+    *,
+    position_id: int,
+    ticker: str = "SPY",
+    strategy_id: str = "overnight_drift",
+    status: str = "CLOSED",
+    quantity: int = 10,
+    entry_price: float = 100.0,
+    entry_time: datetime,
+    alpaca_order_id: str = "alp-entry-001",
+    alpaca_stop_order_id: str | None = None,
+    alpaca_target_order_id: str | None = None,
+    alpaca_trail_order_id: str | None = None,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO positions (
+            id, ticker, exchange, currency, quantity,
+            entry_price, entry_time, status, hold_type, phase,
+            alpaca_order_id, alpaca_stop_order_id,
+            alpaca_target_order_id, alpaca_trail_order_id,
+            strategy_id
+        ) VALUES (?, ?, 'NYSE', 'USD', ?, ?, ?, ?, 'swing', 1, ?, ?, ?, ?, ?)
+        """,
+        (
+            position_id, ticker, quantity, entry_price,
+            entry_time.strftime("%Y-%m-%dT%H:%M:%S%z") or entry_time.isoformat(),
+            status,
+            alpaca_order_id, alpaca_stop_order_id,
+            alpaca_target_order_id, alpaca_trail_order_id,
+            strategy_id,
+        ),
+    )
+
+
+def _make_position(
+    position_id: int = 1,
+    ticker: str = "SPY",
+    *,
+    stop_id: str | None = None,
+    target_id: str | None = None,
+    trail_id: str | None = None,
+) -> ClosedPositionRow:
+    return ClosedPositionRow(
+        position_id=position_id,
+        ticker=ticker,
+        exchange="NYSE",
+        currency="USD",
+        strategy_id="overnight_drift",
+        quantity=10,
+        entry_price=100.0,
+        entry_time=datetime(2026, 4, 1, 15, 45, tzinfo=timezone.utc),
+        hold_type="swing",
+        phase=1,
+        alpaca_order_id="alp-entry",
+        alpaca_stop_order_id=stop_id,
+        alpaca_target_order_id=target_id,
+        alpaca_trail_order_id=trail_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# load_candidates
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_load_candidates_returns_only_closed_with_strategy(tmp_db):
+    now = datetime.now(timezone.utc)
+    _insert_position(tmp_db, position_id=1, status="CLOSED", strategy_id="mean_reversion",
+                     entry_time=now)
+    _insert_position(tmp_db, position_id=2, status="POSITION_OPEN",
+                     strategy_id="overnight_drift", entry_time=now)
+    _insert_position(tmp_db, position_id=3, status="CLOSED", strategy_id="unknown",
+                     entry_time=now)
+    tmp_db.commit()
+
+    candidates = load_candidates(tmp_db)
+    ids = {c.position_id for c in candidates}
+    assert ids == {1}
+
+
+@pytest.mark.unit
+def test_load_candidates_skips_already_backfilled(tmp_db):
+    now = datetime.now(timezone.utc)
+    _insert_position(tmp_db, position_id=42, entry_time=now)
+    # Pre-existing trades row marking this position as backfilled
+    tmp_db.execute(
+        """
+        INSERT INTO trades (ticker, exchange, currency, side, entry_time, entry_price,
+                            quantity, hold_type, phase, strategy_id, notes)
+        VALUES ('SPY','NYSE','USD','long', ?, 100, 10, 'swing', 1, 'overnight_drift', ?)
+        """,
+        (now.strftime("%Y-%m-%d %H:%M:%S"), f"{BACKFILL_MARKER_PREFIX}42"),
+    )
+    tmp_db.commit()
+
+    assert load_candidates(tmp_db) == []
+
+
+# ---------------------------------------------------------------------------
+# _infer_exit_reason
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_infer_exit_reason_matches_stop():
+    p = _make_position(stop_id="alp-stop", target_id="alp-target", trail_id="alp-trail")
+    assert _infer_exit_reason("alp-stop", p) == "stop_loss"
+    assert _infer_exit_reason("alp-target", p) == "take_profit"
+    assert _infer_exit_reason("alp-trail", p) == "trailing_stop"
+
+
+@pytest.mark.unit
+def test_infer_exit_reason_unknown_falls_back_to_manual():
+    p = _make_position(stop_id="alp-stop")
+    assert _infer_exit_reason("alp-unrelated", p) == "manual"
+
+
+@pytest.mark.unit
+def test_infer_exit_reason_handles_missing_bracket_ids():
+    p = _make_position()  # no stop/target/trail
+    assert _infer_exit_reason("alp-anything", p) == "manual"
+
+
+# ---------------------------------------------------------------------------
+# insert_backfilled_trade
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_insert_writes_complete_row(tmp_db):
+    p = _make_position(stop_id="alp-stop")
+    fill = ExitFill(
+        order_id="alp-stop",
+        filled_at=datetime(2026, 4, 2, 9, 31, tzinfo=timezone.utc),
+        filled_avg_price=98.0,
+        filled_qty=10.0,
+    )
+    insert_backfilled_trade(tmp_db, p, fill)
+    tmp_db.commit()
+
+    row = tmp_db.execute(
+        "SELECT ticker, strategy_id, exit_reason, gross_pnl, net_pnl, notes FROM trades"
+    ).fetchone()
+    assert row[0] == "SPY"
+    assert row[1] == "overnight_drift"
+    assert row[2] == "stop_loss"
+    assert row[3] == pytest.approx((98.0 - 100.0) * 10)
+    assert row[4] == pytest.approx((98.0 - 100.0) * 10)
+    assert row[5] == f"{BACKFILL_MARKER_PREFIX}1"
+
+
+# ---------------------------------------------------------------------------
+# backfill (orchestrator with stubbed fill finder)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_backfill_inserts_one_row_per_paired_position(tmp_db):
+    now = datetime.now(timezone.utc)
+    _insert_position(tmp_db, position_id=1, ticker="SPY", entry_time=now,
+                     alpaca_target_order_id="tgt-1")
+    _insert_position(tmp_db, position_id=2, ticker="QQQ", entry_time=now,
+                     alpaca_stop_order_id="stp-2")
+    tmp_db.commit()
+
+    async def stub_finder(client, position):
+        if position.ticker == "SPY":
+            return ExitFill(
+                order_id="tgt-1", filled_at=now + timedelta(hours=1),
+                filled_avg_price=101.0, filled_qty=10,
+            )
+        return ExitFill(
+            order_id="stp-2", filled_at=now + timedelta(hours=1),
+            filled_avg_price=99.0, filled_qty=10,
+        )
+
+    report = await backfill(tmp_db, client=None, fill_finder=stub_finder)
+    assert report.inserted == 2
+    assert report.no_exit_found == 0
+
+    rows = [
+        tuple(r) for r in tmp_db.execute(
+            "SELECT ticker, exit_reason, gross_pnl FROM trades ORDER BY ticker"
+        ).fetchall()
+    ]
+    assert rows[0] == ("QQQ", "stop_loss", pytest.approx(-10.0))
+    assert rows[1] == ("SPY", "take_profit", pytest.approx(10.0))
+
+
+@pytest.mark.asyncio
+async def test_backfill_dry_run_writes_nothing(tmp_db):
+    now = datetime.now(timezone.utc)
+    _insert_position(tmp_db, position_id=1, entry_time=now)
+    tmp_db.commit()
+
+    async def stub_finder(client, position):
+        return ExitFill(order_id="x", filled_at=now + timedelta(hours=1),
+                        filled_avg_price=101.0, filled_qty=10)
+
+    report = await backfill(tmp_db, client=None, fill_finder=stub_finder, dry_run=True)
+    assert report.inserted == 0
+    assert report.dry_run is True
+    assert tmp_db.execute("SELECT COUNT(*) FROM trades").fetchone()[0] == 0
+
+
+@pytest.mark.asyncio
+async def test_backfill_handles_no_exit_found(tmp_db):
+    now = datetime.now(timezone.utc)
+    _insert_position(tmp_db, position_id=1, entry_time=now)
+    tmp_db.commit()
+
+    async def stub_finder(client, position):
+        return None
+
+    report = await backfill(tmp_db, client=None, fill_finder=stub_finder)
+    assert report.inserted == 0
+    assert report.no_exit_found == 1
+
+
+@pytest.mark.asyncio
+async def test_backfill_is_idempotent(tmp_db):
+    """Re-running backfill on a DB that already has the row should be a no-op."""
+    now = datetime.now(timezone.utc)
+    _insert_position(tmp_db, position_id=1, entry_time=now)
+    tmp_db.commit()
+
+    async def stub_finder(client, position):
+        return ExitFill(order_id="x", filled_at=now + timedelta(hours=1),
+                        filled_avg_price=101.0, filled_qty=10)
+
+    first = await backfill(tmp_db, client=None, fill_finder=stub_finder)
+    assert first.inserted == 1
+    second = await backfill(tmp_db, client=None, fill_finder=stub_finder)
+    assert second.inserted == 0
+    assert second.candidates_found == 0
+    assert tmp_db.execute("SELECT COUNT(*) FROM trades").fetchone()[0] == 1

--- a/trading_bot/tests/test_self_improve_backtest_gate.py
+++ b/trading_bot/tests/test_self_improve_backtest_gate.py
@@ -1,0 +1,266 @@
+"""Tests for trading_bot.self_improve.backtest_gate.
+
+Uses a stub runner so we don't actually invoke the real backtester. The
+real backtester is exercised by the existing test_multi_strategy_backtest
+suite — here we only test the A/B harness.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from trading_bot.config import Config
+from trading_bot.multi_strategy_backtest import (
+    MultiStrategyResult,
+    StrategyResult,
+)
+from trading_bot.self_improve.backtest_gate import (
+    BacktestComparison,
+    StrategyMetrics,
+    _judge,
+    _mutate_config,
+    evaluate,
+)
+from trading_bot.self_improve.hypotheses import Proposal
+
+
+def _make_proposal(
+    strategy_id: str = "mean_reversion",
+    param_path: tuple[str, ...] = ("rsi_oversold",),
+    current: float = 28,
+    proposed: float = 26,
+) -> Proposal:
+    return Proposal(
+        rule_id="TEST-RULE",
+        strategy_id=strategy_id,
+        param_path=param_path,
+        current_value=current,
+        proposed_value=proposed,
+        rationale="test",
+        evidence={},
+    )
+
+
+def _make_strategy_result(
+    strategy_id: str,
+    *,
+    return_pct: float = 5.0,
+    max_drawdown_pct: float = 4.0,
+    sharpe_approx: float = 0.5,
+    n_trades: int = 50,
+    win_rate: float = 0.55,
+    profit_factor: float | None = 1.3,
+) -> StrategyResult:
+    return StrategyResult(
+        strategy_id=strategy_id,
+        display_name=strategy_id,
+        initial_cash_usd=2500.0,
+        final_cash_usd=2500.0 * (1 + return_pct / 100),
+        total_trades=n_trades,
+        wins=int(n_trades * win_rate),
+        losses=n_trades - int(n_trades * win_rate),
+        total_pnl_usd=2500.0 * return_pct / 100,
+        return_pct=return_pct,
+        max_drawdown_pct=max_drawdown_pct,
+        win_rate=win_rate,
+        profit_factor=profit_factor,
+        avg_hold_minutes=45.0,
+        sharpe_approx=sharpe_approx,
+    )
+
+
+def _result(strategy_results: list[StrategyResult]) -> MultiStrategyResult:
+    return MultiStrategyResult(
+        from_date="2026-01-01",
+        to_date="2026-04-01",
+        trading_days=60,
+        strategies=strategy_results,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _mutate_config
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_mutate_config_preserves_other_keys():
+    base = {
+        "trading": {
+            "strategies": {
+                "mean_reversion": {"enabled": True, "rsi_oversold": 28, "atr_stop_mult": 2.0},
+                "overnight_drift": {"enabled": True, "stop_loss_pct": 0.03},
+            }
+        }
+    }
+    new = _mutate_config(base, "mean_reversion", ("rsi_oversold",), 26)
+    assert new["trading"]["strategies"]["mean_reversion"]["rsi_oversold"] == 26
+    assert new["trading"]["strategies"]["mean_reversion"]["atr_stop_mult"] == 2.0
+    assert new["trading"]["strategies"]["overnight_drift"]["stop_loss_pct"] == 0.03
+    # original is not mutated
+    assert base["trading"]["strategies"]["mean_reversion"]["rsi_oversold"] == 28
+
+
+@pytest.mark.unit
+def test_mutate_config_preserves_int_type():
+    base = {"trading": {"strategies": {"mean_reversion": {"rsi_oversold": 28}}}}
+    new = _mutate_config(base, "mean_reversion", ("rsi_oversold",), 26.0)
+    assert isinstance(new["trading"]["strategies"]["mean_reversion"]["rsi_oversold"], int)
+
+
+@pytest.mark.unit
+def test_mutate_config_unknown_strategy_raises():
+    base = {"trading": {"strategies": {"mean_reversion": {"rsi_oversold": 28}}}}
+    with pytest.raises(KeyError):
+        _mutate_config(base, "nonexistent", ("rsi_oversold",), 26)
+
+
+@pytest.mark.unit
+def test_mutate_config_refuses_to_create_new_key():
+    base = {"trading": {"strategies": {"mean_reversion": {"rsi_oversold": 28}}}}
+    with pytest.raises(KeyError):
+        _mutate_config(base, "mean_reversion", ("nonexistent_param",), 5)
+
+
+# ---------------------------------------------------------------------------
+# _judge
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_judge_passes_when_candidate_matches_baseline():
+    baseline = StrategyMetrics.from_result(_make_strategy_result("mr"))
+    candidate = StrategyMetrics.from_result(_make_strategy_result("mr"))
+    passed, reason = _judge(_make_proposal(), baseline, candidate)
+    assert passed
+    assert "sharpe" in reason
+
+
+@pytest.mark.unit
+def test_judge_fails_on_sharpe_drop():
+    baseline = StrategyMetrics.from_result(_make_strategy_result("mr", sharpe_approx=0.6))
+    candidate = StrategyMetrics.from_result(_make_strategy_result("mr", sharpe_approx=0.4))
+    passed, reason = _judge(_make_proposal(), baseline, candidate)
+    assert not passed
+    assert "Sharpe" in reason
+
+
+@pytest.mark.unit
+def test_judge_fails_on_drawdown_increase():
+    baseline = StrategyMetrics.from_result(_make_strategy_result("mr", max_drawdown_pct=4.0))
+    candidate = StrategyMetrics.from_result(_make_strategy_result("mr", max_drawdown_pct=7.0))
+    passed, reason = _judge(_make_proposal(), baseline, candidate)
+    assert not passed
+    assert "drawdown" in reason.lower()
+
+
+@pytest.mark.unit
+def test_judge_fails_on_return_drop():
+    baseline = StrategyMetrics.from_result(_make_strategy_result("mr", return_pct=10.0))
+    candidate = StrategyMetrics.from_result(_make_strategy_result("mr", return_pct=5.0))
+    passed, reason = _judge(_make_proposal(), baseline, candidate)
+    assert not passed
+    assert "Return" in reason
+
+
+@pytest.mark.unit
+def test_judge_fails_on_zero_trades():
+    baseline = StrategyMetrics.from_result(_make_strategy_result("mr"))
+    candidate = StrategyMetrics.from_result(_make_strategy_result("mr", n_trades=0))
+    passed, reason = _judge(_make_proposal(), baseline, candidate)
+    assert not passed
+    assert "zero trades" in reason
+
+
+# ---------------------------------------------------------------------------
+# evaluate (end-to-end with stub runner)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_evaluate_runs_baseline_once_per_call():
+    base_raw = {
+        "trading": {
+            "strategies": {
+                "mean_reversion": {"enabled": True, "rsi_oversold": 28},
+            }
+        }
+    }
+    config = Config(base_raw)
+
+    call_count = {"n": 0}
+    seen_rsi: list[int] = []
+
+    async def stub_runner(c: Config) -> MultiStrategyResult:
+        call_count["n"] += 1
+        rsi = c._raw["trading"]["strategies"]["mean_reversion"]["rsi_oversold"]
+        seen_rsi.append(rsi)
+        # Improving candidate
+        sharpe = 0.5 if rsi == 28 else 0.6
+        return _result([_make_strategy_result("mean_reversion", sharpe_approx=sharpe)])
+
+    proposals = [
+        _make_proposal(current=28, proposed=26),
+        _make_proposal(param_path=("rsi_recovery",), current=35, proposed=33),
+    ]
+    # Add the second param path to the config so mutation succeeds
+    base_raw["trading"]["strategies"]["mean_reversion"]["rsi_recovery"] = 35
+
+    comps = await evaluate(proposals, config, stub_runner)
+    # 1 baseline + 2 candidates = 3 runs
+    assert call_count["n"] == 3
+    assert seen_rsi[0] == 28  # baseline first
+    assert all(c.passed for c in comps)
+    assert len(comps) == 2
+
+
+@pytest.mark.asyncio
+async def test_evaluate_skips_proposal_when_strategy_not_in_baseline():
+    base_raw = {
+        "trading": {
+            "strategies": {"mean_reversion": {"enabled": True, "rsi_oversold": 28}}
+        }
+    }
+    config = Config(base_raw)
+
+    async def stub_runner(c: Config) -> MultiStrategyResult:
+        return _result([_make_strategy_result("mean_reversion")])
+
+    # Proposal targets a strategy that isn't in baseline output
+    proposal = _make_proposal(strategy_id="ghost", current=1, proposed=2)
+    comps = await evaluate([proposal], config, stub_runner)
+    assert comps == []
+
+
+@pytest.mark.asyncio
+async def test_evaluate_empty_proposals_returns_empty():
+    config = Config({"trading": {"strategies": {}}})
+
+    async def stub_runner(c: Config) -> MultiStrategyResult:
+        raise AssertionError("runner should not be called when no proposals")
+
+    assert await evaluate([], config, stub_runner) == []
+
+
+@pytest.mark.asyncio
+async def test_evaluate_marks_failing_candidate():
+    base_raw = {
+        "trading": {
+            "strategies": {"mean_reversion": {"enabled": True, "rsi_oversold": 28}}
+        }
+    }
+    config = Config(base_raw)
+
+    async def stub_runner(c: Config) -> MultiStrategyResult:
+        rsi = c._raw["trading"]["strategies"]["mean_reversion"]["rsi_oversold"]
+        # Worse candidate
+        sharpe = 0.6 if rsi == 28 else 0.3
+        return _result([_make_strategy_result("mean_reversion", sharpe_approx=sharpe)])
+
+    comps = await evaluate(
+        [_make_proposal(current=28, proposed=26)], config, stub_runner,
+    )
+    assert len(comps) == 1
+    assert not comps[0].passed

--- a/trading_bot/tests/test_self_improve_hypotheses.py
+++ b/trading_bot/tests/test_self_improve_hypotheses.py
@@ -1,0 +1,215 @@
+"""Tests for trading_bot.self_improve.hypotheses."""
+
+from __future__ import annotations
+
+import pytest
+
+from trading_bot.self_improve.hypotheses import (
+    BASELINES,
+    MAX_PROPOSALS_PER_RUN,
+    MIN_TRADES_FOR_PROPOSAL,
+    propose,
+)
+from trading_bot.self_improve.postmortem import StrategyStats
+
+
+def _stats(
+    strategy_id: str,
+    *,
+    n_trades: int = 30,
+    win_rate: float = 0.55,
+    profit_factor: float | None = 1.3,
+    total_pnl_usd: float = 50.0,
+    avg_win_usd: float = 6.0,
+    avg_loss_usd: float = -4.0,
+    avg_hold_minutes: float = 90.0,
+    exit_reason_counts: dict[str, int] | None = None,
+) -> StrategyStats:
+    return StrategyStats(
+        strategy_id=strategy_id,
+        window_days=20,
+        n_trades=n_trades,
+        win_rate=win_rate,
+        profit_factor=profit_factor,
+        total_pnl_usd=total_pnl_usd,
+        avg_win_usd=avg_win_usd,
+        avg_loss_usd=avg_loss_usd,
+        avg_hold_minutes=avg_hold_minutes,
+        exit_reason_counts=exit_reason_counts or {},
+    )
+
+
+# Realistic config snippets matching config.yaml shape.
+MR_CFG = {
+    "enabled": True,
+    "rsi_oversold": 28,
+    "atr_stop_mult": 2.0,
+    "let_winners_run": True,
+    "let_winners_run_up_pct": 0.03,
+}
+
+OD_CFG = {
+    "enabled": True,
+    "stop_loss_pct": 0.03,
+}
+
+CONFIGS = {"mean_reversion": MR_CFG, "overnight_drift": OD_CFG}
+
+
+@pytest.mark.unit
+def test_no_proposal_when_within_baseline():
+    stats = {
+        "mean_reversion": _stats(
+            "mean_reversion",
+            win_rate=0.55,
+            profit_factor=1.3,
+            exit_reason_counts={"take_profit": 12, "stop_loss": 10, "trailing_stop": 8},
+        ),
+        "overnight_drift": _stats(
+            "overnight_drift",
+            win_rate=0.6,
+            profit_factor=1.1,
+            # 3/30 = 10% stop_loss share, well below 15% trigger
+            exit_reason_counts={"take_profit": 27, "stop_loss": 3},
+        ),
+    }
+    assert propose(stats, CONFIGS) == []
+
+
+@pytest.mark.unit
+def test_no_proposal_below_min_trades():
+    stats = {
+        "mean_reversion": _stats(
+            "mean_reversion",
+            n_trades=MIN_TRADES_FOR_PROPOSAL - 1,
+            win_rate=0.10,
+            profit_factor=0.5,
+            exit_reason_counts={"stop_loss": 19},
+        ),
+    }
+    assert propose(stats, CONFIGS) == []
+
+
+@pytest.mark.unit
+def test_mr_rsi_tighten_fires_on_degraded_signal():
+    stats = {
+        "mean_reversion": _stats(
+            "mean_reversion",
+            n_trades=30,
+            # baseline WR=0.527, baseline PF=1.201
+            win_rate=0.40,         # 12.7pp below baseline
+            profit_factor=0.95,    # 79% of baseline (< 0.85)
+            exit_reason_counts={"stop_loss": 10, "take_profit": 8, "trailing_stop": 12},
+        ),
+    }
+    out = propose(stats, CONFIGS)
+    rule_ids = [p.rule_id for p in out]
+    assert "MR-RSI-TIGHTEN" in rule_ids
+    p = next(p for p in out if p.rule_id == "MR-RSI-TIGHTEN")
+    assert p.param_path == ("rsi_oversold",)
+    assert p.current_value == 28
+    assert p.proposed_value == 26
+    assert p.proposed_value < p.current_value
+
+
+@pytest.mark.unit
+def test_mr_atr_tighten_fires_on_high_stop_share():
+    stats = {
+        "mean_reversion": _stats(
+            "mean_reversion",
+            n_trades=30,
+            win_rate=0.50,
+            profit_factor=1.1,
+            exit_reason_counts={"stop_loss": 18, "take_profit": 6, "trailing_stop": 6},
+        ),
+    }
+    out = propose(stats, CONFIGS)
+    p = next(p for p in out if p.rule_id == "MR-ATR-TIGHTEN")
+    assert p.param_path == ("atr_stop_mult",)
+    assert p.proposed_value == 1.8
+
+
+@pytest.mark.unit
+def test_mr_lwr_earlier_fires_when_trail_never_engages():
+    stats = {
+        "mean_reversion": _stats(
+            "mean_reversion",
+            n_trades=30,
+            win_rate=0.55,
+            profit_factor=1.2,
+            avg_hold_minutes=40,
+            exit_reason_counts={"stop_loss": 8, "wind_down": 22},
+        ),
+    }
+    out = propose(stats, CONFIGS)
+    p = next(p for p in out if p.rule_id == "MR-LWR-EARLIER")
+    assert p.param_path == ("let_winners_run_up_pct",)
+    assert p.proposed_value < p.current_value
+    assert p.proposed_value == pytest.approx(0.024, abs=1e-4)
+
+
+@pytest.mark.unit
+def test_od_stop_tighten_fires_on_high_overnight_stop_share():
+    stats = {
+        "overnight_drift": _stats(
+            "overnight_drift",
+            n_trades=40,
+            win_rate=0.55,
+            profit_factor=1.0,
+            exit_reason_counts={"stop_loss": 8, "wind_down": 32},
+        ),
+    }
+    out = propose(stats, CONFIGS)
+    p = next(p for p in out if p.rule_id == "OD-STOP-TIGHTEN")
+    assert p.param_path == ("stop_loss_pct",)
+    assert p.proposed_value == pytest.approx(0.027, abs=1e-4)
+
+
+@pytest.mark.unit
+def test_proposals_capped():
+    """Many failure modes simultaneously — output is bounded."""
+    stats = {
+        "mean_reversion": _stats(
+            "mean_reversion",
+            n_trades=30,
+            win_rate=0.40,
+            profit_factor=0.95,
+            avg_hold_minutes=40,
+            exit_reason_counts={"stop_loss": 22, "wind_down": 8},
+        ),
+        "overnight_drift": _stats(
+            "overnight_drift",
+            n_trades=40,
+            win_rate=0.55,
+            profit_factor=1.0,
+            exit_reason_counts={"stop_loss": 10, "wind_down": 30},
+        ),
+    }
+    out = propose(stats, CONFIGS)
+    assert len(out) <= MAX_PROPOSALS_PER_RUN
+
+
+@pytest.mark.unit
+def test_unknown_strategy_skipped():
+    stats = {
+        "trend_following": _stats(
+            "trend_following",
+            n_trades=30,
+            win_rate=0.10,
+            profit_factor=0.3,
+            exit_reason_counts={"stop_loss": 27},
+        ),
+    }
+    assert propose(stats, {"trend_following": {"stop_loss_pct": 0.03}}) == []
+
+
+@pytest.mark.unit
+def test_baselines_are_documented_for_active_strategies():
+    """Guards against silently dropping a baseline for an enabled strategy."""
+    assert "mean_reversion" in BASELINES
+    assert "overnight_drift" in BASELINES
+    for sid, b in BASELINES.items():
+        assert "win_rate" in b
+        assert "profit_factor" in b
+        assert 0 < b["win_rate"] < 1
+        assert b["profit_factor"] > 0

--- a/trading_bot/tests/test_self_improve_postmortem.py
+++ b/trading_bot/tests/test_self_improve_postmortem.py
@@ -1,0 +1,189 @@
+"""Tests for trading_bot.self_improve.postmortem."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from trading_bot.self_improve.postmortem import (
+    StrategyStats,
+    compute_window_stats,
+    summarize_all,
+)
+
+
+def _insert_trade(
+    conn,
+    *,
+    ticker: str = "SPY",
+    strategy_id: str = "mean_reversion",
+    entry_time: datetime,
+    exit_time: datetime | None,
+    exit_reason: str | None,
+    net_pnl: float | None,
+    quantity: int = 10,
+    entry_price: float = 100.0,
+    exit_price: float | None = 101.0,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO trades (
+            ticker, exchange, currency, side, entry_time, entry_price,
+            quantity, exit_time, exit_price, exit_reason,
+            gross_pnl, net_pnl, hold_type, phase, strategy_id
+        )
+        VALUES (?, 'NASDAQ', 'USD', 'long', ?, ?, ?, ?, ?, ?, ?, ?, 'intraday', 1, ?)
+        """,
+        (
+            ticker,
+            entry_time.strftime("%Y-%m-%d %H:%M:%S"),
+            entry_price,
+            quantity,
+            exit_time.strftime("%Y-%m-%d %H:%M:%S") if exit_time else None,
+            exit_price,
+            exit_reason,
+            net_pnl,
+            net_pnl,
+            strategy_id,
+        ),
+    )
+    conn.commit()
+
+
+@pytest.mark.unit
+def test_empty_window_returns_zero_stats(tmp_db):
+    stats = compute_window_stats(tmp_db, "mean_reversion", window_days=20)
+    assert stats.n_trades == 0
+    assert stats.win_rate == 0.0
+    assert stats.profit_factor is None
+    assert stats.total_pnl_usd == 0.0
+
+
+@pytest.mark.unit
+def test_open_trades_excluded(tmp_db):
+    now = datetime.now(timezone.utc)
+    _insert_trade(
+        tmp_db,
+        entry_time=now - timedelta(hours=2),
+        exit_time=None,
+        exit_reason=None,
+        net_pnl=None,
+    )
+    stats = compute_window_stats(tmp_db, "mean_reversion", window_days=20)
+    assert stats.n_trades == 0
+
+
+@pytest.mark.unit
+def test_trades_outside_window_excluded(tmp_db):
+    now = datetime.now(timezone.utc)
+    old = now - timedelta(days=40)
+    _insert_trade(
+        tmp_db,
+        entry_time=old,
+        exit_time=old + timedelta(minutes=30),
+        exit_reason="take_profit",
+        net_pnl=10.0,
+    )
+    stats = compute_window_stats(tmp_db, "mean_reversion", window_days=20)
+    assert stats.n_trades == 0
+
+
+@pytest.mark.unit
+def test_stats_aggregate_correctly(tmp_db):
+    now = datetime.now(timezone.utc)
+    base = now - timedelta(days=5)
+    # 2 wins (+12, +8), 2 losses (-10, -4)
+    for i, (pnl, reason, hold_min) in enumerate([
+        (12.0, "trailing_stop", 60),
+        (8.0, "take_profit", 30),
+        (-10.0, "stop_loss", 15),
+        (-4.0, "wind_down", 90),
+    ]):
+        entry = base + timedelta(hours=i)
+        _insert_trade(
+            tmp_db,
+            entry_time=entry,
+            exit_time=entry + timedelta(minutes=hold_min),
+            exit_reason=reason,
+            net_pnl=pnl,
+        )
+
+    stats = compute_window_stats(tmp_db, "mean_reversion", window_days=20)
+    assert stats.n_trades == 4
+    assert stats.win_rate == 0.5
+    assert stats.total_pnl_usd == pytest.approx(6.0)
+    assert stats.avg_win_usd == pytest.approx(10.0)
+    assert stats.avg_loss_usd == pytest.approx(-7.0)
+    # PF = wins / |losses| = 20 / 14
+    assert stats.profit_factor == pytest.approx(20 / 14)
+    assert stats.exit_share("stop_loss") == 0.25
+    assert stats.exit_share("take_profit") == 0.25
+    assert stats.exit_share("nonexistent") == 0.0
+    assert stats.avg_hold_minutes == pytest.approx((60 + 30 + 15 + 90) / 4)
+
+
+@pytest.mark.unit
+def test_profit_factor_when_only_wins(tmp_db):
+    now = datetime.now(timezone.utc)
+    base = now - timedelta(days=2)
+    _insert_trade(
+        tmp_db,
+        entry_time=base,
+        exit_time=base + timedelta(minutes=30),
+        exit_reason="take_profit",
+        net_pnl=5.0,
+    )
+    stats = compute_window_stats(tmp_db, "mean_reversion", window_days=20)
+    assert stats.profit_factor == float("inf")
+
+
+@pytest.mark.unit
+def test_summarize_all_partitions_by_strategy(tmp_db):
+    now = datetime.now(timezone.utc)
+    base = now - timedelta(days=1)
+    _insert_trade(
+        tmp_db,
+        entry_time=base,
+        exit_time=base + timedelta(minutes=10),
+        exit_reason="take_profit",
+        net_pnl=5.0,
+        strategy_id="mean_reversion",
+    )
+    _insert_trade(
+        tmp_db,
+        entry_time=base,
+        exit_time=base + timedelta(hours=18),
+        exit_reason="stop_loss",
+        net_pnl=-3.0,
+        strategy_id="overnight_drift",
+    )
+    out = summarize_all(
+        tmp_db, ["mean_reversion", "overnight_drift", "trend_following"], 20,
+    )
+    assert out["mean_reversion"].n_trades == 1
+    assert out["overnight_drift"].n_trades == 1
+    assert out["trend_following"].n_trades == 0
+
+
+@pytest.mark.unit
+def test_invalid_window_raises(tmp_db):
+    with pytest.raises(ValueError):
+        compute_window_stats(tmp_db, "mean_reversion", window_days=0)
+
+
+@pytest.mark.unit
+def test_stats_dataclass_is_immutable():
+    s = StrategyStats(
+        strategy_id="x",
+        window_days=10,
+        n_trades=0,
+        win_rate=0.0,
+        profit_factor=None,
+        total_pnl_usd=0.0,
+        avg_win_usd=0.0,
+        avg_loss_usd=0.0,
+        avg_hold_minutes=0.0,
+    )
+    with pytest.raises(Exception):
+        s.n_trades = 5  # type: ignore[misc]

--- a/trading_bot/tests/test_self_improve_report.py
+++ b/trading_bot/tests/test_self_improve_report.py
@@ -1,0 +1,140 @@
+"""Smoke tests for trading_bot.self_improve.report rendering."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from trading_bot.self_improve.backtest_gate import BacktestComparison, StrategyMetrics
+from trading_bot.self_improve.hypotheses import Proposal
+from trading_bot.self_improve.postmortem import StrategyStats
+from trading_bot.self_improve.report import render_markdown
+
+
+def _stats(strategy_id: str, **kw) -> StrategyStats:
+    defaults = dict(
+        window_days=20,
+        n_trades=30,
+        win_rate=0.55,
+        profit_factor=1.3,
+        total_pnl_usd=42.0,
+        avg_win_usd=6.0,
+        avg_loss_usd=-4.0,
+        avg_hold_minutes=45.0,
+        exit_reason_counts={"take_profit": 10, "stop_loss": 8, "trailing_stop": 12},
+    )
+    defaults.update(kw)
+    return StrategyStats(strategy_id=strategy_id, **defaults)
+
+
+def _metrics(sid: str, **kw) -> StrategyMetrics:
+    defaults = dict(
+        n_trades=50, return_pct=5.0, max_drawdown_pct=4.0,
+        win_rate=0.55, profit_factor=1.3, sharpe_approx=0.5, total_pnl_usd=125.0,
+    )
+    defaults.update(kw)
+    return StrategyMetrics(strategy_id=sid, **defaults)
+
+
+@pytest.mark.unit
+def test_render_with_no_proposals_is_explicit():
+    md = render_markdown(
+        report_date=date(2026, 4, 30),
+        window_days=20,
+        stats_by_strategy={"mean_reversion": _stats("mean_reversion")},
+        proposals=[],
+        comparisons=[],
+    )
+    assert "Self-improvement review — 2026-04-30" in md
+    assert "No rule fired" in md
+    assert "mean_reversion" in md
+
+
+@pytest.mark.unit
+def test_render_with_passing_proposal_includes_patch_block():
+    proposal = Proposal(
+        rule_id="MR-RSI-TIGHTEN",
+        strategy_id="mean_reversion",
+        param_path=("rsi_oversold",),
+        current_value=28,
+        proposed_value=26,
+        rationale="signal degraded",
+        evidence={"n_trades": 30, "win_rate": 0.40},
+    )
+    comp = BacktestComparison(
+        proposal=proposal,
+        baseline=_metrics("mean_reversion", sharpe_approx=0.5, return_pct=5.0),
+        candidate=_metrics("mean_reversion", sharpe_approx=0.6, return_pct=6.0),
+        passed=True,
+        reason="sharpe +0.10, drawdown +0.00pp, return +1.00pp",
+    )
+    md = render_markdown(
+        report_date=date(2026, 4, 30),
+        window_days=20,
+        stats_by_strategy={"mean_reversion": _stats("mean_reversion")},
+        proposals=[proposal],
+        comparisons=[comp],
+        backtest_window=(date(2026, 1, 1), date(2026, 4, 1)),
+        backtest_universe=["SPY", "QQQ"],
+    )
+    assert "[PASS]" in md
+    assert "Suggested patch" in md
+    assert "rsi_oversold: 26" in md
+    assert "was 28" in md
+    assert "Backtest window: 2026-01-01 to 2026-04-01" in md
+    assert "SPY, QQQ" in md
+
+
+@pytest.mark.unit
+def test_render_with_failing_proposal_omits_patch_block():
+    proposal = Proposal(
+        rule_id="MR-RSI-TIGHTEN",
+        strategy_id="mean_reversion",
+        param_path=("rsi_oversold",),
+        current_value=28,
+        proposed_value=26,
+        rationale="signal degraded",
+        evidence={"n_trades": 30},
+    )
+    comp = BacktestComparison(
+        proposal=proposal,
+        baseline=_metrics("mean_reversion", sharpe_approx=0.6),
+        candidate=_metrics("mean_reversion", sharpe_approx=0.3),
+        passed=False,
+        reason="Sharpe dropped -0.30",
+    )
+    md = render_markdown(
+        report_date=date(2026, 4, 30),
+        window_days=20,
+        stats_by_strategy={"mean_reversion": _stats("mean_reversion")},
+        proposals=[proposal],
+        comparisons=[comp],
+    )
+    assert "[FAIL]" in md
+    assert "Suggested patch" not in md
+
+
+@pytest.mark.unit
+def test_render_handles_zero_trade_strategy():
+    md = render_markdown(
+        report_date=date(2026, 4, 30),
+        window_days=20,
+        stats_by_strategy={
+            "overnight_drift": _stats(
+                "overnight_drift",
+                n_trades=0,
+                win_rate=0.0,
+                profit_factor=None,
+                total_pnl_usd=0.0,
+                avg_win_usd=0.0,
+                avg_loss_usd=0.0,
+                avg_hold_minutes=0.0,
+                exit_reason_counts={},
+            ),
+        },
+        proposals=[],
+        comparisons=[],
+    )
+    assert "no closed trades in window" in md
+    assert "n/a" in md  # PF rendered as n/a


### PR DESCRIPTION
## Summary

- New `trading_bot/self_improve/` module — research-only agent that runs after market close, computes a postmortem from recent closed trades, generates rule-based config-tweak proposals, and validates each via in-process A/B backtest. Writes a markdown report under `self_improve_reports/`. **Never edits `config.yaml`** — patches are advisory.
- New `.github/workflows/daily-review.yml` — workflow_dispatch only (cron deliberately disabled until data layer is fixed; see follow-up doc).
- New `python -m trading_bot.self_improve.backfill_cli` — one-shot tool to reconstruct closed-trade rows from Alpaca order history, paired with positions by Alpaca order id and idempotent via a `notes` marker.
- New `docs/self_improve_followups.md` — captures two real bugs we found in the live bot's data layer while building this. Calls out specific code locations + investigation starting points so a fresh session can pick up cold.

## What this PR is not

The cron is **disabled**. While testing against the GHA-cached SQLite we discovered the live bot is not currently persisting closed trades correctly:

- `trades` table: 54 rows, all with `strategy_id`, `exit_time`, `exit_reason`, `net_pnl` = NULL.
- `positions` table: 52 rows marked `CLOSED` but Alpaca shows only 3 actual SELL fills (all from before the DB entries even exist).
- 3 actual open positions on Alpaca (including a QQQ short) the bot does not appear to be managing.

So the agent ships **code-complete and well-tested but not yet useful** — its postmortem will return zero trades against the current DB. That's the right outcome: the agent is correctly reporting on what it sees. The data layer is the blocker, and that's the work for the next branch.

## Tests

- 44 new tests across 4 files (postmortem, hypotheses, backtest gate, report renderer, alpaca backfill). All pass.
- Pre-existing failures in `test_reporting_and_ops.py::test_daily_metrics_*` (3) are unrelated — verified on `main`.

## Test plan

- [ ] `python3 -m pytest trading_bot/tests/test_self_improve_*.py -q` → 44 passed
- [ ] `python3 -m trading_bot.self_improve --dry-run --bt-from 2026-04-01 --bt-to 2026-04-29 --window-days 20` runs cleanly against an empty DB
- [ ] `gh workflow run daily-review.yml` (manual trigger) produces an empty report (until data layer fixed)
- [ ] Re-enable cron in `daily-review.yml` only after `docs/self_improve_followups.md` tasks #2 + #3 are resolved

## Follow-ups

See `docs/self_improve_followups.md`. Next session will build a read-only reconciliation report against your live Alpaca paper account before any data-layer mutation, on a fresh branch off `main`.