### PR TITLE
fix: data-layer cleanup — reconcile + ENTRY_FAILED migration + 5 live order fixes

### DIFF
--- a/self_improve_reports/reconcile_2026-04-29.md
+++ b/self_improve_reports/reconcile_2026-04-29.md
@@ -1,0 +1,391 @@
+# Reconciliation report — local DB vs Alpaca
+
+_Generated 2026-04-29T23:05:22.718765+00:00 — account `PA3WZLD8NYB2` (paper)_
+
+- DB path: `/tmp/gha_cached.db`
+- Window: `2026-03-01` to `2026-04-29`
+- Alpaca positions: **3** • Alpaca orders in window: **36**
+- DB rows scanned: positions=**55**, trades=**54**
+
+- Strategy enabled map: `breakout`=off, `mean_reversion`=on, `overnight_drift`=on, `sentiment_combo`=off, `trend_following`=off
+
+## Summary
+
+### Positions
+
+| Classification | Count |
+|---|---|
+| ACTUAL_OPEN | 0 |
+| MISMATCH_QTY | 0 |
+| ORPHAN_DISABLED | 2 |
+| ORPHAN_UNKNOWN | 1 |
+| ORPHAN_NOT_HELD | 0 |
+| ACTUAL_FILL | 0 |
+| PHANTOM_CLOSE | 52 |
+| CLOSED_NO_EXIT | 0 |
+
+### Trades
+
+| Classification | Count |
+|---|---|
+| ENTRY_ONLY_PHANTOM | 54 |
+| MISSING_STRATEGY | 0 |
+| MISSING_EXIT | 0 |
+| COMPLETE | 0 |
+
+## Bug-hypothesis confirmation
+
+Counts above map directly to the data-layer bugs in [docs/self_improve_followups.md](../docs/self_improve_followups.md):
+
+1. **trades.strategy_id NULL on entry** — 54 ENTRY_ONLY_PHANTOM rows. Confirms `_create_position_record` (order_manager.py:868) inserts trades without strategy_id.
+2. **trades exit UPDATE never matches** — 0 MISSING_EXIT rows. Confirms `_close_position` (order_manager.py:802) uses positions.id as the trades WHERE clause.
+3. **Phantom CLOSED on canceled entry** — 52 PHANTOM_CLOSE rows. Confirms entry-timeout / submit-error paths stamp positions CLOSED without an actual fill ever existing.
+4. **Orphans on disabled strategies** — 2 ORPHAN_DISABLED + 1 ORPHAN_UNKNOWN open rows that no live tick code is managing.
+5. **DB/Alpaca quantity drift** — 0 MISMATCH_QTY + 0 ORPHAN_NOT_HELD rows where the DB believes one thing and Alpaca believes another.
+
+## Position findings
+
+### ORPHAN_DISABLED (2)
+
+- **id=2** `SPY` strategy=`breakout` qty=1 status=`STOP_AND_TARGET_ACTIVE` entry_time=`2026-04-27T15:40:26.335519-04:00`
+  - Evidence: strategy_id='breakout' is disabled in config; alpaca_holds=yes, db_qty=1
+  - Action: Adopt-and-flatten: re-enable the strategy long enough for the next tick to manage out, OR add an orphan-handler that takes ownership at tick time. Do not edit the DB until cash is reconciled.
+- **id=4** `XLRE` strategy=`trend_following` qty=20 status=`STOP_AND_TARGET_ACTIVE` entry_time=`2026-04-28T09:40:40.758560-04:00`
+  - Evidence: strategy_id='trend_following' is disabled in config; alpaca_holds=yes, db_qty=20
+  - Action: Adopt-and-flatten: re-enable the strategy long enough for the next tick to manage out, OR add an orphan-handler that takes ownership at tick time. Do not edit the DB until cash is reconciled.
+
+### ORPHAN_UNKNOWN (1)
+
+- **id=1** `QQQ` strategy=`unknown` qty=-1 status=`POSITION_OPEN` entry_time=`2026-04-27T10:26:29.851781-04:00`
+  - Evidence: strategy_id='unknown'; alpaca_holds=yes
+  - Action: Manual review required — no strategy means no exit policy. Inspect Alpaca for matching symbol; if held, adopt under a fallback strategy and place a manual exit. If not held, mark CLOSED with exit_reason='reconciliation_mismatch'.
+
+### PHANTOM_CLOSE (52)
+
+- **id=3** `XLP` strategy=`mean_reversion` qty=6.0062 status=`CLOSED` entry_time=`2026-04-27T15:40:29.122150-04:00`
+  - Evidence: No BUY fill found on Alpaca within +/-6h of entry_time=2026-04-27T15:40:29.122150-04:00; alpaca_order_id=None
+  - Action: Confirm with Alpaca that the entry never filled. If so, the position row is correct as CLOSED but the trades row should be deleted (or marked exit_reason='entry_canceled', net_pnl=0). Live fix: don't insert a trades row until entry fill confirms.
+- **id=5** `SPY` strategy=`overnight_drift` qty=1.3384 status=`CLOSED` entry_time=`2026-04-28T11:45:35.838930-04:00`
+  - Evidence: No BUY fill found on Alpaca within +/-6h of entry_time=2026-04-28T11:45:35.838930-04:00; alpaca_order_id=None
+  - Action: Confirm with Alpaca that the entry never filled. If so, the position row is correct as CLOSED but the trades row should be deleted (or marked exit_reason='entry_canceled', net_pnl=0). Live fix: don't insert a trades row until entry fill confirms.
+- **id=6** `QQQ` strategy=`overnight_drift` qty=1.4518 status=`CLOSED` entry_time=`2026-04-28T11:45:35.917916-04:00`
+  - Evidence: No BUY fill found on Alpaca within +/-6h of entry_time=2026-04-28T11:45:35.917916-04:00; alpaca_order_id=None
+  - Action: Confirm with Alpaca that the entry never filled. If so, the position row is correct as CLOSED but the trades row should be deleted (or marked exit_reason='entry_canceled', net_pnl=0). Live fix: don't insert a trades row until entry fill confirms.
+- **id=7** `XLK` strategy=`overnight_drift` qty=6.0689 status=`CLOSED` entry_time=`2026-04-28T11:45:36.019290-04:00`
+  - Evidence: No BUY fill found on Alpaca within +/-6h of entry_time=2026-04-28T11:45:36.019290-04:00; alpaca_order_id=None
+  - Action: Confirm with Alpaca that the entry never filled. If so, the position row is correct as CLOSED but the trades row should be deleted (or marked exit_reason='entry_canceled', net_pnl=0). Live fix: don't insert a trades row until entry fill confirms.
+- **id=8** `XLF` strategy=`overnight_drift` qty=18.2429 status=`CLOSED` entry_time=`2026-04-28T11:45:36.095265-04:00`
+  - Evidence: No BUY fill found on Alpaca within +/-6h of entry_time=2026-04-28T11:45:36.095265-04:00; alpaca_order_id=None
+  - Action: Confirm with Alpaca that the entry never filled. If so, the position row is correct as CLOSED but the trades row should be deleted (or marked exit_reason='entry_canceled', net_pnl=0). Live fix: don't insert a trades row until entry fill confirms.
+- **id=9** `XLV` strategy=`overnight_drift` qty=6.589 status=`CLOSED` entry_time=`2026-04-28T11:45:36.177810-04:00`
+  - Evidence: No BUY fill found on Alpaca within +/-6h of entry_time=2026-04-28T11:45:36.177810-04:00; alpaca_order_id=None
+  - Action: Confirm with Alpaca that the entry never filled. If so, the position row is correct as CLOSED but the trades row should be deleted (or marked exit_reason='entry_canceled', net_pnl=0). Live fix: don't insert a trades row until entry fill confirms.
+- **id=10** `XLY` strategy=`overnight_drift` qty=8.1193 status=`CLOSED` entry_time=`2026-04-28T11:45:36.281749-04:00`
+  - Evidence: No BUY fill found on Alpaca within +/-6h of entry_time=2026-04-28T11:45:36.281749-04:00; alpaca_order_id=None
+  - Action: Confirm with Alpaca that the entry never filled. If so, the position row is correct as CLOSED but the trades row should be deleted (or marked exit_reason='entry_canceled', net_pnl=0). Live fix: don't insert a trades row until entry fill confirms.
+- **id=11** `XLP` strategy=`overnight_drift` qty=11.3834 status=`CLOSED` entry_time=`2026-04-28T11:45:36.349008-04:00`
+  - Evidence: No BUY fill found on Alpaca within +/-6h of entry_time=2026-04-28T11:45:36.349008-04:00; alpaca_order_id=None
+  - Action: Confirm with Alpaca that the entry never filled. If so, the position row is correct as CLOSED but the trades row should be deleted (or marked exit_reason='entry_canceled', net_pnl=0). Live fix: don't insert a trades row until entry fill confirms.
+- **id=12** `XLE` strategy=`overnight_drift` qty=16.3807 status=`CLOSED` entry_time=`2026-04-28T11:45:36.427872-04:00`
+  - Evidence: No BUY fill found on Alpaca within +/-6h of entry_time=2026-04-28T11:45:36.427872-04:00; alpaca_order_id=None
+  - Action: Confirm with Alpaca that the entry never filled. If so, the position row is correct as CLOSED but the trades row should be deleted (or marked exit_reason='entry_canceled', net_pnl=0). Live fix: don't insert a trades row until entry fill confirms.
+- **id=13** `XLI` strategy=`overnight_drift` qty=5.5835 status=`CLOSED` entry_time=`2026-04-28T11:45:36.513547-04:00`
+  - Evidence: No BUY fill found on Alpaca within +/-6h of entry_time=2026-04-28T11:45:36.513547-04:00; alpaca_order_id=None
+  - Action: Confirm with Alpaca that the entry never filled. If so, the position row is correct as CLOSED but the trades row should be deleted (or marked exit_reason='entry_canceled', net_pnl=0). Live fix: don't insert a trades row until entry fill confirms.
+- **id=14** `XLB` strategy=`overnight_drift` qty=18.5348 status=`CLOSED` entry_time=`2026-04-28T11:45:36.623219-04:00`
+  - Evidence: No BUY fill found on Alpaca within +/-6h of entry_time=2026-04-28T11:45:36.623219-04:00; alpaca_order_id=None
+  - Action: Confirm with Alpaca that the entry never filled. If so, the position row is correct as CLOSED but the trades row should be deleted (or marked exit_reason='entry_canceled', net_pnl=0). Live fix: don't insert a trades row until entry fill confirms.
+- **id=15** `XLU` strategy=`overnight_drift` qty=20.494 status=`CLOSED` entry_time=`2026-04-28T11:45:36.712368-04:00`
+  - Evidence: No BUY fill found on Alpaca within +/-6h of entry_time=2026-04-28T11:45:36.712368-04:00; alpaca_order_id=None
+  - Action: Confirm with Alpaca that the entry never filled. If so, the position row is correct as CLOSED but the trades row should be deleted (or marked exit_reason='entry_canceled', net_pnl=0). Live fix: don't insert a trades row until entry fill confirms.
+- **id=16** `XLRE` strategy=`overnight_drift` qty=21.7118 status=`CLOSED` entry_time=`2026-04-28T11:45:36.782613-04:00`
+  - Evidence: No BUY fill found on Alpaca within +/-6h of entry_time=2026-04-28T11:45:36.782613-04:00; alpaca_order_id=None
+  - Action: Confirm with Alpaca that the entry never filled. If so, the position row is correct as CLOSED but the trades row should be deleted (or marked exit_reason='entry_canceled', net_pnl=0). Live fix: don't insert a trades row until entry fill confirms.
+- **id=17** `XLC` strategy=`overnight_drift` qty=8.2223 status=`CLOSED` entry_time=`2026-04-28T11:45:36.858886-04:00`
+  - Evidence: No BUY fill found on Alpaca within +/-6h of entry_time=2026-04-28T11:45:36.858886-04:00; alpaca_order_id=None
+  - Action: Confirm with Alpaca that the entry never filled. If so, the position row is correct as CLOSED but the trades row should be deleted (or marked exit_reason='entry_canceled', net_pnl=0). Live fix: don't insert a trades row until entry fill confirms.
+- **id=18** `SPY` strategy=`overnight_drift` qty=1.3387 status=`CLOSED` entry_time=`2026-04-28T11:50:38.882260-04:00`
+  - Evidence: No BUY fill found on Alpaca within +/-6h of entry_time=2026-04-28T11:50:38.882260-04:00; alpaca_order_id=None
+  - Action: Confirm with Alpaca that the entry never filled. If so, the position row is correct as CLOSED but the trades row should be deleted (or marked exit_reason='entry_canceled', net_pnl=0). Live fix: don't insert a trades row until entry fill confirms.
+- **id=19** `QQQ` strategy=`overnight_drift` qty=1.4524 status=`CLOSED` entry_time=`2026-04-28T11:50:39.929115-04:00`
+  - Evidence: No BUY fill found on Alpaca within +/-6h of entry_time=2026-04-28T11:50:39.929115-04:00; alpaca_order_id=None
+  - Action: Confirm with Alpaca that the entry never filled. If so, the position row is correct as CLOSED but the trades row should be deleted (or marked exit_reason='entry_canceled', net_pnl=0). Live fix: don't insert a trades row until entry fill confirms.
+- **id=20** `XLK` strategy=`overnight_drift` qty=6.0734 status=`CLOSED` entry_time=`2026-04-28T11:50:40.461069-04:00`
+  - Evidence: No BUY fill found on Alpaca within +/-6h of entry_time=2026-04-28T11:50:40.461069-04:00; alpaca_order_id=None
+  - Action: Confirm with Alpaca that the entry never filled. If so, the position row is correct as CLOSED but the trades row should be deleted (or marked exit_reason='entry_canceled', net_pnl=0). Live fix: don't insert a trades row until entry fill confirms.
+- **id=21** `XLF` strategy=`overnight_drift` qty=18.2359 status=`CLOSED` entry_time=`2026-04-28T11:50:41.206896-04:00`
+  - Evidence: No BUY fill found on Alpaca within +/-6h of entry_time=2026-04-28T11:50:41.206896-04:00; alpaca_order_id=None
+  - Action: Confirm with Alpaca that the entry never filled. If so, the position row is correct as CLOSED but the trades row should be deleted (or marked exit_reason='entry_canceled', net_pnl=0). Live fix: don't insert a trades row until entry fill confirms.
+- **id=22** `XLV` strategy=`overnight_drift` qty=6.5872 status=`CLOSED` entry_time=`2026-04-28T11:50:41.922859-04:00`
+  - Evidence: No BUY fill found on Alpaca within +/-6h of entry_time=2026-04-28T11:50:41.922859-04:00; alpaca_order_id=None
+  - Action: Confirm with Alpaca that the entry never filled. If so, the position row is correct as CLOSED but the trades row should be deleted (or marked exit_reason='entry_canceled', net_pnl=0). Live fix: don't insert a trades row until entry fill confirms.
+- **id=23** `XLY` strategy=`overnight_drift` qty=8.12 status=`CLOSED` entry_time=`2026-04-28T11:50:42.865931-04:00`
+  - Evidence: No BUY fill found on Alpaca within +/-6h of entry_time=2026-04-28T11:50:42.865931-04:00; alpaca_order_id=None
+  - Action: Confirm with Alpaca that the entry never filled. If so, the position row is correct as CLOSED but the trades row should be deleted (or marked exit_reason='entry_canceled', net_pnl=0). Live fix: don't insert a trades row until entry fill confirms.
+- **id=24** `XLP` strategy=`overnight_drift` qty=11.3759 status=`CLOSED` entry_time=`2026-04-28T11:50:43.425341-04:00`
+  - Evidence: No BUY fill found on Alpaca within +/-6h of entry_time=2026-04-28T11:50:43.425341-04:00; alpaca_order_id=None
+  - Action: Confirm with Alpaca that the entry never filled. If so, the position row is correct as CLOSED but the trades row should be deleted (or marked exit_reason='entry_canceled', net_pnl=0). Live fix: don't insert a trades row until entry fill confirms.
+- **id=25** `XLE` strategy=`overnight_drift` qty=16.3892 status=`CLOSED` entry_time=`2026-04-28T11:50:44.318501-04:00`
+  - Evidence: No BUY fill found on Alpaca within +/-6h of entry_time=2026-04-28T11:50:44.318501-04:00; alpaca_order_id=None
+  - Action: Confirm with Alpaca that the entry never filled. If so, the position row is correct as CLOSED but the trades row should be deleted (or marked exit_reason='entry_canceled', net_pnl=0). Live fix: don't insert a trades row until entry fill confirms.
+- **id=26** `XLI` strategy=`overnight_drift` qty=5.5846 status=`CLOSED` entry_time=`2026-04-28T11:50:45.133668-04:00`
+  - Evidence: No BUY fill found on Alpaca within +/-6h of entry_time=2026-04-28T11:50:45.133668-04:00; alpaca_order_id=None
+  - Action: Confirm with Alpaca that the entry never filled. If so, the position row is correct as CLOSED but the trades row should be deleted (or marked exit_reason='entry_canceled', net_pnl=0). Live fix: don't insert a trades row until entry fill confirms.
+- **id=27** `XLB` strategy=`overnight_drift` qty=18.5239 status=`CLOSED` entry_time=`2026-04-28T11:50:45.934262-04:00`
+  - Evidence: No BUY fill found on Alpaca within +/-6h of entry_time=2026-04-28T11:50:45.934262-04:00; alpaca_order_id=None
+  - Action: Confirm with Alpaca that the entry never filled. If so, the position row is correct as CLOSED but the trades row should be deleted (or marked exit_reason='entry_canceled', net_pnl=0). Live fix: don't insert a trades row until entry fill confirms.
+- **id=28** `XLU` strategy=`overnight_drift` qty=20.483 status=`CLOSED` entry_time=`2026-04-28T11:50:46.663838-04:00`
+  - Evidence: No BUY fill found on Alpaca within +/-6h of entry_time=2026-04-28T11:50:46.663838-04:00; alpaca_order_id=None
+  - Action: Confirm with Alpaca that the entry never filled. If so, the position row is correct as CLOSED but the trades row should be deleted (or marked exit_reason='entry_canceled', net_pnl=0). Live fix: don't insert a trades row until entry fill confirms.
+- **id=29** `XLRE` strategy=`overnight_drift` qty=21.7044 status=`CLOSED` entry_time=`2026-04-28T11:50:48.031049-04:00`
+  - Evidence: No BUY fill found on Alpaca within +/-6h of entry_time=2026-04-28T11:50:48.031049-04:00; alpaca_order_id=None
+  - Action: Confirm with Alpaca that the entry never filled. If so, the position row is correct as CLOSED but the trades row should be deleted (or marked exit_reason='entry_canceled', net_pnl=0). Live fix: don't insert a trades row until entry fill confirms.
+- **id=30** `XLC` strategy=`overnight_drift` qty=8.2201 status=`CLOSED` entry_time=`2026-04-28T11:50:48.454421-04:00`
+  - Evidence: No BUY fill found on Alpaca within +/-6h of entry_time=2026-04-28T11:50:48.454421-04:00; alpaca_order_id=None
+  - Action: Confirm with Alpaca that the entry never filled. If so, the position row is correct as CLOSED but the trades row should be deleted (or marked exit_reason='entry_canceled', net_pnl=0). Live fix: don't insert a trades row until entry fill confirms.
+- **id=31** `XLY` strategy=`mean_reversion` qty=4.2435 status=`CLOSED` entry_time=`2026-04-29T10:05:37.051283-04:00`
+  - Evidence: No BUY fill found on Alpaca within +/-6h of entry_time=2026-04-29T10:05:37.051283-04:00; alpaca_order_id=None
+  - Action: Confirm with Alpaca that the entry never filled. If so, the position row is correct as CLOSED but the trades row should be deleted (or marked exit_reason='entry_canceled', net_pnl=0). Live fix: don't insert a trades row until entry fill confirms.
+- **id=32** `SPY` strategy=`overnight_drift` qty=1.1042 status=`CLOSED` entry_time=`2026-04-29T11:45:41.968800-04:00`
+  - Evidence: No BUY fill found on Alpaca within +/-6h of entry_time=2026-04-29T11:45:41.968800-04:00; alpaca_order_id=None
+  - Action: Confirm with Alpaca that the entry never filled. If so, the position row is correct as CLOSED but the trades row should be deleted (or marked exit_reason='entry_canceled', net_pnl=0). Live fix: don't insert a trades row until entry fill confirms.
+- **id=33** `QQQ` strategy=`overnight_drift` qty=1.4382 status=`CLOSED` entry_time=`2026-04-29T11:45:42.156196-04:00`
+  - Evidence: No BUY fill found on Alpaca within +/-6h of entry_time=2026-04-29T11:45:42.156196-04:00; alpaca_order_id=None
+  - Action: Confirm with Alpaca that the entry never filled. If so, the position row is correct as CLOSED but the trades row should be deleted (or marked exit_reason='entry_canceled', net_pnl=0). Live fix: don't insert a trades row until entry fill confirms.
+- **id=34** `XLK` strategy=`overnight_drift` qty=5.5115 status=`CLOSED` entry_time=`2026-04-29T11:45:42.235559-04:00`
+  - Evidence: No BUY fill found on Alpaca within +/-6h of entry_time=2026-04-29T11:45:42.235559-04:00; alpaca_order_id=None
+  - Action: Confirm with Alpaca that the entry never filled. If so, the position row is correct as CLOSED but the trades row should be deleted (or marked exit_reason='entry_canceled', net_pnl=0). Live fix: don't insert a trades row until entry fill confirms.
+- **id=35** `XLF` strategy=`overnight_drift` qty=16.8772 status=`CLOSED` entry_time=`2026-04-29T11:45:42.318292-04:00`
+  - Evidence: No BUY fill found on Alpaca within +/-6h of entry_time=2026-04-29T11:45:42.318292-04:00; alpaca_order_id=None
+  - Action: Confirm with Alpaca that the entry never filled. If so, the position row is correct as CLOSED but the trades row should be deleted (or marked exit_reason='entry_canceled', net_pnl=0). Live fix: don't insert a trades row until entry fill confirms.
+- **id=36** `XLV` strategy=`overnight_drift` qty=6.1324 status=`CLOSED` entry_time=`2026-04-29T11:45:42.408252-04:00`
+  - Evidence: No BUY fill found on Alpaca within +/-6h of entry_time=2026-04-29T11:45:42.408252-04:00; alpaca_order_id=None
+  - Action: Confirm with Alpaca that the entry never filled. If so, the position row is correct as CLOSED but the trades row should be deleted (or marked exit_reason='entry_canceled', net_pnl=0). Live fix: don't insert a trades row until entry fill confirms.
+- **id=37** `XLY` strategy=`overnight_drift` qty=6.421 status=`CLOSED` entry_time=`2026-04-29T11:45:42.523013-04:00`
+  - Evidence: No BUY fill found on Alpaca within +/-6h of entry_time=2026-04-29T11:45:42.523013-04:00; alpaca_order_id=None
+  - Action: Confirm with Alpaca that the entry never filled. If so, the position row is correct as CLOSED but the trades row should be deleted (or marked exit_reason='entry_canceled', net_pnl=0). Live fix: don't insert a trades row until entry fill confirms.
+- **id=38** `XLP` strategy=`overnight_drift` qty=9.0717 status=`CLOSED` entry_time=`2026-04-29T11:45:42.619917-04:00`
+  - Evidence: No BUY fill found on Alpaca within +/-6h of entry_time=2026-04-29T11:45:42.619917-04:00; alpaca_order_id=None
+  - Action: Confirm with Alpaca that the entry never filled. If so, the position row is correct as CLOSED but the trades row should be deleted (or marked exit_reason='entry_canceled', net_pnl=0). Live fix: don't insert a trades row until entry fill confirms.
+- **id=39** `XLE` strategy=`overnight_drift` qty=12.8172 status=`CLOSED` entry_time=`2026-04-29T11:45:42.708201-04:00`
+  - Evidence: No BUY fill found on Alpaca within +/-6h of entry_time=2026-04-29T11:45:42.708201-04:00; alpaca_order_id=None
+  - Action: Confirm with Alpaca that the entry never filled. If so, the position row is correct as CLOSED but the trades row should be deleted (or marked exit_reason='entry_canceled', net_pnl=0). Live fix: don't insert a trades row until entry fill confirms.
+- **id=40** `XLI` strategy=`overnight_drift` qty=4.4266 status=`CLOSED` entry_time=`2026-04-29T11:45:42.798016-04:00`
+  - Evidence: No BUY fill found on Alpaca within +/-6h of entry_time=2026-04-29T11:45:42.798016-04:00; alpaca_order_id=None
+  - Action: Confirm with Alpaca that the entry never filled. If so, the position row is correct as CLOSED but the trades row should be deleted (or marked exit_reason='entry_canceled', net_pnl=0). Live fix: don't insert a trades row until entry fill confirms.
+- **id=41** `XLB` strategy=`overnight_drift` qty=12.2513 status=`CLOSED` entry_time=`2026-04-29T11:45:42.883221-04:00`
+  - Evidence: No BUY fill found on Alpaca within +/-6h of entry_time=2026-04-29T11:45:42.883221-04:00; alpaca_order_id=None
+  - Action: Confirm with Alpaca that the entry never filled. If so, the position row is correct as CLOSED but the trades row should be deleted (or marked exit_reason='entry_canceled', net_pnl=0). Live fix: don't insert a trades row until entry fill confirms.
+- **id=42** `XLU` strategy=`overnight_drift` qty=13.624 status=`CLOSED` entry_time=`2026-04-29T11:45:42.964502-04:00`
+  - Evidence: No BUY fill found on Alpaca within +/-6h of entry_time=2026-04-29T11:45:42.964502-04:00; alpaca_order_id=None
+  - Action: Confirm with Alpaca that the entry never filled. If so, the position row is correct as CLOSED but the trades row should be deleted (or marked exit_reason='entry_canceled', net_pnl=0). Live fix: don't insert a trades row until entry fill confirms.
+- **id=43** `XLC` strategy=`overnight_drift` qty=6.5039 status=`CLOSED` entry_time=`2026-04-29T11:45:43.155984-04:00`
+  - Evidence: No BUY fill found on Alpaca within +/-6h of entry_time=2026-04-29T11:45:43.155984-04:00; alpaca_order_id=None
+  - Action: Confirm with Alpaca that the entry never filled. If so, the position row is correct as CLOSED but the trades row should be deleted (or marked exit_reason='entry_canceled', net_pnl=0). Live fix: don't insert a trades row until entry fill confirms.
+- **id=44** `SPY` strategy=`overnight_drift` qty=1.1038 status=`CLOSED` entry_time=`2026-04-29T11:50:43.115683-04:00`
+  - Evidence: No BUY fill found on Alpaca within +/-6h of entry_time=2026-04-29T11:50:43.115683-04:00; alpaca_order_id=None
+  - Action: Confirm with Alpaca that the entry never filled. If so, the position row is correct as CLOSED but the trades row should be deleted (or marked exit_reason='entry_canceled', net_pnl=0). Live fix: don't insert a trades row until entry fill confirms.
+- **id=45** `QQQ` strategy=`overnight_drift` qty=1.4382 status=`CLOSED` entry_time=`2026-04-29T11:50:43.444439-04:00`
+  - Evidence: No BUY fill found on Alpaca within +/-6h of entry_time=2026-04-29T11:50:43.444439-04:00; alpaca_order_id=None
+  - Action: Confirm with Alpaca that the entry never filled. If so, the position row is correct as CLOSED but the trades row should be deleted (or marked exit_reason='entry_canceled', net_pnl=0). Live fix: don't insert a trades row until entry fill confirms.
+- **id=46** `XLK` strategy=`overnight_drift` qty=5.5125 status=`CLOSED` entry_time=`2026-04-29T11:50:43.735415-04:00`
+  - Evidence: No BUY fill found on Alpaca within +/-6h of entry_time=2026-04-29T11:50:43.735415-04:00; alpaca_order_id=None
+  - Action: Confirm with Alpaca that the entry never filled. If so, the position row is correct as CLOSED but the trades row should be deleted (or marked exit_reason='entry_canceled', net_pnl=0). Live fix: don't insert a trades row until entry fill confirms.
+- **id=47** `XLF` strategy=`overnight_drift` qty=16.8707 status=`CLOSED` entry_time=`2026-04-29T11:50:44.026949-04:00`
+  - Evidence: No BUY fill found on Alpaca within +/-6h of entry_time=2026-04-29T11:50:44.026949-04:00; alpaca_order_id=None
+  - Action: Confirm with Alpaca that the entry never filled. If so, the position row is correct as CLOSED but the trades row should be deleted (or marked exit_reason='entry_canceled', net_pnl=0). Live fix: don't insert a trades row until entry fill confirms.
+- **id=48** `XLV` strategy=`overnight_drift` qty=6.1268 status=`CLOSED` entry_time=`2026-04-29T11:50:44.310543-04:00`
+  - Evidence: No BUY fill found on Alpaca within +/-6h of entry_time=2026-04-29T11:50:44.310543-04:00; alpaca_order_id=None
+  - Action: Confirm with Alpaca that the entry never filled. If so, the position row is correct as CLOSED but the trades row should be deleted (or marked exit_reason='entry_canceled', net_pnl=0). Live fix: don't insert a trades row until entry fill confirms.
+- **id=49** `XLY` strategy=`overnight_drift` qty=6.4196 status=`CLOSED` entry_time=`2026-04-29T11:50:44.608105-04:00`
+  - Evidence: No BUY fill found on Alpaca within +/-6h of entry_time=2026-04-29T11:50:44.608105-04:00; alpaca_order_id=None
+  - Action: Confirm with Alpaca that the entry never filled. If so, the position row is correct as CLOSED but the trades row should be deleted (or marked exit_reason='entry_canceled', net_pnl=0). Live fix: don't insert a trades row until entry fill confirms.
+- **id=50** `XLP` strategy=`overnight_drift` qty=9.0656 status=`CLOSED` entry_time=`2026-04-29T11:50:44.878798-04:00`
+  - Evidence: No BUY fill found on Alpaca within +/-6h of entry_time=2026-04-29T11:50:44.878798-04:00; alpaca_order_id=None
+  - Action: Confirm with Alpaca that the entry never filled. If so, the position row is correct as CLOSED but the trades row should be deleted (or marked exit_reason='entry_canceled', net_pnl=0). Live fix: don't insert a trades row until entry fill confirms.
+- **id=51** `XLE` strategy=`overnight_drift` qty=12.8172 status=`CLOSED` entry_time=`2026-04-29T11:50:45.157415-04:00`
+  - Evidence: No BUY fill found on Alpaca within +/-6h of entry_time=2026-04-29T11:50:45.157415-04:00; alpaca_order_id=None
+  - Action: Confirm with Alpaca that the entry never filled. If so, the position row is correct as CLOSED but the trades row should be deleted (or marked exit_reason='entry_canceled', net_pnl=0). Live fix: don't insert a trades row until entry fill confirms.
+- **id=52** `XLI` strategy=`overnight_drift` qty=4.4218 status=`CLOSED` entry_time=`2026-04-29T11:50:45.433412-04:00`
+  - Evidence: No BUY fill found on Alpaca within +/-6h of entry_time=2026-04-29T11:50:45.433412-04:00; alpaca_order_id=None
+  - Action: Confirm with Alpaca that the entry never filled. If so, the position row is correct as CLOSED but the trades row should be deleted (or marked exit_reason='entry_canceled', net_pnl=0). Live fix: don't insert a trades row until entry fill confirms.
+- **id=53** `XLB` strategy=`overnight_drift` qty=12.2489 status=`CLOSED` entry_time=`2026-04-29T11:50:45.739327-04:00`
+  - Evidence: No BUY fill found on Alpaca within +/-6h of entry_time=2026-04-29T11:50:45.739327-04:00; alpaca_order_id=None
+  - Action: Confirm with Alpaca that the entry never filled. If so, the position row is correct as CLOSED but the trades row should be deleted (or marked exit_reason='entry_canceled', net_pnl=0). Live fix: don't insert a trades row until entry fill confirms.
+- **id=54** `XLU` strategy=`overnight_drift` qty=13.6062 status=`CLOSED` entry_time=`2026-04-29T11:50:46.018815-04:00`
+  - Evidence: No BUY fill found on Alpaca within +/-6h of entry_time=2026-04-29T11:50:46.018815-04:00; alpaca_order_id=None
+  - Action: Confirm with Alpaca that the entry never filled. If so, the position row is correct as CLOSED but the trades row should be deleted (or marked exit_reason='entry_canceled', net_pnl=0). Live fix: don't insert a trades row until entry fill confirms.
+- **id=55** `XLC` strategy=`overnight_drift` qty=6.4994 status=`CLOSED` entry_time=`2026-04-29T11:50:46.505430-04:00`
+  - Evidence: No BUY fill found on Alpaca within +/-6h of entry_time=2026-04-29T11:50:46.505430-04:00; alpaca_order_id=None
+  - Action: Confirm with Alpaca that the entry never filled. If so, the position row is correct as CLOSED but the trades row should be deleted (or marked exit_reason='entry_canceled', net_pnl=0). Live fix: don't insert a trades row until entry fill confirms.
+
+## Trade findings
+
+### ENTRY_ONLY_PHANTOM (54)
+
+- **id=1** `SPY` strategy=`NULL` qty=1 entry_time=`2026-04-27T15:40:26.335519-04:00` exit_time=`NULL`
+  - Evidence: strategy_id IS NULL and exit_time IS NULL; paired position strategy='breakout' status=STOP_AND_TARGET_ACTIVE
+  - Action: Live bug: order_manager._create_position_record inserts trades without strategy_id and never updates exit (positions.id is used as trade_id, so UPDATE trades WHERE id = ? misses). Either delete and rewrite via save_trade(), or backfill via alpaca_backfill keyed off positions row.
+- **id=2** `XLP` strategy=`NULL` qty=6.0062 entry_time=`2026-04-27T15:40:29.122150-04:00` exit_time=`NULL`
+  - Evidence: strategy_id IS NULL and exit_time IS NULL; paired position strategy='mean_reversion' status=CLOSED
+  - Action: Live bug: order_manager._create_position_record inserts trades without strategy_id and never updates exit (positions.id is used as trade_id, so UPDATE trades WHERE id = ? misses). Either delete and rewrite via save_trade(), or backfill via alpaca_backfill keyed off positions row.
+- **id=3** `XLRE` strategy=`NULL` qty=20 entry_time=`2026-04-28T09:40:40.758560-04:00` exit_time=`NULL`
+  - Evidence: strategy_id IS NULL and exit_time IS NULL; paired position strategy='trend_following' status=STOP_AND_TARGET_ACTIVE
+  - Action: Live bug: order_manager._create_position_record inserts trades without strategy_id and never updates exit (positions.id is used as trade_id, so UPDATE trades WHERE id = ? misses). Either delete and rewrite via save_trade(), or backfill via alpaca_backfill keyed off positions row.
+- **id=4** `SPY` strategy=`NULL` qty=1.3384 entry_time=`2026-04-28T11:45:35.838930-04:00` exit_time=`NULL`
+  - Evidence: strategy_id IS NULL and exit_time IS NULL; paired position strategy='overnight_drift' status=CLOSED
+  - Action: Live bug: order_manager._create_position_record inserts trades without strategy_id and never updates exit (positions.id is used as trade_id, so UPDATE trades WHERE id = ? misses). Either delete and rewrite via save_trade(), or backfill via alpaca_backfill keyed off positions row.
+- **id=5** `QQQ` strategy=`NULL` qty=1.4518 entry_time=`2026-04-28T11:45:35.917916-04:00` exit_time=`NULL`
+  - Evidence: strategy_id IS NULL and exit_time IS NULL; paired position strategy='overnight_drift' status=CLOSED
+  - Action: Live bug: order_manager._create_position_record inserts trades without strategy_id and never updates exit (positions.id is used as trade_id, so UPDATE trades WHERE id = ? misses). Either delete and rewrite via save_trade(), or backfill via alpaca_backfill keyed off positions row.
+- **id=6** `XLK` strategy=`NULL` qty=6.0689 entry_time=`2026-04-28T11:45:36.019290-04:00` exit_time=`NULL`
+  - Evidence: strategy_id IS NULL and exit_time IS NULL; paired position strategy='overnight_drift' status=CLOSED
+  - Action: Live bug: order_manager._create_position_record inserts trades without strategy_id and never updates exit (positions.id is used as trade_id, so UPDATE trades WHERE id = ? misses). Either delete and rewrite via save_trade(), or backfill via alpaca_backfill keyed off positions row.
+- **id=7** `XLF` strategy=`NULL` qty=18.2429 entry_time=`2026-04-28T11:45:36.095265-04:00` exit_time=`NULL`
+  - Evidence: strategy_id IS NULL and exit_time IS NULL; paired position strategy='overnight_drift' status=CLOSED
+  - Action: Live bug: order_manager._create_position_record inserts trades without strategy_id and never updates exit (positions.id is used as trade_id, so UPDATE trades WHERE id = ? misses). Either delete and rewrite via save_trade(), or backfill via alpaca_backfill keyed off positions row.
+- **id=8** `XLV` strategy=`NULL` qty=6.589 entry_time=`2026-04-28T11:45:36.177810-04:00` exit_time=`NULL`
+  - Evidence: strategy_id IS NULL and exit_time IS NULL; paired position strategy='overnight_drift' status=CLOSED
+  - Action: Live bug: order_manager._create_position_record inserts trades without strategy_id and never updates exit (positions.id is used as trade_id, so UPDATE trades WHERE id = ? misses). Either delete and rewrite via save_trade(), or backfill via alpaca_backfill keyed off positions row.
+- **id=9** `XLY` strategy=`NULL` qty=8.1193 entry_time=`2026-04-28T11:45:36.281749-04:00` exit_time=`NULL`
+  - Evidence: strategy_id IS NULL and exit_time IS NULL; paired position strategy='overnight_drift' status=CLOSED
+  - Action: Live bug: order_manager._create_position_record inserts trades without strategy_id and never updates exit (positions.id is used as trade_id, so UPDATE trades WHERE id = ? misses). Either delete and rewrite via save_trade(), or backfill via alpaca_backfill keyed off positions row.
+- **id=10** `XLP` strategy=`NULL` qty=11.3834 entry_time=`2026-04-28T11:45:36.349008-04:00` exit_time=`NULL`
+  - Evidence: strategy_id IS NULL and exit_time IS NULL; paired position strategy='overnight_drift' status=CLOSED
+  - Action: Live bug: order_manager._create_position_record inserts trades without strategy_id and never updates exit (positions.id is used as trade_id, so UPDATE trades WHERE id = ? misses). Either delete and rewrite via save_trade(), or backfill via alpaca_backfill keyed off positions row.
+- **id=11** `XLE` strategy=`NULL` qty=16.3807 entry_time=`2026-04-28T11:45:36.427872-04:00` exit_time=`NULL`
+  - Evidence: strategy_id IS NULL and exit_time IS NULL; paired position strategy='overnight_drift' status=CLOSED
+  - Action: Live bug: order_manager._create_position_record inserts trades without strategy_id and never updates exit (positions.id is used as trade_id, so UPDATE trades WHERE id = ? misses). Either delete and rewrite via save_trade(), or backfill via alpaca_backfill keyed off positions row.
+- **id=12** `XLI` strategy=`NULL` qty=5.5835 entry_time=`2026-04-28T11:45:36.513547-04:00` exit_time=`NULL`
+  - Evidence: strategy_id IS NULL and exit_time IS NULL; paired position strategy='overnight_drift' status=CLOSED
+  - Action: Live bug: order_manager._create_position_record inserts trades without strategy_id and never updates exit (positions.id is used as trade_id, so UPDATE trades WHERE id = ? misses). Either delete and rewrite via save_trade(), or backfill via alpaca_backfill keyed off positions row.
+- **id=13** `XLB` strategy=`NULL` qty=18.5348 entry_time=`2026-04-28T11:45:36.623219-04:00` exit_time=`NULL`
+  - Evidence: strategy_id IS NULL and exit_time IS NULL; paired position strategy='overnight_drift' status=CLOSED
+  - Action: Live bug: order_manager._create_position_record inserts trades without strategy_id and never updates exit (positions.id is used as trade_id, so UPDATE trades WHERE id = ? misses). Either delete and rewrite via save_trade(), or backfill via alpaca_backfill keyed off positions row.
+- **id=14** `XLU` strategy=`NULL` qty=20.494 entry_time=`2026-04-28T11:45:36.712368-04:00` exit_time=`NULL`
+  - Evidence: strategy_id IS NULL and exit_time IS NULL; paired position strategy='overnight_drift' status=CLOSED
+  - Action: Live bug: order_manager._create_position_record inserts trades without strategy_id and never updates exit (positions.id is used as trade_id, so UPDATE trades WHERE id = ? misses). Either delete and rewrite via save_trade(), or backfill via alpaca_backfill keyed off positions row.
+- **id=15** `XLRE` strategy=`NULL` qty=21.7118 entry_time=`2026-04-28T11:45:36.782613-04:00` exit_time=`NULL`
+  - Evidence: strategy_id IS NULL and exit_time IS NULL; paired position strategy='overnight_drift' status=CLOSED
+  - Action: Live bug: order_manager._create_position_record inserts trades without strategy_id and never updates exit (positions.id is used as trade_id, so UPDATE trades WHERE id = ? misses). Either delete and rewrite via save_trade(), or backfill via alpaca_backfill keyed off positions row.
+- **id=16** `XLC` strategy=`NULL` qty=8.2223 entry_time=`2026-04-28T11:45:36.858886-04:00` exit_time=`NULL`
+  - Evidence: strategy_id IS NULL and exit_time IS NULL; paired position strategy='overnight_drift' status=CLOSED
+  - Action: Live bug: order_manager._create_position_record inserts trades without strategy_id and never updates exit (positions.id is used as trade_id, so UPDATE trades WHERE id = ? misses). Either delete and rewrite via save_trade(), or backfill via alpaca_backfill keyed off positions row.
+- **id=17** `SPY` strategy=`NULL` qty=1.3387 entry_time=`2026-04-28T11:50:38.882260-04:00` exit_time=`NULL`
+  - Evidence: strategy_id IS NULL and exit_time IS NULL; paired position strategy='overnight_drift' status=CLOSED
+  - Action: Live bug: order_manager._create_position_record inserts trades without strategy_id and never updates exit (positions.id is used as trade_id, so UPDATE trades WHERE id = ? misses). Either delete and rewrite via save_trade(), or backfill via alpaca_backfill keyed off positions row.
+- **id=18** `QQQ` strategy=`NULL` qty=1.4524 entry_time=`2026-04-28T11:50:39.929115-04:00` exit_time=`NULL`
+  - Evidence: strategy_id IS NULL and exit_time IS NULL; paired position strategy='overnight_drift' status=CLOSED
+  - Action: Live bug: order_manager._create_position_record inserts trades without strategy_id and never updates exit (positions.id is used as trade_id, so UPDATE trades WHERE id = ? misses). Either delete and rewrite via save_trade(), or backfill via alpaca_backfill keyed off positions row.
+- **id=19** `XLK` strategy=`NULL` qty=6.0734 entry_time=`2026-04-28T11:50:40.461069-04:00` exit_time=`NULL`
+  - Evidence: strategy_id IS NULL and exit_time IS NULL; paired position strategy='overnight_drift' status=CLOSED
+  - Action: Live bug: order_manager._create_position_record inserts trades without strategy_id and never updates exit (positions.id is used as trade_id, so UPDATE trades WHERE id = ? misses). Either delete and rewrite via save_trade(), or backfill via alpaca_backfill keyed off positions row.
+- **id=20** `XLF` strategy=`NULL` qty=18.2359 entry_time=`2026-04-28T11:50:41.206896-04:00` exit_time=`NULL`
+  - Evidence: strategy_id IS NULL and exit_time IS NULL; paired position strategy='overnight_drift' status=CLOSED
+  - Action: Live bug: order_manager._create_position_record inserts trades without strategy_id and never updates exit (positions.id is used as trade_id, so UPDATE trades WHERE id = ? misses). Either delete and rewrite via save_trade(), or backfill via alpaca_backfill keyed off positions row.
+- **id=21** `XLV` strategy=`NULL` qty=6.5872 entry_time=`2026-04-28T11:50:41.922859-04:00` exit_time=`NULL`
+  - Evidence: strategy_id IS NULL and exit_time IS NULL; paired position strategy='overnight_drift' status=CLOSED
+  - Action: Live bug: order_manager._create_position_record inserts trades without strategy_id and never updates exit (positions.id is used as trade_id, so UPDATE trades WHERE id = ? misses). Either delete and rewrite via save_trade(), or backfill via alpaca_backfill keyed off positions row.
+- **id=22** `XLY` strategy=`NULL` qty=8.12 entry_time=`2026-04-28T11:50:42.865931-04:00` exit_time=`NULL`
+  - Evidence: strategy_id IS NULL and exit_time IS NULL; paired position strategy='overnight_drift' status=CLOSED
+  - Action: Live bug: order_manager._create_position_record inserts trades without strategy_id and never updates exit (positions.id is used as trade_id, so UPDATE trades WHERE id = ? misses). Either delete and rewrite via save_trade(), or backfill via alpaca_backfill keyed off positions row.
+- **id=23** `XLP` strategy=`NULL` qty=11.3759 entry_time=`2026-04-28T11:50:43.425341-04:00` exit_time=`NULL`
+  - Evidence: strategy_id IS NULL and exit_time IS NULL; paired position strategy='overnight_drift' status=CLOSED
+  - Action: Live bug: order_manager._create_position_record inserts trades without strategy_id and never updates exit (positions.id is used as trade_id, so UPDATE trades WHERE id = ? misses). Either delete and rewrite via save_trade(), or backfill via alpaca_backfill keyed off positions row.
+- **id=24** `XLE` strategy=`NULL` qty=16.3892 entry_time=`2026-04-28T11:50:44.318501-04:00` exit_time=`NULL`
+  - Evidence: strategy_id IS NULL and exit_time IS NULL; paired position strategy='overnight_drift' status=CLOSED
+  - Action: Live bug: order_manager._create_position_record inserts trades without strategy_id and never updates exit (positions.id is used as trade_id, so UPDATE trades WHERE id = ? misses). Either delete and rewrite via save_trade(), or backfill via alpaca_backfill keyed off positions row.
+- **id=25** `XLI` strategy=`NULL` qty=5.5846 entry_time=`2026-04-28T11:50:45.133668-04:00` exit_time=`NULL`
+  - Evidence: strategy_id IS NULL and exit_time IS NULL; paired position strategy='overnight_drift' status=CLOSED
+  - Action: Live bug: order_manager._create_position_record inserts trades without strategy_id and never updates exit (positions.id is used as trade_id, so UPDATE trades WHERE id = ? misses). Either delete and rewrite via save_trade(), or backfill via alpaca_backfill keyed off positions row.
+- **id=26** `XLB` strategy=`NULL` qty=18.5239 entry_time=`2026-04-28T11:50:45.934262-04:00` exit_time=`NULL`
+  - Evidence: strategy_id IS NULL and exit_time IS NULL; paired position strategy='overnight_drift' status=CLOSED
+  - Action: Live bug: order_manager._create_position_record inserts trades without strategy_id and never updates exit (positions.id is used as trade_id, so UPDATE trades WHERE id = ? misses). Either delete and rewrite via save_trade(), or backfill via alpaca_backfill keyed off positions row.
+- **id=27** `XLU` strategy=`NULL` qty=20.483 entry_time=`2026-04-28T11:50:46.663838-04:00` exit_time=`NULL`
+  - Evidence: strategy_id IS NULL and exit_time IS NULL; paired position strategy='overnight_drift' status=CLOSED
+  - Action: Live bug: order_manager._create_position_record inserts trades without strategy_id and never updates exit (positions.id is used as trade_id, so UPDATE trades WHERE id = ? misses). Either delete and rewrite via save_trade(), or backfill via alpaca_backfill keyed off positions row.
+- **id=28** `XLRE` strategy=`NULL` qty=21.7044 entry_time=`2026-04-28T11:50:48.031049-04:00` exit_time=`NULL`
+  - Evidence: strategy_id IS NULL and exit_time IS NULL; paired position strategy='overnight_drift' status=CLOSED
+  - Action: Live bug: order_manager._create_position_record inserts trades without strategy_id and never updates exit (positions.id is used as trade_id, so UPDATE trades WHERE id = ? misses). Either delete and rewrite via save_trade(), or backfill via alpaca_backfill keyed off positions row.
+- **id=29** `XLC` strategy=`NULL` qty=8.2201 entry_time=`2026-04-28T11:50:48.454421-04:00` exit_time=`NULL`
+  - Evidence: strategy_id IS NULL and exit_time IS NULL; paired position strategy='overnight_drift' status=CLOSED
+  - Action: Live bug: order_manager._create_position_record inserts trades without strategy_id and never updates exit (positions.id is used as trade_id, so UPDATE trades WHERE id = ? misses). Either delete and rewrite via save_trade(), or backfill via alpaca_backfill keyed off positions row.
+- **id=30** `XLY` strategy=`NULL` qty=4.2435 entry_time=`2026-04-29T10:05:37.051283-04:00` exit_time=`NULL`
+  - Evidence: strategy_id IS NULL and exit_time IS NULL; paired position strategy='mean_reversion' status=CLOSED
+  - Action: Live bug: order_manager._create_position_record inserts trades without strategy_id and never updates exit (positions.id is used as trade_id, so UPDATE trades WHERE id = ? misses). Either delete and rewrite via save_trade(), or backfill via alpaca_backfill keyed off positions row.
+- **id=31** `SPY` strategy=`NULL` qty=1.1042 entry_time=`2026-04-29T11:45:41.968800-04:00` exit_time=`NULL`
+  - Evidence: strategy_id IS NULL and exit_time IS NULL; paired position strategy='overnight_drift' status=CLOSED
+  - Action: Live bug: order_manager._create_position_record inserts trades without strategy_id and never updates exit (positions.id is used as trade_id, so UPDATE trades WHERE id = ? misses). Either delete and rewrite via save_trade(), or backfill via alpaca_backfill keyed off positions row.
+- **id=32** `QQQ` strategy=`NULL` qty=1.4382 entry_time=`2026-04-29T11:45:42.156196-04:00` exit_time=`NULL`
+  - Evidence: strategy_id IS NULL and exit_time IS NULL; paired position strategy='overnight_drift' status=CLOSED
+  - Action: Live bug: order_manager._create_position_record inserts trades without strategy_id and never updates exit (positions.id is used as trade_id, so UPDATE trades WHERE id = ? misses). Either delete and rewrite via save_trade(), or backfill via alpaca_backfill keyed off positions row.
+- **id=33** `XLK` strategy=`NULL` qty=5.5115 entry_time=`2026-04-29T11:45:42.235559-04:00` exit_time=`NULL`
+  - Evidence: strategy_id IS NULL and exit_time IS NULL; paired position strategy='overnight_drift' status=CLOSED
+  - Action: Live bug: order_manager._create_position_record inserts trades without strategy_id and never updates exit (positions.id is used as trade_id, so UPDATE trades WHERE id = ? misses). Either delete and rewrite via save_trade(), or backfill via alpaca_backfill keyed off positions row.
+- **id=34** `XLF` strategy=`NULL` qty=16.8772 entry_time=`2026-04-29T11:45:42.318292-04:00` exit_time=`NULL`
+  - Evidence: strategy_id IS NULL and exit_time IS NULL; paired position strategy='overnight_drift' status=CLOSED
+  - Action: Live bug: order_manager._create_position_record inserts trades without strategy_id and never updates exit (positions.id is used as trade_id, so UPDATE trades WHERE id = ? misses). Either delete and rewrite via save_trade(), or backfill via alpaca_backfill keyed off positions row.
+- **id=35** `XLV` strategy=`NULL` qty=6.1324 entry_time=`2026-04-29T11:45:42.408252-04:00` exit_time=`NULL`
+  - Evidence: strategy_id IS NULL and exit_time IS NULL; paired position strategy='overnight_drift' status=CLOSED
+  - Action: Live bug: order_manager._create_position_record inserts trades without strategy_id and never updates exit (positions.id is used as trade_id, so UPDATE trades WHERE id = ? misses). Either delete and rewrite via save_trade(), or backfill via alpaca_backfill keyed off positions row.
+- **id=36** `XLY` strategy=`NULL` qty=6.421 entry_time=`2026-04-29T11:45:42.523013-04:00` exit_time=`NULL`
+  - Evidence: strategy_id IS NULL and exit_time IS NULL; paired position strategy='overnight_drift' status=CLOSED
+  - Action: Live bug: order_manager._create_position_record inserts trades without strategy_id and never updates exit (positions.id is used as trade_id, so UPDATE trades WHERE id = ? misses). Either delete and rewrite via save_trade(), or backfill via alpaca_backfill keyed off positions row.
+- **id=37** `XLP` strategy=`NULL` qty=9.0717 entry_time=`2026-04-29T11:45:42.619917-04:00` exit_time=`NULL`
+  - Evidence: strategy_id IS NULL and exit_time IS NULL; paired position strategy='overnight_drift' status=CLOSED
+  - Action: Live bug: order_manager._create_position_record inserts trades without strategy_id and never updates exit (positions.id is used as trade_id, so UPDATE trades WHERE id = ? misses). Either delete and rewrite via save_trade(), or backfill via alpaca_backfill keyed off positions row.
+- **id=38** `XLE` strategy=`NULL` qty=12.8172 entry_time=`2026-04-29T11:45:42.708201-04:00` exit_time=`NULL`
+  - Evidence: strategy_id IS NULL and exit_time IS NULL; paired position strategy='overnight_drift' status=CLOSED
+  - Action: Live bug: order_manager._create_position_record inserts trades without strategy_id and never updates exit (positions.id is used as trade_id, so UPDATE trades WHERE id = ? misses). Either delete and rewrite via save_trade(), or backfill via alpaca_backfill keyed off positions row.
+- **id=39** `XLI` strategy=`NULL` qty=4.4266 entry_time=`2026-04-29T11:45:42.798016-04:00` exit_time=`NULL`
+  - Evidence: strategy_id IS NULL and exit_time IS NULL; paired position strategy='overnight_drift' status=CLOSED
+  - Action: Live bug: order_manager._create_position_record inserts trades without strategy_id and never updates exit (positions.id is used as trade_id, so UPDATE trades WHERE id = ? misses). Either delete and rewrite via save_trade(), or backfill via alpaca_backfill keyed off positions row.
+- **id=40** `XLB` strategy=`NULL` qty=12.2513 entry_time=`2026-04-29T11:45:42.883221-04:00` exit_time=`NULL`
+  - Evidence: strategy_id IS NULL and exit_time IS NULL; paired position strategy='overnight_drift' status=CLOSED
+  - Action: Live bug: order_manager._create_position_record inserts trades without strategy_id and never updates exit (positions.id is used as trade_id, so UPDATE trades WHERE id = ? misses). Either delete and rewrite via save_trade(), or backfill via alpaca_backfill keyed off positions row.
+- **id=41** `XLU` strategy=`NULL` qty=13.624 entry_time=`2026-04-29T11:45:42.964502-04:00` exit_time=`NULL`
+  - Evidence: strategy_id IS NULL and exit_time IS NULL; paired position strategy='overnight_drift' status=CLOSED
+  - Action: Live bug: order_manager._create_position_record inserts trades without strategy_id and never updates exit (positions.id is used as trade_id, so UPDATE trades WHERE id = ? misses). Either delete and rewrite via save_trade(), or backfill via alpaca_backfill keyed off positions row.
+- **id=42** `XLC` strategy=`NULL` qty=6.5039 entry_time=`2026-04-29T11:45:43.155984-04:00` exit_time=`NULL`
+  - Evidence: strategy_id IS NULL and exit_time IS NULL; paired position strategy='overnight_drift' status=CLOSED
+  - Action: Live bug: order_manager._create_position_record inserts trades without strategy_id and never updates exit (positions.id is used as trade_id, so UPDATE trades WHERE id = ? misses). Either delete and rewrite via save_trade(), or backfill via alpaca_backfill keyed off positions row.
+- **id=43** `SPY` strategy=`NULL` qty=1.1038 entry_time=`2026-04-29T11:50:43.115683-04:00` exit_time=`NULL`
+  - Evidence: strategy_id IS NULL and exit_time IS NULL; paired position strategy='overnight_drift' status=CLOSED
+  - Action: Live bug: order_manager._create_position_record inserts trades without strategy_id and never updates exit (positions.id is used as trade_id, so UPDATE trades WHERE id = ? misses). Either delete and rewrite via save_trade(), or backfill via alpaca_backfill keyed off positions row.
+- **id=44** `QQQ` strategy=`NULL` qty=1.4382 entry_time=`2026-04-29T11:50:43.444439-04:00` exit_time=`NULL`
+  - Evidence: strategy_id IS NULL and exit_time IS NULL; paired position strategy='overnight_drift' status=CLOSED
+  - Action: Live bug: order_manager._create_position_record inserts trades without strategy_id and never updates exit (positions.id is used as trade_id, so UPDATE trades WHERE id = ? misses). Either delete and rewrite via save_trade(), or backfill via alpaca_backfill keyed off positions row.
+- **id=45** `XLK` strategy=`NULL` qty=5.5125 entry_time=`2026-04-29T11:50:43.735415-04:00` exit_time=`NULL`
+  - Evidence: strategy_id IS NULL and exit_time IS NULL; paired position strategy='overnight_drift' status=CLOSED
+  - Action: Live bug: order_manager._create_position_record inserts trades without strategy_id and never updates exit (positions.id is used as trade_id, so UPDATE trades WHERE id = ? misses). Either delete and rewrite via save_trade(), or backfill via alpaca_backfill keyed off positions row.
+- **id=46** `XLF` strategy=`NULL` qty=16.8707 entry_time=`2026-04-29T11:50:44.026949-04:00` exit_time=`NULL`
+  - Evidence: strategy_id IS NULL and exit_time IS NULL; paired position strategy='overnight_drift' status=CLOSED
+  - Action: Live bug: order_manager._create_position_record inserts trades without strategy_id and never updates exit (positions.id is used as trade_id, so UPDATE trades WHERE id = ? misses). Either delete and rewrite via save_trade(), or backfill via alpaca_backfill keyed off positions row.
+- **id=47** `XLV` strategy=`NULL` qty=6.1268 entry_time=`2026-04-29T11:50:44.310543-04:00` exit_time=`NULL`
+  - Evidence: strategy_id IS NULL and exit_time IS NULL; paired position strategy='overnight_drift' status=CLOSED
+  - Action: Live bug: order_manager._create_position_record inserts trades without strategy_id and never updates exit (positions.id is used as trade_id, so UPDATE trades WHERE id = ? misses). Either delete and rewrite via save_trade(), or backfill via alpaca_backfill keyed off positions row.
+- **id=48** `XLY` strategy=`NULL` qty=6.4196 entry_time=`2026-04-29T11:50:44.608105-04:00` exit_time=`NULL`
+  - Evidence: strategy_id IS NULL and exit_time IS NULL; paired position strategy='overnight_drift' status=CLOSED
+  - Action: Live bug: order_manager._create_position_record inserts trades without strategy_id and never updates exit (positions.id is used as trade_id, so UPDATE trades WHERE id = ? misses). Either delete and rewrite via save_trade(), or backfill via alpaca_backfill keyed off positions row.
+- **id=49** `XLP` strategy=`NULL` qty=9.0656 entry_time=`2026-04-29T11:50:44.878798-04:00` exit_time=`NULL`
+  - Evidence: strategy_id IS NULL and exit_time IS NULL; paired position strategy='overnight_drift' status=CLOSED
+  - Action: Live bug: order_manager._create_position_record inserts trades without strategy_id and never updates exit (positions.id is used as trade_id, so UPDATE trades WHERE id = ? misses). Either delete and rewrite via save_trade(), or backfill via alpaca_backfill keyed off positions row.
+- **id=50** `XLE` strategy=`NULL` qty=12.8172 entry_time=`2026-04-29T11:50:45.157415-04:00` exit_time=`NULL`
+  - Evidence: strategy_id IS NULL and exit_time IS NULL; paired position strategy='overnight_drift' status=CLOSED
+  - Action: Live bug: order_manager._create_position_record inserts trades without strategy_id and never updates exit (positions.id is used as trade_id, so UPDATE trades WHERE id = ? misses). Either delete and rewrite via save_trade(), or backfill via alpaca_backfill keyed off positions row.
+- **id=51** `XLI` strategy=`NULL` qty=4.4218 entry_time=`2026-04-29T11:50:45.433412-04:00` exit_time=`NULL`
+  - Evidence: strategy_id IS NULL and exit_time IS NULL; paired position strategy='overnight_drift' status=CLOSED
+  - Action: Live bug: order_manager._create_position_record inserts trades without strategy_id and never updates exit (positions.id is used as trade_id, so UPDATE trades WHERE id = ? misses). Either delete and rewrite via save_trade(), or backfill via alpaca_backfill keyed off positions row.
+- **id=52** `XLB` strategy=`NULL` qty=12.2489 entry_time=`2026-04-29T11:50:45.739327-04:00` exit_time=`NULL`
+  - Evidence: strategy_id IS NULL and exit_time IS NULL; paired position strategy='overnight_drift' status=CLOSED
+  - Action: Live bug: order_manager._create_position_record inserts trades without strategy_id and never updates exit (positions.id is used as trade_id, so UPDATE trades WHERE id = ? misses). Either delete and rewrite via save_trade(), or backfill via alpaca_backfill keyed off positions row.
+- **id=53** `XLU` strategy=`NULL` qty=13.6062 entry_time=`2026-04-29T11:50:46.018815-04:00` exit_time=`NULL`
+  - Evidence: strategy_id IS NULL and exit_time IS NULL; paired position strategy='overnight_drift' status=CLOSED
+  - Action: Live bug: order_manager._create_position_record inserts trades without strategy_id and never updates exit (positions.id is used as trade_id, so UPDATE trades WHERE id = ? misses). Either delete and rewrite via save_trade(), or backfill via alpaca_backfill keyed off positions row.
+- **id=54** `XLC` strategy=`NULL` qty=6.4994 entry_time=`2026-04-29T11:50:46.505430-04:00` exit_time=`NULL`
+  - Evidence: strategy_id IS NULL and exit_time IS NULL; paired position strategy='overnight_drift' status=CLOSED
+  - Action: Live bug: order_manager._create_position_record inserts trades without strategy_id and never updates exit (positions.id is used as trade_id, so UPDATE trades WHERE id = ? misses). Either delete and rewrite via save_trade(), or backfill via alpaca_backfill keyed off positions row.
+
+---
+
+_This report is read-only. No DB rows were modified and no orders were submitted. Use it to plan Phase 2 (DB migration) and Phase 3 (live order logic fixes)._

--- a/trading_bot/constants.py
+++ b/trading_bot/constants.py
@@ -48,13 +48,33 @@ class OrderSide(str, Enum):
 
 
 class PositionStatus(str, Enum):
-    """Lifecycle states for an open position."""
+    """Lifecycle states for a position.
+
+    Terminal states (the row never transitions out):
+        - CLOSED — entry filled, then exited (normal lifecycle).
+        - ENTRY_FAILED — entry never filled (cancel, reject, timeout). The
+          row exists because we optimistically inserted into ``positions``
+          before the bracket order confirmed; we cannot delete it without
+          breaking foreign keys + audit history. Callers querying for
+          "in-flight" positions must exclude both terminal states.
+
+    All other states are in-flight.
+    """
     ENTRY_PENDING = "ENTRY_PENDING"
     POSITION_OPEN = "POSITION_OPEN"
     STOP_AND_TARGET_ACTIVE = "STOP_AND_TARGET_ACTIVE"
     TRAILING_ACTIVE = "TRAILING_ACTIVE"
     CLOSING = "CLOSING"
     CLOSED = "CLOSED"
+    ENTRY_FAILED = "ENTRY_FAILED"
+
+
+# Set of terminal PositionStatus values. Use this in any query that asks
+# "is this position still in flight?" — it must exclude every terminal
+# state, not just CLOSED.
+TERMINAL_POSITION_STATUSES: frozenset[str] = frozenset(
+    {PositionStatus.CLOSED.value, PositionStatus.ENTRY_FAILED.value}
+)
 
 
 class HoldType(str, Enum):
@@ -176,4 +196,4 @@ def ticker_market(ticker: str) -> Market:
 # Schema version — must match the DB migration target
 # ---------------------------------------------------------------------------
 
-SCHEMA_VERSION: int = 7
+SCHEMA_VERSION: int = 8

--- a/trading_bot/db/migrations.py
+++ b/trading_bot/db/migrations.py
@@ -216,11 +216,77 @@ def _migration_v7(conn: sqlite3.Connection) -> None:
     logger.info("Applied migration V7: tick_state + risk_circuit_state")
 
 
+def _migration_v8(conn: sqlite3.Connection) -> None:
+    """V8: retro-convert phantom-CLOSED positions to ENTRY_FAILED.
+
+    Pre-V8, every path in ``order_manager`` that aborted an entry stamped
+    the row ``status='CLOSED'`` even though no fill ever existed on Alpaca
+    (entry-timeout, submit error, rejection-after-DB-insert).  These rows
+    pollute every "completed trade" report and exit-recovery scan because
+    they look identical to a real round-trip.
+
+    A row is a phantom close iff ALL of:
+      - ``status = 'CLOSED'``
+      - ``alpaca_order_id IS NULL``
+        (entry order id is only set on a successful submit_order)
+      - the paired ``trades`` row has ``exit_time IS NULL``
+        (the close path never wrote exit data — confirms no real fill)
+
+    Rows where ``alpaca_order_id`` IS set but the entry was canceled at the
+    broker are NOT touched here — they require a live Alpaca lookup to
+    classify, which is the Phase 1 reconcile tool's job.  This migration
+    only flips the obvious cases that can be detected from local DB state
+    alone.
+
+    The migration is reversible by replaying the SELECT that produced the
+    target ids and restoring ``status='CLOSED'``; it never deletes rows
+    or columns.  Operationally it is also reversible by restoring the
+    SQLite file from the GHA cache artifact.
+    """
+    target_ids: list[int] = [
+        row[0]
+        for row in conn.execute(
+            """
+            SELECT p.id
+              FROM positions p
+              LEFT JOIN trades t
+                ON t.ticker = p.ticker
+               AND t.entry_time = p.entry_time
+             WHERE p.status = 'CLOSED'
+               AND p.alpaca_order_id IS NULL
+               AND (t.exit_time IS NULL OR t.id IS NULL)
+            """
+        ).fetchall()
+    ]
+
+    if target_ids:
+        # IN (?,?,?…) with positional binds — no string interpolation of
+        # row data.
+        placeholders: str = ",".join("?" for _ in target_ids)
+        conn.execute(
+            f"UPDATE positions SET status = 'ENTRY_FAILED', "
+            f"updated_at = datetime('now') "
+            f"WHERE id IN ({placeholders})",
+            target_ids,
+        )
+    logger.info(
+        "V8: retro-converted %d phantom-CLOSED row(s) to ENTRY_FAILED",
+        len(target_ids),
+    )
+
+    conn.execute(
+        "INSERT OR REPLACE INTO schema_version (version, description) "
+        "VALUES (8, 'V8 schema - ENTRY_FAILED terminal status (data-only)')"
+    )
+    logger.info("Applied migration V8: ENTRY_FAILED terminal status")
+
+
 _MIGRATIONS: list[tuple[int, str, MigrationFn]] = [
     (4, "V4 schema - multi-market adaptive trading bot", _migration_v4),
     (5, "V5 schema - multi-strategy Alpaca trading bot", _migration_v5),
     (6, "V6 schema - positions.strategy_id NOT NULL", _migration_v6),
     (7, "V7 schema - tick_state + risk_circuit_state", _migration_v7),
+    (8, "V8 schema - ENTRY_FAILED terminal status (data-only)", _migration_v8),
 ]
 
 

--- a/trading_bot/db/repository.py
+++ b/trading_bot/db/repository.py
@@ -146,10 +146,18 @@ def update_trade_exit(conn: sqlite3.Connection, trade_id: int, exit_data: dict[s
 # ---------------------------------------------------------------------------
 
 def get_open_positions(conn: sqlite3.Connection) -> list[dict[str, Any]]:
-    """Return all positions that are not CLOSED."""
+    """Return all positions in non-terminal states.
+
+    Terminal states (CLOSED + ENTRY_FAILED) are excluded — see
+    :class:`trading_bot.constants.PositionStatus` for the lifecycle.
+    ``has_attempted_today`` deliberately ignores status entirely; this
+    function is for "what does the bot still need to manage?" callers.
+    """
     _ensure_row_factory(conn)
     rows = conn.execute(
-        "SELECT * FROM positions WHERE status != 'CLOSED' ORDER BY entry_time"
+        "SELECT * FROM positions "
+        "WHERE status NOT IN ('CLOSED', 'ENTRY_FAILED') "
+        "ORDER BY entry_time"
     ).fetchall()
     return _rows_to_dicts(rows)
 

--- a/trading_bot/db/schema.py
+++ b/trading_bot/db/schema.py
@@ -281,7 +281,7 @@ CREATE TABLE IF NOT EXISTS schema_version (
 
 _SEED_VERSION_SQL: str = (
     "INSERT OR IGNORE INTO schema_version (version, description) "
-    "VALUES (?, 'V7 schema - tick_state + risk_circuit_state');"
+    "VALUES (?, 'V8 schema - ENTRY_FAILED terminal status (data-only)');"
 )
 
 # Expected tables — used for quick health check

--- a/trading_bot/execution/order_manager.py
+++ b/trading_bot/execution/order_manager.py
@@ -105,6 +105,12 @@ class _ActiveOrder:
     trail_pct: float | None = None
     trail_activation_price: float | None = None
     trail_activated: bool = False
+    # Trades-table primary key for this position. Populated when the row is
+    # inserted in _create_position_record and rehydrated via (ticker,
+    # entry_time) match. Used as the WHERE on UPDATE trades during exit so
+    # the update lands on the correct row — pre-Phase-3, the code reused
+    # trade_id (which is positions.id) and silently missed.
+    db_trade_id: int | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -132,6 +138,10 @@ class OrderManager:
 
         self._active_orders: dict[int, _ActiveOrder] = {}
         self._alpaca_to_trade: dict[str, int] = {}
+        # Holds positions.id -> trades.id between _create_position_record
+        # and place_entry constructing the _ActiveOrder. Cleared once the
+        # tracker takes ownership.
+        self._pending_db_trade_ids: dict[int, int] = {}
 
     # ------------------------------------------------------------------
     # Tick-model hydration + status check
@@ -149,9 +159,22 @@ class OrderManager:
             conn.row_factory = sqlite3.Row
             try:
                 rows = conn.execute(
-                    "SELECT * FROM positions WHERE status != ?",
-                    (PositionStatus.CLOSED.value,),
+                    "SELECT * FROM positions "
+                    "WHERE status NOT IN (?, ?)",
+                    (
+                        PositionStatus.CLOSED.value,
+                        PositionStatus.ENTRY_FAILED.value,
+                    ),
                 ).fetchall()
+                # Pair-key index for trades.id lookup. Same pairing the
+                # alpaca_backfill tool uses (ticker, entry_time) since
+                # there is no FK between the tables.
+                trades_index: dict[tuple[str, str], int] = {
+                    (str(t["ticker"]), str(t["entry_time"])): int(t["id"])
+                    for t in conn.execute(
+                        "SELECT id, ticker, entry_time FROM trades"
+                    ).fetchall()
+                }
             finally:
                 conn.close()
         except sqlite3.OperationalError:
@@ -187,6 +210,9 @@ class OrderManager:
                 target_price=float(row["target_price"] or 0),
                 hold_type=str(row["hold_type"]),
                 strategy_id=row["strategy_id"],
+                db_trade_id=trades_index.get(
+                    (str(row["ticker"]), str(row["entry_time"]))
+                ),
             )
             self._active_orders[trade_id] = active
             for oid in (
@@ -241,8 +267,12 @@ class OrderManager:
                             "Entry %s: %s (trade_id=%d)",
                             order.status.value, active.ticker, trade_id,
                         )
-                        self._update_position_status(trade_id, PositionStatus.CLOSED)
-                        active.status = PositionStatus.CLOSED
+                        # Phase 3 B2: Use ENTRY_FAILED, not CLOSED — no fill
+                        # ever happened so this is not a real round-trip.
+                        self._update_position_status(
+                            trade_id, PositionStatus.ENTRY_FAILED
+                        )
+                        active.status = PositionStatus.ENTRY_FAILED
                         self._log_rejection(
                             ticker=active.ticker,
                             exchange=active.exchange,
@@ -371,6 +401,7 @@ class OrderManager:
                 strategy_id=decision.strategy_id,
                 trail_pct=decision.trail_pct,
                 trail_activation_price=decision.trail_activation_price,
+                db_trade_id=self._pending_db_trade_ids.pop(trade_id, None),
             )
             self._active_orders[trade_id] = active
             self._alpaca_to_trade[alpaca_order_id] = trade_id
@@ -381,7 +412,13 @@ class OrderManager:
 
         except Exception as exc:
             logger.exception("Failed to place entry order for %s", decision.ticker)
-            self._update_position_status(trade_id, PositionStatus.CLOSED)
+            # Phase 3 B2: ENTRY_FAILED, not CLOSED — Alpaca rejected the
+            # submit so no order ever existed. CLOSED implies a real
+            # round-trip and pollutes every postmortem report.
+            self._update_position_status(trade_id, PositionStatus.ENTRY_FAILED)
+            # Drop the unused mapping so it can't leak into a stale
+            # _ActiveOrder if the same positions.id is later rehydrated.
+            self._pending_db_trade_ids.pop(trade_id, None)
             self._log_rejection(
                 ticker=decision.ticker,
                 exchange=decision.exchange,
@@ -442,8 +479,10 @@ class OrderManager:
                     active.ticker, active.filled_shares, active.exchange,
                 )
 
-            self._update_position_status(trade_id, PositionStatus.CLOSED)
-            active.status = PositionStatus.CLOSED
+            # Phase 3 B2: zero-fill timeout cancels the order at the broker
+            # so no entry ever happens — ENTRY_FAILED, not CLOSED.
+            self._update_position_status(trade_id, PositionStatus.ENTRY_FAILED)
+            active.status = PositionStatus.ENTRY_FAILED
             self._log_rejection(
                 ticker=active.ticker,
                 exchange=active.exchange,
@@ -796,19 +835,53 @@ class OrderManager:
         active.status = PositionStatus.CLOSED
         self._update_position_status(trade_id, PositionStatus.CLOSED)
 
-        try:
-            conn: sqlite3.Connection = sqlite3.connect(self._db_path)
+        # Compute realised P&L while we still have the active order in hand.
+        # The bot is commission-free so net == gross; FX is 1.0 for USD.
+        gross_pnl: float = (exit_price - active.entry_price) * active.filled_shares
+
+        # B3: target the trades row by trades.id, not positions.id. The two
+        # tables have independent autoincrements; pre-fix this UPDATE
+        # silently matched the wrong row (or zero rows).
+        db_trade_id: int | None = active.db_trade_id
+        if db_trade_id is None:
+            logger.warning(
+                "_close_position called with no db_trade_id (trade_id=%d "
+                "ticker=%s); exit data will be backfilled from Alpaca.",
+                trade_id, active.ticker,
+            )
+        else:
             try:
-                conn.execute(
-                    "UPDATE trades SET exit_time = ?, exit_price = ?, "
-                    "exit_reason = ? WHERE id = ?",
-                    (now_str, exit_price, exit_reason, trade_id),
+                conn: sqlite3.Connection = sqlite3.connect(self._db_path)
+                try:
+                    cur = conn.execute(
+                        "UPDATE trades SET exit_time = ?, exit_price = ?, "
+                        "exit_reason = ?, gross_pnl = ?, net_pnl = ? "
+                        "WHERE id = ?",
+                        (
+                            now_str,
+                            exit_price,
+                            exit_reason,
+                            gross_pnl,
+                            gross_pnl,
+                            db_trade_id,
+                        ),
+                    )
+                    conn.commit()
+                    if cur.rowcount != 1:
+                        logger.warning(
+                            "Exit UPDATE on trades.id=%d affected "
+                            "rows_affected=%d (expected 1) ticker=%s "
+                            "trade_id=%d",
+                            db_trade_id, cur.rowcount, active.ticker, trade_id,
+                        )
+                finally:
+                    conn.close()
+            except Exception:
+                logger.exception(
+                    "Failed to update trade record for db_trade_id=%d "
+                    "(positions.id=%d)",
+                    db_trade_id, trade_id,
                 )
-                conn.commit()
-            finally:
-                conn.close()
-        except Exception:
-            logger.exception("Failed to update trade record for trade_id=%d", trade_id)
 
         if trade_id in self._active_orders:
             del self._active_orders[trade_id]
@@ -864,12 +937,16 @@ class OrderManager:
                 )
                 trade_id: int = cursor.lastrowid  # type: ignore[assignment]
 
-                conn.execute(
+                # Tag the trades row with strategy_id so postmortems and
+                # daily reports can attribute outcomes. Falls back to
+                # 'unknown' to mirror the positions row above and keep
+                # downstream queries NULL-safe.
+                trades_cursor = conn.execute(
                     "INSERT INTO trades "
                     "(ticker, exchange, currency, side, entry_time, entry_price, "
                     " quantity, hold_type, phase, signal_price, sentiment_score, "
-                    " signals) "
-                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    " signals, strategy_id) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                     (
                         decision.ticker,
                         decision.exchange,
@@ -883,13 +960,22 @@ class OrderManager:
                         decision.limit_price,
                         decision.sentiment_score,
                         decision.signals,
+                        decision.strategy_id or "unknown",
                     ),
                 )
+                # Capture trades.id so the exit-update path can target the
+                # correct trades row (B3). trades.id and positions.id are
+                # independent autoincrements; pre-fix _close_position used
+                # positions.id as the trades WHERE clause.
+                db_trade_id: int = trades_cursor.lastrowid  # type: ignore[assignment]
                 conn.commit()
                 logger.info(
-                    "Created position record: %s trade_id=%d",
-                    decision.ticker, trade_id,
+                    "Created position record: %s positions.id=%d trades.id=%d",
+                    decision.ticker, trade_id, db_trade_id,
                 )
+                # Stash on the in-memory tracker so the active order can
+                # carry the trades.id forward.
+                self._pending_db_trade_ids[trade_id] = db_trade_id
                 return trade_id
             finally:
                 conn.close()
@@ -925,14 +1011,33 @@ class OrderManager:
         try:
             conn: sqlite3.Connection = sqlite3.connect(self._db_path)
             try:
-                conn.execute(sql, (value, now_str, trade_id))
+                cursor = conn.execute(sql, (value, now_str, trade_id))
                 conn.commit()
+                rows_affected: int = cursor.rowcount
             finally:
                 conn.close()
         except Exception:
             logger.exception(
                 "Failed to update positions.%s for trade_id=%d",
                 field_name, trade_id,
+            )
+            return
+
+        # B5 observability: pin which writes succeeded with rows_affected so a
+        # silent no-op (wrong WHERE clause, missing row) surfaces immediately.
+        # Pre-Phase-3 hypothesis was that this UPDATE was hitting the wrong
+        # trade_id; the real cause was upstream submit_order errors / recovery
+        # paths skipping the call entirely. Either way, we want the breadcrumb.
+        if rows_affected == 1:
+            logger.debug(
+                "positions UPDATE field=%s trade_id=%d rows_affected=1",
+                field_name, trade_id,
+            )
+        else:
+            logger.warning(
+                "positions UPDATE field=%s trade_id=%d rows_affected=%d "
+                "(expected 1) — silent write-back failure",
+                field_name, trade_id, rows_affected,
             )
 
     def _log_rejection(

--- a/trading_bot/execution/virtual_portfolio.py
+++ b/trading_bot/execution/virtual_portfolio.py
@@ -116,7 +116,9 @@ class VirtualPortfolio:
         conn.row_factory = sqlite3.Row
         try:
             rows = conn.execute(
-                "SELECT * FROM positions WHERE strategy_id = ? AND status != 'CLOSED'",
+                "SELECT * FROM positions "
+                "WHERE strategy_id = ? "
+                "AND status NOT IN ('CLOSED', 'ENTRY_FAILED')",
                 (self.strategy_id,),
             ).fetchall()
             return [dict(r) for r in rows]

--- a/trading_bot/gateway/recovery.py
+++ b/trading_bot/gateway/recovery.py
@@ -465,6 +465,17 @@ class StateRecovery:
             conn.close()
 
     def _close_db_position(self, position_id: int, reason: str) -> None:
+        """Mark a DB-only position CLOSED and stamp a matching trades row.
+
+        Phase 3 B4 fix: the trades INSERT now carries the position's
+        strategy_id, derives ``side`` from the quantity sign (positive →
+        BUY long entry, negative → SELL short entry — the schema stores
+        the entry direction; ``exit_reason`` captures the close), and
+        leaves ``exit_price``/``net_pnl`` NULL so the alpaca_backfill
+        tool can populate them from order history. Pre-fix hardcoded
+        side='SELL' made every recovery-driven trade look like a short
+        entry, with no strategy attribution at all.
+        """
         now: str = datetime.now(tz=ET).isoformat()
         conn: sqlite3.Connection = sqlite3.connect(self._db_path)
         # Use Row factory so the audit-table INSERT below references columns
@@ -487,27 +498,38 @@ class StateRecovery:
                         "SELECT * FROM positions WHERE id = ?", (position_id,)
                     ).fetchone()
                     if row:
+                        qty: int = int(row["quantity"] or 0)
+                        # The bot is long-only at the strategy layer, but
+                        # the schema technically allows shorts — derive
+                        # rather than assume. Positive qty == long entry.
+                        entry_side: str = "BUY" if qty >= 0 else "SELL"
                         conn.execute(
-                            """INSERT INTO trades
-                               (ticker, exchange, currency, side, entry_time,
-                                entry_price, quantity, exit_time, exit_reason,
-                                hold_type, phase, notes)
-                               VALUES (:ticker, :exchange, :currency, 'SELL',
-                                       :entry_time, :entry_price, :quantity,
-                                       :exit_time, :exit_reason, :hold_type,
-                                       :phase,
-                                       'Auto-closed by state recovery')""",
+                            "INSERT INTO trades "
+                            "(ticker, exchange, currency, side, entry_time, "
+                            " entry_price, quantity, exit_time, exit_reason, "
+                            " hold_type, phase, strategy_id, notes) "
+                            "VALUES (:ticker, :exchange, :currency, :side, "
+                            "        :entry_time, :entry_price, :quantity, "
+                            "        :exit_time, :exit_reason, :hold_type, "
+                            "        :phase, :strategy_id, :notes)",
                             {
                                 "ticker": row["ticker"],
                                 "exchange": row["exchange"],
                                 "currency": row["currency"],
+                                "side": entry_side,
                                 "entry_time": row["entry_time"],
                                 "entry_price": row["entry_price"],
-                                "quantity": row["quantity"],
+                                "quantity": abs(qty),
                                 "exit_time": now,
                                 "exit_reason": reason,
                                 "hold_type": row["hold_type"],
                                 "phase": row["phase"],
+                                "strategy_id": row["strategy_id"] or "unknown",
+                                "notes": (
+                                    "Auto-closed by state recovery; "
+                                    "exit_price/net_pnl pending "
+                                    "alpaca_backfill"
+                                ),
                             },
                         )
             except sqlite3.OperationalError:

--- a/trading_bot/health/server.py
+++ b/trading_bot/health/server.py
@@ -127,7 +127,8 @@ class HealthServer:
             try:
                 # Open positions count
                 row = conn.execute(
-                    "SELECT COUNT(*) AS cnt FROM positions WHERE status != 'CLOSED'"
+                    "SELECT COUNT(*) AS cnt FROM positions "
+                    "WHERE status NOT IN ('CLOSED', 'ENTRY_FAILED')"
                 ).fetchone()
                 open_positions_count = int(row["cnt"]) if row else 0
 

--- a/trading_bot/main.py
+++ b/trading_bot/main.py
@@ -765,7 +765,11 @@ class TradingBot:
             status: str = position.get("status", "")
 
             # Skip positions that are already being closed
-            if status in (PositionStatus.CLOSING.value, PositionStatus.CLOSED.value):
+            if status in (
+                PositionStatus.CLOSING.value,
+                PositionStatus.CLOSED.value,
+                PositionStatus.ENTRY_FAILED.value,
+            ):
                 continue
 
             # Require a current price
@@ -965,7 +969,11 @@ class TradingBot:
                 logger.info("%s: swing — exempt from wind-down", ticker)
                 continue
 
-            if status in (PositionStatus.CLOSING.value, PositionStatus.CLOSED.value):
+            if status in (
+                PositionStatus.CLOSING.value,
+                PositionStatus.CLOSED.value,
+                PositionStatus.ENTRY_FAILED.value,
+            ):
                 continue
 
             # Only close positions belonging to this market

--- a/trading_bot/reporting/daily_report.py
+++ b/trading_bot/reporting/daily_report.py
@@ -368,7 +368,9 @@ class ReportGenerator:
         conn.row_factory = sqlite3.Row
         try:
             rows = conn.execute(
-                "SELECT * FROM positions WHERE status != 'CLOSED' ORDER BY entry_time"
+                "SELECT * FROM positions "
+                "WHERE status NOT IN ('CLOSED', 'ENTRY_FAILED') "
+                "ORDER BY entry_time"
             ).fetchall()
             return [dict(r) for r in rows]
         except sqlite3.OperationalError:

--- a/trading_bot/self_improve/__init__.py
+++ b/trading_bot/self_improve/__init__.py
@@ -1,12 +1,10 @@
-"""Self-improvement research agent.
+"""Self-improvement and reconciliation tooling.
 
-Runs at end of trading day. Produces a markdown report containing:
-  1. Postmortem of recent trades (per-strategy stats over rolling window)
-  2. Hypotheses for config tweaks (deterministic, rule-based, bounded steps)
-  3. Backtest A/B results validating each hypothesis on historical data
-
-The report is committed via a draft PR. Humans review and apply the patch
-manually. The agent never edits ``config.yaml`` directly.
+The agent (postmortem + hypotheses + backtest gate + report) runs at end
+of trading day and produces a draft-PR markdown report. The reconcile
+module is a standalone read-only research tool that compares local
+SQLite state against the live Alpaca account and produces a markdown
+inventory of discrepancies. Neither edits the live DB or submits orders.
 """
 
 from trading_bot.self_improve.postmortem import StrategyStats, compute_window_stats

--- a/trading_bot/self_improve/reconcile/__init__.py
+++ b/trading_bot/self_improve/reconcile/__init__.py
@@ -1,0 +1,65 @@
+"""Read-only reconciliation: local SQLite state vs live Alpaca account.
+
+Run as a module to produce a markdown inventory report::
+
+    python -m trading_bot.self_improve.reconcile [--db PATH] [--since YYYY-MM-DD]
+                                                  [--output PATH]
+
+The package never writes to the DB and never submits orders. It pulls every
+order + position in the window, walks the local DB, classifies each row, and
+renders a markdown report grouped by classification with a proposed corrective
+action per row.
+
+See ``docs/self_improve_followups.md`` for the data-layer bug hypotheses this
+report is designed to confirm.
+"""
+
+from __future__ import annotations
+
+from trading_bot.self_improve.reconcile.alpaca_fetch import (
+    AlpacaFetcher,
+    AlpacaOrderRec,
+    AlpacaPosition,
+    AlpacaState,
+    fetch_alpaca_state,
+)
+from trading_bot.self_improve.reconcile.classify import (
+    PositionClass,
+    PositionFinding,
+    TradeClass,
+    TradeFinding,
+    classify_position,
+    classify_trade,
+)
+from trading_bot.self_improve.reconcile.db_loaders import (
+    _position_lookup,
+    load_db_positions,
+    load_db_trades,
+    load_strategy_enabled_map,
+)
+from trading_bot.self_improve.reconcile.report import (
+    ReconcileReport,
+    build_report,
+    render_markdown,
+)
+
+__all__: list[str] = [
+    "AlpacaFetcher",
+    "AlpacaOrderRec",
+    "AlpacaPosition",
+    "AlpacaState",
+    "PositionClass",
+    "PositionFinding",
+    "ReconcileReport",
+    "TradeClass",
+    "TradeFinding",
+    "build_report",
+    "classify_position",
+    "classify_trade",
+    "fetch_alpaca_state",
+    "load_db_positions",
+    "load_db_trades",
+    "load_strategy_enabled_map",
+    "render_markdown",
+    "_position_lookup",
+]

--- a/trading_bot/self_improve/reconcile/__main__.py
+++ b/trading_bot/self_improve/reconcile/__main__.py
@@ -1,0 +1,200 @@
+"""CLI entry point: ``python -m trading_bot.self_improve.reconcile``.
+
+Read-only by construction — the only side effects are logging and writing
+the markdown report file. Pulls Alpaca state via the unified env resolver
+so paper/live selection follows the same contract as the live bot.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sqlite3
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from trading_bot.self_improve.reconcile.alpaca_fetch import (
+    AlpacaFetcher,
+    AlpacaState,
+    fetch_alpaca_state,
+)
+from trading_bot.self_improve.reconcile.db_loaders import (
+    load_db_positions,
+    load_db_trades,
+    load_strategy_enabled_map,
+)
+from trading_bot.self_improve.reconcile.report import (
+    ReconcileReport,
+    build_report,
+    render_markdown,
+)
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+DEFAULT_LOOKBACK_DAYS: int = 30
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="python -m trading_bot.self_improve.reconcile",
+        description=(
+            "Read-only reconciliation between the local SQLite DB and the "
+            "live Alpaca account. Writes a markdown report; touches nothing."
+        ),
+    )
+    parser.add_argument(
+        "--db",
+        default=None,
+        help=(
+            "Path to the SQLite DB. Defaults to config.yaml's database.path "
+            "(typically trading_bot/data/trading_bot.db)."
+        ),
+    )
+    parser.add_argument(
+        "--config",
+        default="config.yaml",
+        help="Path to config.yaml (used for db path + strategy enabled map).",
+    )
+    parser.add_argument(
+        "--since",
+        default=None,
+        help=(
+            "Lower bound for Alpaca order pull as YYYY-MM-DD. "
+            f"Default: {DEFAULT_LOOKBACK_DAYS} days back."
+        ),
+    )
+    parser.add_argument(
+        "--until",
+        default=None,
+        help="Upper bound for Alpaca order pull as YYYY-MM-DD. Default: now.",
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        help=(
+            "Output path for the markdown report. Default: "
+            "self_improve_reports/reconcile_<UTC date>.md."
+        ),
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+    )
+    return parser.parse_args(argv)
+
+
+def _resolve_db_path(args: argparse.Namespace) -> str:
+    if args.db:
+        return str(args.db)
+    import yaml
+
+    config_path = Path(args.config).expanduser().resolve()
+    if not config_path.exists():
+        raise FileNotFoundError(f"config.yaml not found at {config_path}")
+    with config_path.open("r", encoding="utf-8") as fh:
+        cfg: Any = yaml.safe_load(fh) or {}
+    db_block: Any = cfg.get("database") or {}
+    return str(db_block.get("path") or "trading_bot/data/trading_bot.db")
+
+
+def _resolve_window(args: argparse.Namespace) -> tuple[datetime, datetime]:
+    until: datetime
+    if args.until:
+        until = datetime.fromisoformat(args.until).replace(tzinfo=timezone.utc)
+    else:
+        until = datetime.now(tz=timezone.utc)
+    since: datetime
+    if args.since:
+        since = datetime.fromisoformat(args.since).replace(tzinfo=timezone.utc)
+    else:
+        since = until - timedelta(days=DEFAULT_LOOKBACK_DAYS)
+    return since, until
+
+
+def _build_alpaca_client() -> AlpacaFetcher:
+    """Construct a TradingClient using the unified env resolver."""
+    from alpaca.trading.client import TradingClient
+
+    from trading_bot.env import resolve_alpaca_env
+
+    api_key, secret_key, is_paper = resolve_alpaca_env()
+    if not api_key or not secret_key:
+        raise RuntimeError(
+            "Missing Alpaca credentials. Set ALPACA_PAPER_KEY_ID + "
+            "ALPACA_PAPER_SECRET (or ALPACA_LIVE_*) in the environment."
+        )
+    return TradingClient(api_key=api_key, secret_key=secret_key, paper=is_paper)
+
+
+def _resolve_output_path(args: argparse.Namespace) -> Path:
+    if args.output:
+        return Path(args.output).expanduser().resolve()
+    today: str = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d")
+    return Path("self_improve_reports").resolve() / f"reconcile_{today}.md"
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(list(sys.argv[1:] if argv is None else argv))
+    logging.basicConfig(
+        level=getattr(logging, args.log_level),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    db_path: str = _resolve_db_path(args)
+    if not Path(db_path).exists():
+        logger.error("DB not found at %s", db_path)
+        return 2
+    since, until = _resolve_window(args)
+    strategy_enabled: dict[str, bool] = load_strategy_enabled_map(args.config)
+    logger.info(
+        "Reconciling DB=%s window=[%s, %s] strategies=%s",
+        db_path,
+        since.date(),
+        until.date(),
+        strategy_enabled,
+    )
+
+    client: AlpacaFetcher = _build_alpaca_client()
+    state: AlpacaState = fetch_alpaca_state(client, since=since, until=until)
+    logger.info(
+        "Alpaca state: %d positions, %d orders in window",
+        len(state.positions_by_symbol),
+        len(state.orders_by_id),
+    )
+
+    conn: sqlite3.Connection = sqlite3.connect(db_path)
+    try:
+        db_positions: list[dict[str, Any]] = load_db_positions(conn)
+        db_trades: list[dict[str, Any]] = load_db_trades(conn)
+    finally:
+        conn.close()
+    logger.info(
+        "DB rows: %d positions, %d trades",
+        len(db_positions),
+        len(db_trades),
+    )
+
+    report: ReconcileReport = build_report(
+        db_path=db_path,
+        state=state,
+        db_positions=db_positions,
+        db_trades=db_trades,
+        strategy_enabled=strategy_enabled,
+        since=since,
+        until=until,
+    )
+    markdown: str = render_markdown(report)
+
+    output_path: Path = _resolve_output_path(args)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(markdown, encoding="utf-8")
+    logger.info("Wrote reconciliation report to %s", output_path)
+    print(str(output_path))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/trading_bot/self_improve/reconcile/alpaca_fetch.py
+++ b/trading_bot/self_improve/reconcile/alpaca_fetch.py
@@ -1,0 +1,214 @@
+"""Pull positions and orders from Alpaca for reconciliation.
+
+The fetcher is isolated behind a Protocol so tests can build an ``AlpacaState``
+by hand without touching the network.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Mapping, Protocol
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Data containers
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AlpacaPosition:
+    """Subset of an alpaca-py Position we need for reconciliation."""
+
+    symbol: str
+    qty: float
+    avg_entry_price: float
+    market_value: float
+
+
+@dataclass(frozen=True)
+class AlpacaOrderRec:
+    """Subset of an alpaca-py Order, normalised for matching."""
+
+    order_id: str
+    symbol: str
+    side: str  # "buy" / "sell"
+    status: str
+    qty: float
+    filled_qty: float
+    filled_avg_price: float | None
+    filled_at: datetime | None
+    submitted_at: datetime | None
+
+
+@dataclass(frozen=True)
+class AlpacaState:
+    """Snapshot of Alpaca state at the time the report was generated."""
+
+    account_id: str
+    is_paper: bool
+    fetched_at: datetime
+    positions_by_symbol: Mapping[str, AlpacaPosition]
+    orders_by_id: Mapping[str, AlpacaOrderRec]
+    fills_by_symbol: Mapping[str, tuple[AlpacaOrderRec, ...]]
+
+
+class AlpacaFetcher(Protocol):
+    """Minimal interface for the bits of alpaca-py we need."""
+
+    def get_account(self) -> Any: ...
+
+    def get_all_positions(self) -> list[Any]: ...
+
+    def get_orders(self, *, filter: Any) -> list[Any]: ...  # noqa: A002
+
+
+# ---------------------------------------------------------------------------
+# Parsers / normalisers
+# ---------------------------------------------------------------------------
+
+
+def parse_iso(value: str | datetime | None) -> datetime | None:
+    """Parse ISO timestamps from Alpaca / SQLite into a tz-aware UTC datetime."""
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    if not isinstance(value, str) or not value:
+        return None
+    text: str = value
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        dt: datetime = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def to_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _normalise_alpaca_position(raw: Any) -> AlpacaPosition | None:
+    symbol: str | None = getattr(raw, "symbol", None)
+    qty: float | None = to_float(getattr(raw, "qty", None))
+    if symbol is None or qty is None:
+        return None
+    return AlpacaPosition(
+        symbol=str(symbol).upper(),
+        qty=qty,
+        avg_entry_price=to_float(getattr(raw, "avg_entry_price", None)) or 0.0,
+        market_value=to_float(getattr(raw, "market_value", None)) or 0.0,
+    )
+
+
+def _normalise_alpaca_order(raw: Any) -> AlpacaOrderRec | None:
+    order_id: Any = getattr(raw, "id", None)
+    symbol: Any = getattr(raw, "symbol", None)
+    side: Any = getattr(raw, "side", None)
+    status: Any = getattr(raw, "status", None)
+    qty: float | None = to_float(getattr(raw, "qty", None))
+    if order_id is None or symbol is None or side is None or qty is None:
+        return None
+    return AlpacaOrderRec(
+        order_id=str(order_id),
+        symbol=str(symbol).upper(),
+        side=str(side).split(".")[-1].lower(),  # "OrderSide.BUY" -> "buy"
+        status=str(status).split(".")[-1].lower(),
+        qty=qty,
+        filled_qty=to_float(getattr(raw, "filled_qty", None)) or 0.0,
+        filled_avg_price=to_float(getattr(raw, "filled_avg_price", None)),
+        filled_at=parse_iso(getattr(raw, "filled_at", None)),
+        submitted_at=parse_iso(getattr(raw, "submitted_at", None)),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fetch
+# ---------------------------------------------------------------------------
+
+
+def fetch_alpaca_state(
+    client: AlpacaFetcher,
+    *,
+    since: datetime,
+    until: datetime,
+    page_limit: int = 500,
+) -> AlpacaState:
+    """Pull positions and orders from Alpaca in the [since, until] window.
+
+    Closed and open orders are paginated by ``submitted_at``; both feeds
+    are merged into ``orders_by_id`` so callers can look up by order id
+    regardless of status.
+    """
+    from alpaca.trading.enums import QueryOrderStatus
+    from alpaca.trading.requests import GetOrdersRequest
+
+    account = client.get_account()
+    account_id: str = str(getattr(account, "account_number", ""))
+
+    positions_raw: list[Any] = client.get_all_positions()
+    positions_by_symbol: dict[str, AlpacaPosition] = {}
+    for raw in positions_raw:
+        norm = _normalise_alpaca_position(raw)
+        if norm is not None:
+            positions_by_symbol[norm.symbol] = norm
+
+    orders_by_id: dict[str, AlpacaOrderRec] = {}
+    fills_by_symbol: dict[str, list[AlpacaOrderRec]] = {}
+
+    for status in (QueryOrderStatus.CLOSED, QueryOrderStatus.OPEN):
+        cursor_until: datetime = until
+        while True:
+            request = GetOrdersRequest(
+                status=status,
+                after=since,
+                until=cursor_until,
+                limit=page_limit,
+                direction="desc",
+            )
+            page: list[Any] = client.get_orders(filter=request)
+            if not page:
+                break
+            oldest: datetime | None = None
+            for raw in page:
+                norm = _normalise_alpaca_order(raw)
+                if norm is None:
+                    continue
+                orders_by_id[norm.order_id] = norm
+                if norm.filled_at is not None and norm.filled_qty > 0:
+                    fills_by_symbol.setdefault(norm.symbol, []).append(norm)
+                ts: datetime | None = norm.submitted_at or norm.filled_at
+                if ts is not None and (oldest is None or ts < oldest):
+                    oldest = ts
+            if len(page) < page_limit or oldest is None:
+                break
+            # Step the cursor strictly older. Alpaca's ``until`` is exclusive,
+            # so a 1-microsecond shift is enough to keep paging.
+            next_until: datetime = oldest - timedelta(microseconds=1)
+            if next_until <= since:
+                break
+            cursor_until = next_until
+
+    is_paper: bool = os.environ.get("ALPACA_ENV", "paper").strip().lower() != "live"
+
+    return AlpacaState(
+        account_id=account_id,
+        is_paper=is_paper,
+        fetched_at=datetime.now(tz=timezone.utc),
+        positions_by_symbol=positions_by_symbol,
+        orders_by_id=orders_by_id,
+        fills_by_symbol={k: tuple(v) for k, v in fills_by_symbol.items()},
+    )

--- a/trading_bot/self_improve/reconcile/classify.py
+++ b/trading_bot/self_improve/reconcile/classify.py
@@ -1,0 +1,405 @@
+"""Per-row classification of ``positions`` and ``trades`` against Alpaca state.
+
+Classifications are deliberately fine-grained so the report doubles as the
+inventory needed to plan Phase 2 (DB migration) and Phase 3 (live order
+logic fixes). See ``docs/self_improve_followups.md`` for the data-layer bug
+hypotheses each label is designed to surface.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from enum import Enum
+from typing import Any, Iterable, Mapping
+
+from trading_bot.self_improve.reconcile.alpaca_fetch import (
+    AlpacaOrderRec,
+    AlpacaState,
+    parse_iso,
+    to_float,
+)
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+QTY_TOLERANCE: float = 1e-4
+ENTRY_FILL_LOOKBACK_HOURS: int = 6
+EXIT_FILL_LOOKBACK_DAYS: int = 14
+
+
+# ---------------------------------------------------------------------------
+# Classifications
+# ---------------------------------------------------------------------------
+
+
+class PositionClass(str, Enum):
+    """Classification labels for rows in the ``positions`` table."""
+
+    ACTUAL_OPEN = "ACTUAL_OPEN"
+    MISMATCH_QTY = "MISMATCH_QTY"
+    ORPHAN_DISABLED = "ORPHAN_DISABLED"
+    ORPHAN_UNKNOWN = "ORPHAN_UNKNOWN"
+    ORPHAN_NOT_HELD = "ORPHAN_NOT_HELD"
+    ACTUAL_FILL = "ACTUAL_FILL"
+    PHANTOM_CLOSE = "PHANTOM_CLOSE"
+    CLOSED_NO_EXIT = "CLOSED_NO_EXIT"
+
+
+class TradeClass(str, Enum):
+    """Classification labels for rows in the ``trades`` table."""
+
+    ENTRY_ONLY_PHANTOM = "ENTRY_ONLY_PHANTOM"
+    MISSING_STRATEGY = "MISSING_STRATEGY"
+    MISSING_EXIT = "MISSING_EXIT"
+    COMPLETE = "COMPLETE"
+
+
+_POSITION_ACTION: dict[PositionClass, str] = {
+    PositionClass.ACTUAL_OPEN: "No action — DB and Alpaca agree.",
+    PositionClass.MISMATCH_QTY: (
+        "Update positions.quantity to match Alpaca (or place reconciling order). "
+        "Investigate whether a partial fill was missed."
+    ),
+    PositionClass.ORPHAN_DISABLED: (
+        "Adopt-and-flatten: re-enable the strategy long enough for the next tick "
+        "to manage out, OR add an orphan-handler that takes ownership at tick "
+        "time. Do not edit the DB until cash is reconciled."
+    ),
+    PositionClass.ORPHAN_UNKNOWN: (
+        "Manual review required — no strategy means no exit policy. Inspect "
+        "Alpaca for matching symbol; if held, adopt under a fallback strategy "
+        "and place a manual exit. If not held, mark CLOSED with "
+        "exit_reason='reconciliation_mismatch'."
+    ),
+    PositionClass.ORPHAN_NOT_HELD: (
+        "DB shows open but Alpaca holds zero. Likely an unrecorded fill of an "
+        "exit order. Backfill the trades row from Alpaca order history (see "
+        "alpaca_backfill) and stamp positions.status = CLOSED."
+    ),
+    PositionClass.ACTUAL_FILL: (
+        "No action — DB CLOSED and both entry+exit fills present on Alpaca. "
+        "If trades row is missing exit data, run alpaca_backfill."
+    ),
+    PositionClass.PHANTOM_CLOSE: (
+        "Confirm with Alpaca that the entry never filled. If so, the position "
+        "row is correct as CLOSED but the trades row should be deleted (or "
+        "marked exit_reason='entry_canceled', net_pnl=0). Live fix: don't "
+        "insert a trades row until entry fill confirms."
+    ),
+    PositionClass.CLOSED_NO_EXIT: (
+        "Entry filled but no exit fill found in lookback window. Widen window "
+        "or treat as wind_down/manual close — backfill trades row from "
+        "positions and any matching SELL within 14 days. If still nothing, "
+        "exit may have happened pre-window."
+    ),
+}
+
+_TRADE_ACTION: dict[TradeClass, str] = {
+    TradeClass.ENTRY_ONLY_PHANTOM: (
+        "Live bug: order_manager._create_position_record inserts trades "
+        "without strategy_id and never updates exit (positions.id is used as "
+        "trade_id, so UPDATE trades WHERE id = ? misses). Either delete and "
+        "rewrite via save_trade(), or backfill via alpaca_backfill keyed off "
+        "positions row."
+    ),
+    TradeClass.MISSING_STRATEGY: (
+        "Backfill strategy_id from the paired positions row "
+        "(JOIN ON ticker AND entry_time)."
+    ),
+    TradeClass.MISSING_EXIT: (
+        "Pair against CLOSED positions row and backfill exit fields from "
+        "Alpaca fills (alpaca_backfill handles this)."
+    ),
+    TradeClass.COMPLETE: "No action — row is fully populated.",
+}
+
+
+# ---------------------------------------------------------------------------
+# Findings
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PositionFinding:
+    db_row: Mapping[str, Any]
+    classification: PositionClass
+    evidence: str
+    proposed_action: str
+
+
+@dataclass(frozen=True)
+class TradeFinding:
+    db_row: Mapping[str, Any]
+    classification: TradeClass
+    evidence: str
+    proposed_action: str
+
+
+# ---------------------------------------------------------------------------
+# Position classifier
+# ---------------------------------------------------------------------------
+
+
+def _find_entry_fill(
+    state: AlpacaState,
+    *,
+    symbol: str,
+    entry_time: datetime,
+    qty: float,
+    explicit_order_id: str | None,
+) -> AlpacaOrderRec | None:
+    """Return the BUY fill that backs a position's entry, if discoverable."""
+    if explicit_order_id and explicit_order_id in state.orders_by_id:
+        order = state.orders_by_id[explicit_order_id]
+        if order.filled_qty > 0:
+            return order
+    candidates: Iterable[AlpacaOrderRec] = state.fills_by_symbol.get(symbol, ())
+    window_start: datetime = entry_time - timedelta(hours=ENTRY_FILL_LOOKBACK_HOURS)
+    window_end: datetime = entry_time + timedelta(hours=ENTRY_FILL_LOOKBACK_HOURS)
+    best: AlpacaOrderRec | None = None
+    for c in candidates:
+        if c.side != "buy":
+            continue
+        if c.filled_at is None or not (window_start <= c.filled_at <= window_end):
+            continue
+        if c.filled_qty + QTY_TOLERANCE < qty:
+            continue
+        if best is None or abs((c.filled_at - entry_time).total_seconds()) < abs(
+            (best.filled_at - entry_time).total_seconds()  # type: ignore[operator]
+        ):
+            best = c
+    return best
+
+
+def _find_exit_fill(
+    state: AlpacaState,
+    *,
+    symbol: str,
+    entry_time: datetime,
+    qty: float,
+    bracket_order_ids: tuple[str | None, ...],
+) -> AlpacaOrderRec | None:
+    """Return the SELL fill that closed a position, if discoverable."""
+    for oid in bracket_order_ids:
+        if oid and oid in state.orders_by_id:
+            order = state.orders_by_id[oid]
+            if order.side == "sell" and order.filled_qty > 0:
+                return order
+    candidates: Iterable[AlpacaOrderRec] = state.fills_by_symbol.get(symbol, ())
+    window_start: datetime = entry_time
+    window_end: datetime = entry_time + timedelta(days=EXIT_FILL_LOOKBACK_DAYS)
+    for c in candidates:
+        if c.side != "sell":
+            continue
+        if c.filled_at is None or not (window_start <= c.filled_at <= window_end):
+            continue
+        if c.filled_qty + QTY_TOLERANCE < qty:
+            continue
+        return c
+    return None
+
+
+def _classify_open_position(
+    pos: Mapping[str, Any],
+    state: AlpacaState,
+    strategy_enabled: Mapping[str, bool],
+) -> PositionFinding:
+    ticker: str = str(pos["ticker"]).upper()
+    db_qty: float = to_float(pos.get("quantity")) or 0.0
+    strategy_id: Any = pos.get("strategy_id")
+    held = state.positions_by_symbol.get(ticker)
+
+    if strategy_id in (None, "", "unknown"):
+        return PositionFinding(
+            db_row=pos,
+            classification=PositionClass.ORPHAN_UNKNOWN,
+            evidence=(
+                f"strategy_id={strategy_id!r}; "
+                f"alpaca_holds={'yes' if held else 'no'}"
+            ),
+            proposed_action=_POSITION_ACTION[PositionClass.ORPHAN_UNKNOWN],
+        )
+    if not strategy_enabled.get(strategy_id, False):
+        return PositionFinding(
+            db_row=pos,
+            classification=PositionClass.ORPHAN_DISABLED,
+            evidence=(
+                f"strategy_id={strategy_id!r} is disabled in config; "
+                f"alpaca_holds={'yes' if held else 'no'}, db_qty={db_qty:g}"
+            ),
+            proposed_action=_POSITION_ACTION[PositionClass.ORPHAN_DISABLED],
+        )
+    if held is None:
+        return PositionFinding(
+            db_row=pos,
+            classification=PositionClass.ORPHAN_NOT_HELD,
+            evidence=(
+                f"DB qty={db_qty:g} but Alpaca holds zero {ticker}; "
+                f"strategy={strategy_id}"
+            ),
+            proposed_action=_POSITION_ACTION[PositionClass.ORPHAN_NOT_HELD],
+        )
+    if abs(held.qty - db_qty) > QTY_TOLERANCE:
+        return PositionFinding(
+            db_row=pos,
+            classification=PositionClass.MISMATCH_QTY,
+            evidence=(
+                f"DB qty={db_qty:g} vs Alpaca qty={held.qty:g} "
+                f"(diff={held.qty - db_qty:+g})"
+            ),
+            proposed_action=_POSITION_ACTION[PositionClass.MISMATCH_QTY],
+        )
+    return PositionFinding(
+        db_row=pos,
+        classification=PositionClass.ACTUAL_OPEN,
+        evidence=(
+            f"DB qty={db_qty:g} matches Alpaca qty={held.qty:g}; "
+            f"avg_entry={held.avg_entry_price:.4f}"
+        ),
+        proposed_action=_POSITION_ACTION[PositionClass.ACTUAL_OPEN],
+    )
+
+
+def _classify_closed_position(
+    pos: Mapping[str, Any],
+    state: AlpacaState,
+) -> PositionFinding:
+    ticker: str = str(pos["ticker"]).upper()
+    db_qty: float = to_float(pos.get("quantity")) or 0.0
+    entry_time: datetime | None = parse_iso(pos.get("entry_time"))
+    if entry_time is None:
+        return PositionFinding(
+            db_row=pos,
+            classification=PositionClass.PHANTOM_CLOSE,
+            evidence="entry_time is unparseable; cannot search Alpaca for fills",
+            proposed_action=_POSITION_ACTION[PositionClass.PHANTOM_CLOSE],
+        )
+
+    entry_fill = _find_entry_fill(
+        state,
+        symbol=ticker,
+        entry_time=entry_time,
+        qty=db_qty,
+        explicit_order_id=pos.get("alpaca_order_id"),
+    )
+    if entry_fill is None:
+        return PositionFinding(
+            db_row=pos,
+            classification=PositionClass.PHANTOM_CLOSE,
+            evidence=(
+                f"No BUY fill found on Alpaca within "
+                f"+/-{ENTRY_FILL_LOOKBACK_HOURS}h of "
+                f"entry_time={entry_time.isoformat()}; "
+                f"alpaca_order_id={pos.get('alpaca_order_id')!r}"
+            ),
+            proposed_action=_POSITION_ACTION[PositionClass.PHANTOM_CLOSE],
+        )
+
+    exit_fill = _find_exit_fill(
+        state,
+        symbol=ticker,
+        entry_time=entry_time,
+        qty=db_qty,
+        bracket_order_ids=(
+            pos.get("alpaca_stop_order_id"),
+            pos.get("alpaca_target_order_id"),
+            pos.get("alpaca_trail_order_id"),
+        ),
+    )
+    if exit_fill is None:
+        return PositionFinding(
+            db_row=pos,
+            classification=PositionClass.CLOSED_NO_EXIT,
+            evidence=(
+                f"Entry fill found ({entry_fill.order_id}) but no SELL fill "
+                f"within {EXIT_FILL_LOOKBACK_DAYS} days. May have closed "
+                "outside lookback window."
+            ),
+            proposed_action=_POSITION_ACTION[PositionClass.CLOSED_NO_EXIT],
+        )
+
+    return PositionFinding(
+        db_row=pos,
+        classification=PositionClass.ACTUAL_FILL,
+        evidence=(
+            f"Entry {entry_fill.order_id} filled {entry_fill.filled_qty:g}@"
+            f"{entry_fill.filled_avg_price}; "
+            f"exit {exit_fill.order_id} filled {exit_fill.filled_qty:g}@"
+            f"{exit_fill.filled_avg_price}"
+        ),
+        proposed_action=_POSITION_ACTION[PositionClass.ACTUAL_FILL],
+    )
+
+
+def classify_position(
+    pos: Mapping[str, Any],
+    state: AlpacaState,
+    strategy_enabled: Mapping[str, bool],
+) -> PositionFinding:
+    """Classify a single ``positions`` row against live Alpaca state."""
+    status: str = str(pos.get("status") or "").upper()
+    if status != "CLOSED":
+        return _classify_open_position(pos, state, strategy_enabled)
+    return _classify_closed_position(pos, state)
+
+
+# ---------------------------------------------------------------------------
+# Trade classifier
+# ---------------------------------------------------------------------------
+
+
+def classify_trade(
+    trade: Mapping[str, Any],
+    position_lookup: Mapping[tuple[str, str], Mapping[str, Any]],
+) -> TradeFinding:
+    """Classify a single ``trades`` row, pairing it against positions."""
+    strategy_id: Any = trade.get("strategy_id")
+    exit_time: Any = trade.get("exit_time")
+    has_strategy: bool = bool(strategy_id) and strategy_id != "unknown"
+    has_exit: bool = bool(exit_time)
+    paired = position_lookup.get(
+        (str(trade["ticker"]).upper(), str(trade.get("entry_time") or ""))
+    )
+    paired_strategy: Any = paired.get("strategy_id") if paired else None
+    paired_status: str = str(paired.get("status") or "").upper() if paired else ""
+
+    if not has_strategy and not has_exit:
+        return TradeFinding(
+            db_row=trade,
+            classification=TradeClass.ENTRY_ONLY_PHANTOM,
+            evidence=(
+                f"strategy_id IS NULL and exit_time IS NULL; "
+                f"paired position strategy={paired_strategy!r} "
+                f"status={paired_status or 'NONE'}"
+            ),
+            proposed_action=_TRADE_ACTION[TradeClass.ENTRY_ONLY_PHANTOM],
+        )
+    if not has_strategy:
+        return TradeFinding(
+            db_row=trade,
+            classification=TradeClass.MISSING_STRATEGY,
+            evidence=(
+                f"exit_time={exit_time!r} present but strategy_id NULL; "
+                f"paired position strategy={paired_strategy!r}"
+            ),
+            proposed_action=_TRADE_ACTION[TradeClass.MISSING_STRATEGY],
+        )
+    if not has_exit:
+        return TradeFinding(
+            db_row=trade,
+            classification=TradeClass.MISSING_EXIT,
+            evidence=(
+                f"strategy_id={strategy_id!r} present but exit_time NULL; "
+                f"paired position status={paired_status or 'NONE'}"
+            ),
+            proposed_action=_TRADE_ACTION[TradeClass.MISSING_EXIT],
+        )
+    return TradeFinding(
+        db_row=trade,
+        classification=TradeClass.COMPLETE,
+        evidence=f"strategy={strategy_id} exit_time={exit_time}",
+        proposed_action=_TRADE_ACTION[TradeClass.COMPLETE],
+    )

--- a/trading_bot/self_improve/reconcile/classify.py
+++ b/trading_bot/self_improve/reconcile/classify.py
@@ -339,8 +339,21 @@ def classify_position(
     state: AlpacaState,
     strategy_enabled: Mapping[str, bool],
 ) -> PositionFinding:
-    """Classify a single ``positions`` row against live Alpaca state."""
+    """Classify a single ``positions`` row against live Alpaca state.
+
+    Terminal states (CLOSED, ENTRY_FAILED) take the closed-side branch.
+    ENTRY_FAILED is the post-V8 label for what we used to detect heuristically
+    as PHANTOM_CLOSE — when we see it we can short-circuit to that classification
+    without re-querying Alpaca.
+    """
     status: str = str(pos.get("status") or "").upper()
+    if status == "ENTRY_FAILED":
+        return PositionFinding(
+            db_row=pos,
+            classification=PositionClass.PHANTOM_CLOSE,
+            evidence="status='ENTRY_FAILED' — V8 migration already flagged this row",
+            proposed_action=_POSITION_ACTION[PositionClass.PHANTOM_CLOSE],
+        )
     if status != "CLOSED":
         return _classify_open_position(pos, state, strategy_enabled)
     return _classify_closed_position(pos, state)

--- a/trading_bot/self_improve/reconcile/db_loaders.py
+++ b/trading_bot/self_improve/reconcile/db_loaders.py
@@ -1,0 +1,63 @@
+"""DB row loaders and config-derived strategy enabled map.
+
+Read-only: every function takes a ``sqlite3.Connection`` (or a path) and
+returns plain dicts; nothing is written.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+
+def load_db_positions(conn: sqlite3.Connection) -> list[dict[str, Any]]:
+    """Return every row in ``positions`` as a dict, ordered by entry_time."""
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute(
+        "SELECT * FROM positions ORDER BY entry_time"
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def load_db_trades(conn: sqlite3.Connection) -> list[dict[str, Any]]:
+    """Return every row in ``trades`` as a dict, ordered by entry_time."""
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute(
+        "SELECT * FROM trades ORDER BY entry_time"
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def _position_lookup(
+    positions: Iterable[Mapping[str, Any]],
+) -> dict[tuple[str, str], Mapping[str, Any]]:
+    """Build ``(ticker, entry_time) -> position row`` for trade pairing."""
+    out: dict[tuple[str, str], Mapping[str, Any]] = {}
+    for p in positions:
+        key = (str(p["ticker"]).upper(), str(p.get("entry_time") or ""))
+        out[key] = p
+    return out
+
+
+def load_strategy_enabled_map(config_path: str) -> dict[str, bool]:
+    """Return ``{strategy_id: enabled}`` for every strategy defined in config.
+
+    Read directly from ``config.yaml`` so we don't have to instantiate the
+    full ``Config`` (which loads a lot of unrelated state and can fail
+    reconcile runs in environments where some other config block is mid-
+    edit).
+    """
+    import yaml
+
+    path = Path(config_path).expanduser().resolve()
+    with path.open("r", encoding="utf-8") as fh:
+        raw: Any = yaml.safe_load(fh)
+    multi: Any = (raw or {}).get("multi_strategy") or {}
+    strategies: Any = multi.get("strategies") or {}
+    out: dict[str, bool] = {}
+    if isinstance(strategies, dict):
+        for sid, body in strategies.items():
+            if isinstance(body, dict):
+                out[str(sid)] = bool(body.get("enabled", False))
+    return out

--- a/trading_bot/self_improve/reconcile/report.py
+++ b/trading_bot/self_improve/reconcile/report.py
@@ -1,0 +1,250 @@
+"""Assemble + render the markdown reconciliation report.
+
+The report groups every classified row by category, prints a per-row
+evidence line and a proposed corrective action, and ends with a
+bug-hypothesis confirmation table that maps category counts back to the
+five bugs in ``docs/self_improve_followups.md``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Iterable, Mapping
+
+from trading_bot.self_improve.reconcile.alpaca_fetch import AlpacaState
+from trading_bot.self_improve.reconcile.classify import (
+    PositionClass,
+    PositionFinding,
+    TradeClass,
+    TradeFinding,
+    classify_position,
+    classify_trade,
+)
+from trading_bot.self_improve.reconcile.db_loaders import _position_lookup
+
+
+@dataclass(frozen=True)
+class ReconcileReport:
+    generated_at: datetime
+    db_path: str
+    account_id: str
+    is_paper: bool
+    since: datetime
+    until: datetime
+    strategy_enabled: Mapping[str, bool]
+    position_findings: tuple[PositionFinding, ...]
+    trade_findings: tuple[TradeFinding, ...]
+    raw_alpaca_position_count: int
+    raw_alpaca_order_count: int
+
+
+def build_report(
+    *,
+    db_path: str,
+    state: AlpacaState,
+    db_positions: list[dict[str, Any]],
+    db_trades: list[dict[str, Any]],
+    strategy_enabled: Mapping[str, bool],
+    since: datetime,
+    until: datetime,
+) -> ReconcileReport:
+    """Classify every DB row and roll the findings into a single report."""
+    position_findings = tuple(
+        classify_position(p, state, strategy_enabled) for p in db_positions
+    )
+    lookup = _position_lookup(db_positions)
+    trade_findings = tuple(
+        classify_trade(t, lookup) for t in db_trades
+    )
+    return ReconcileReport(
+        generated_at=datetime.now(tz=timezone.utc),
+        db_path=db_path,
+        account_id=state.account_id,
+        is_paper=state.is_paper,
+        since=since,
+        until=until,
+        strategy_enabled=dict(strategy_enabled),
+        position_findings=position_findings,
+        trade_findings=trade_findings,
+        raw_alpaca_position_count=len(state.positions_by_symbol),
+        raw_alpaca_order_count=len(state.orders_by_id),
+    )
+
+
+def _counts(items: Iterable[Any], key: str) -> dict[str, int]:
+    out: dict[str, int] = {}
+    for item in items:
+        label: str = str(getattr(item, key).value)
+        out[label] = out.get(label, 0) + 1
+    return out
+
+
+def _fmt_position_row(pf: PositionFinding) -> str:
+    p = pf.db_row
+    return (
+        f"- **id={p.get('id')}** `{p.get('ticker')}` "
+        f"strategy=`{p.get('strategy_id') or 'NULL'}` "
+        f"qty={p.get('quantity')} status=`{p.get('status')}` "
+        f"entry_time=`{p.get('entry_time')}`\n"
+        f"  - Evidence: {pf.evidence}\n"
+        f"  - Action: {pf.proposed_action}"
+    )
+
+
+def _fmt_trade_row(tf: TradeFinding) -> str:
+    t = tf.db_row
+    return (
+        f"- **id={t.get('id')}** `{t.get('ticker')}` "
+        f"strategy=`{t.get('strategy_id') or 'NULL'}` "
+        f"qty={t.get('quantity')} entry_time=`{t.get('entry_time')}` "
+        f"exit_time=`{t.get('exit_time') or 'NULL'}`\n"
+        f"  - Evidence: {tf.evidence}\n"
+        f"  - Action: {tf.proposed_action}"
+    )
+
+
+def _render_header(report: ReconcileReport) -> list[str]:
+    lines: list[str] = [
+        "# Reconciliation report — local DB vs Alpaca",
+        "",
+        f"_Generated {report.generated_at.isoformat()} — "
+        f"account `{report.account_id}` "
+        f"({'paper' if report.is_paper else 'live'})_",
+        "",
+        f"- DB path: `{report.db_path}`",
+        f"- Window: `{report.since.date().isoformat()}` to "
+        f"`{report.until.date().isoformat()}`",
+        f"- Alpaca positions: **{report.raw_alpaca_position_count}** • "
+        f"Alpaca orders in window: **{report.raw_alpaca_order_count}**",
+        f"- DB rows scanned: positions=**{len(report.position_findings)}**, "
+        f"trades=**{len(report.trade_findings)}**",
+        "",
+    ]
+    enabled_str = ", ".join(
+        f"`{k}`={'on' if v else 'off'}"
+        for k, v in sorted(report.strategy_enabled.items())
+    )
+    lines.append(f"- Strategy enabled map: {enabled_str or '(none configured)'}")
+    lines.append("")
+    return lines
+
+
+def _render_summary_tables(
+    pos_counts: Mapping[str, int],
+    trade_counts: Mapping[str, int],
+) -> list[str]:
+    lines: list[str] = ["## Summary", "", "### Positions", ""]
+    lines.append("| Classification | Count |")
+    lines.append("|---|---|")
+    for cls in PositionClass:
+        lines.append(f"| {cls.value} | {pos_counts.get(cls.value, 0)} |")
+    lines.extend(["", "### Trades", "", "| Classification | Count |", "|---|---|"])
+    for cls in TradeClass:
+        lines.append(f"| {cls.value} | {trade_counts.get(cls.value, 0)} |")
+    lines.append("")
+    return lines
+
+
+def _render_bug_confirmation(
+    pos_counts: Mapping[str, int],
+    trade_counts: Mapping[str, int],
+) -> list[str]:
+    return [
+        "## Bug-hypothesis confirmation",
+        "",
+        "Counts above map directly to the data-layer bugs in "
+        "[docs/self_improve_followups.md](../docs/self_improve_followups.md):",
+        "",
+        f"1. **trades.strategy_id NULL on entry** — "
+        f"{trade_counts.get(TradeClass.ENTRY_ONLY_PHANTOM.value, 0)} "
+        "ENTRY_ONLY_PHANTOM rows. Confirms `_create_position_record` "
+        "(order_manager.py:868) inserts trades without strategy_id.",
+        f"2. **trades exit UPDATE never matches** — "
+        f"{trade_counts.get(TradeClass.MISSING_EXIT.value, 0)} MISSING_EXIT "
+        "rows. Confirms `_close_position` (order_manager.py:802) uses "
+        "positions.id as the trades WHERE clause.",
+        f"3. **Phantom CLOSED on canceled entry** — "
+        f"{pos_counts.get(PositionClass.PHANTOM_CLOSE.value, 0)} PHANTOM_CLOSE "
+        "rows. Confirms entry-timeout / submit-error paths stamp positions "
+        "CLOSED without an actual fill ever existing.",
+        f"4. **Orphans on disabled strategies** — "
+        f"{pos_counts.get(PositionClass.ORPHAN_DISABLED.value, 0)} "
+        f"ORPHAN_DISABLED + "
+        f"{pos_counts.get(PositionClass.ORPHAN_UNKNOWN.value, 0)} "
+        "ORPHAN_UNKNOWN open rows that no live tick code is managing.",
+        f"5. **DB/Alpaca quantity drift** — "
+        f"{pos_counts.get(PositionClass.MISMATCH_QTY.value, 0)} MISMATCH_QTY + "
+        f"{pos_counts.get(PositionClass.ORPHAN_NOT_HELD.value, 0)} "
+        "ORPHAN_NOT_HELD rows where the DB believes one thing and Alpaca "
+        "believes another.",
+        "",
+    ]
+
+
+def _render_position_findings(
+    findings: Iterable[PositionFinding],
+) -> list[str]:
+    grouped: dict[str, list[PositionFinding]] = {}
+    for pf in findings:
+        grouped.setdefault(pf.classification.value, []).append(pf)
+    lines: list[str] = ["## Position findings", ""]
+    for cls in PositionClass:
+        bucket = grouped.get(cls.value, [])
+        if not bucket:
+            continue
+        lines.append(f"### {cls.value} ({len(bucket)})")
+        lines.append("")
+        for pf in bucket:
+            lines.append(_fmt_position_row(pf))
+        lines.append("")
+    return lines
+
+
+def _render_trade_findings(findings: Iterable[TradeFinding]) -> list[str]:
+    grouped: dict[str, list[TradeFinding]] = {}
+    for tf in findings:
+        grouped.setdefault(tf.classification.value, []).append(tf)
+    lines: list[str] = ["## Trade findings", ""]
+    for cls in TradeClass:
+        bucket = grouped.get(cls.value, [])
+        if not bucket:
+            continue
+        lines.append(f"### {cls.value} ({len(bucket)})")
+        lines.append("")
+        # COMPLETE rows can run into the hundreds and add no signal — collapse.
+        if cls is TradeClass.COMPLETE and len(bucket) > 5:
+            lines.append(
+                f"_Collapsed: {len(bucket)} fully-populated trade rows. "
+                "Listing first 5 only._"
+            )
+            lines.append("")
+            for tf in bucket[:5]:
+                lines.append(_fmt_trade_row(tf))
+        else:
+            for tf in bucket:
+                lines.append(_fmt_trade_row(tf))
+        lines.append("")
+    return lines
+
+
+def render_markdown(report: ReconcileReport) -> str:
+    """Render the report as a markdown document for human review."""
+    pos_counts = _counts(report.position_findings, "classification")
+    trade_counts = _counts(report.trade_findings, "classification")
+
+    lines: list[str] = []
+    lines.extend(_render_header(report))
+    lines.extend(_render_summary_tables(pos_counts, trade_counts))
+    lines.extend(_render_bug_confirmation(pos_counts, trade_counts))
+    lines.extend(_render_position_findings(report.position_findings))
+    lines.extend(_render_trade_findings(report.trade_findings))
+    lines.extend([
+        "---",
+        "",
+        "_This report is read-only. No DB rows were modified and no orders "
+        "were submitted. Use it to plan Phase 2 (DB migration) and Phase 3 "
+        "(live order logic fixes)._",
+        "",
+    ])
+    return "\n".join(lines)

--- a/trading_bot/strategy/strategy_manager.py
+++ b/trading_bot/strategy/strategy_manager.py
@@ -12,7 +12,7 @@ from zoneinfo import ZoneInfo
 
 import pandas as pd
 
-from trading_bot.constants import GICS_SECTOR, PositionStatus, TZ_EASTERN
+from trading_bot.constants import GICS_SECTOR, TZ_EASTERN
 from trading_bot.data.event_calendar import fomc_size_multiplier
 from trading_bot.db import repository as repo
 from trading_bot.execution.loss_cooldown import LossCooldownTracker
@@ -375,7 +375,8 @@ class StrategyManager:
             conn.row_factory = sqlite3.Row
             try:
                 rows = conn.execute(
-                    "SELECT * FROM positions WHERE status != 'CLOSED'"
+                    "SELECT * FROM positions "
+                    "WHERE status NOT IN ('CLOSED', 'ENTRY_FAILED')"
                 ).fetchall()
             finally:
                 conn.close()
@@ -624,8 +625,9 @@ class StrategyManager:
             try:
                 rows = conn.execute(
                     "SELECT quantity, entry_price FROM positions "
-                    "WHERE ticker = ? AND status != ?",
-                    (ticker, PositionStatus.CLOSED.value),
+                    "WHERE ticker = ? "
+                    "AND status NOT IN ('CLOSED', 'ENTRY_FAILED')",
+                    (ticker,),
                 ).fetchall()
             finally:
                 conn.close()

--- a/trading_bot/tests/test_migration_v8_entry_failed.py
+++ b/trading_bot/tests/test_migration_v8_entry_failed.py
@@ -1,0 +1,357 @@
+"""Tests for V8: retro-convert phantom-CLOSED rows to ENTRY_FAILED.
+
+The migration is data-only (no DDL). These tests pin:
+1. The detection rule — only rows with status='CLOSED', alpaca_order_id IS NULL,
+   and a paired trades row missing exit_time get flipped.
+2. Idempotency — running V8 twice converts the same set once and is a noop on
+   the second run.
+3. Negative cases — rows that look like phantoms but have any one disqualifier
+   (alpaca_order_id present, exit_time present, no paired trades row, status
+   not CLOSED) are LEFT ALONE.
+4. Open-position queries (get_open_positions) treat ENTRY_FAILED as terminal,
+   identical to CLOSED.
+5. has_attempted_today() does NOT exclude ENTRY_FAILED — the dedup gate must
+   still fire for failed entries so we don't refire identical orders.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from trading_bot.constants import (
+    TERMINAL_POSITION_STATUSES,
+    PositionStatus,
+    SCHEMA_VERSION,
+)
+from trading_bot.db import repository as repo
+from trading_bot.db.migrations import _migration_v8, run_migrations
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def db_at_v7(tmp_path) -> Path:
+    """Create a SQLite DB at V7 so we can drive _migration_v8 explicitly."""
+    db = tmp_path / "v7.db"
+    conn = sqlite3.connect(str(db))
+    try:
+        # Apply schema up through V7 by running the existing migration runner
+        # against an empty DB, then ROLLBACK the version to 7 so V8 can run.
+        run_migrations(str(db))
+        conn = sqlite3.connect(str(db))
+        # Force schema version back to 7 to simulate a pre-V8 deployment.
+        conn.execute("DELETE FROM schema_version WHERE version >= 8")
+        conn.commit()
+    finally:
+        conn.close()
+    return db
+
+
+def _seed(
+    conn: sqlite3.Connection,
+    *,
+    ticker: str,
+    status: str,
+    alpaca_order_id: str | None,
+    strategy_id: str = "mean_reversion",
+    entry_time: str = "2026-04-28T10:30:00",
+    qty: int = 10,
+    entry_price: float = 100.0,
+) -> int:
+    cur = conn.execute(
+        "INSERT INTO positions ("
+        "ticker, exchange, currency, quantity, entry_price, entry_time, "
+        "status, hold_type, phase, strategy_id, alpaca_order_id"
+        ") VALUES (?, 'ARCA', 'USD', ?, ?, ?, ?, 'intraday', 1, ?, ?)",
+        (ticker, qty, entry_price, entry_time, status, strategy_id, alpaca_order_id),
+    )
+    return int(cur.lastrowid)
+
+
+def _seed_trade(
+    conn: sqlite3.Connection,
+    *,
+    ticker: str,
+    entry_time: str = "2026-04-28T10:30:00",
+    exit_time: str | None = None,
+    strategy_id: str | None = None,
+) -> None:
+    conn.execute(
+        "INSERT INTO trades ("
+        "ticker, exchange, currency, side, entry_time, entry_price, "
+        "quantity, exit_time, exit_price, exit_reason, hold_type, phase, "
+        "strategy_id"
+        ") VALUES (?, 'ARCA', 'USD', 'long', ?, 100.0, 10, ?, ?, ?, "
+        "'intraday', 1, ?)",
+        (
+            ticker,
+            entry_time,
+            exit_time,
+            101.5 if exit_time else None,
+            "stop_loss" if exit_time else None,
+            strategy_id,
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Migration logic
+# ---------------------------------------------------------------------------
+
+
+def test_v8_converts_only_obvious_phantoms(db_at_v7: Path) -> None:
+    conn = sqlite3.connect(str(db_at_v7))
+    try:
+        # Phantom: status=CLOSED, alpaca_order_id NULL, paired trade has no
+        # exit_time. (Two of these — the live bug fires repeatedly.)
+        _seed(conn, ticker="PHANTOM1", status="CLOSED", alpaca_order_id=None)
+        _seed_trade(conn, ticker="PHANTOM1", exit_time=None)
+        _seed(conn, ticker="PHANTOM2", status="CLOSED", alpaca_order_id=None)
+        _seed_trade(conn, ticker="PHANTOM2", exit_time=None)
+
+        # Real fill: status=CLOSED, alpaca_order_id present.
+        _seed(conn, ticker="REAL1", status="CLOSED", alpaca_order_id="ord-1")
+        _seed_trade(conn, ticker="REAL1", exit_time="2026-04-28T13:00:00")
+
+        # Open: status != CLOSED, must not be touched.
+        _seed(conn, ticker="OPEN1", status="POSITION_OPEN", alpaca_order_id="ord-2")
+
+        # Phantom-with-no-trades-row: status=CLOSED + no paired trade row.
+        # (LEFT JOIN exposes this — converted because t.id IS NULL.)
+        _seed(conn, ticker="ORPHAN1", status="CLOSED", alpaca_order_id=None)
+
+        conn.commit()
+
+        _migration_v8(conn)
+        conn.commit()
+
+        rows = dict(conn.execute(
+            "SELECT ticker, status FROM positions"
+        ).fetchall())
+        assert rows["PHANTOM1"] == "ENTRY_FAILED"
+        assert rows["PHANTOM2"] == "ENTRY_FAILED"
+        assert rows["ORPHAN1"] == "ENTRY_FAILED"
+        # Untouched.
+        assert rows["REAL1"] == "CLOSED"
+        assert rows["OPEN1"] == "POSITION_OPEN"
+    finally:
+        conn.close()
+
+
+def test_v8_does_not_touch_closed_with_real_exit_data(db_at_v7: Path) -> None:
+    """A row with alpaca_order_id NULL but a complete trades exit row is NOT
+    a phantom — exit_time being present means a fill DID happen and just
+    wasn't tagged with the entry order id."""
+    conn = sqlite3.connect(str(db_at_v7))
+    try:
+        _seed(conn, ticker="LATE_TAG", status="CLOSED", alpaca_order_id=None)
+        _seed_trade(
+            conn,
+            ticker="LATE_TAG",
+            exit_time="2026-04-28T13:00:00",
+            strategy_id="mean_reversion",
+        )
+        conn.commit()
+        _migration_v8(conn)
+        conn.commit()
+        status = conn.execute(
+            "SELECT status FROM positions WHERE ticker = 'LATE_TAG'"
+        ).fetchone()[0]
+        assert status == "CLOSED"
+    finally:
+        conn.close()
+
+
+def test_v8_is_idempotent(db_at_v7: Path) -> None:
+    conn = sqlite3.connect(str(db_at_v7))
+    try:
+        _seed(conn, ticker="P1", status="CLOSED", alpaca_order_id=None)
+        _seed_trade(conn, ticker="P1", exit_time=None)
+        conn.commit()
+
+        _migration_v8(conn)
+        conn.commit()
+        first = conn.execute(
+            "SELECT status FROM positions WHERE ticker = 'P1'"
+        ).fetchone()[0]
+
+        # Run it again; nothing should change.
+        _migration_v8(conn)
+        conn.commit()
+        second = conn.execute(
+            "SELECT status FROM positions WHERE ticker = 'P1'"
+        ).fetchone()[0]
+
+        assert first == second == "ENTRY_FAILED"
+    finally:
+        conn.close()
+
+
+def test_v8_count_matches_phase1_query_pattern(db_at_v7: Path) -> None:
+    """Cross-check: the count of rows V8 converts equals the count produced
+    by the same SELECT pattern the Phase 1 reconcile report would surface as
+    PHANTOM_CLOSE candidates from local DB state alone (i.e. without an
+    Alpaca round-trip).  Operationally, the user runs reconcile on the
+    GHA-cached DB before and after and confirms the numbers match."""
+    conn = sqlite3.connect(str(db_at_v7))
+    try:
+        for i in range(5):
+            _seed(conn, ticker=f"P{i}", status="CLOSED", alpaca_order_id=None,
+                  entry_time=f"2026-04-2{i}T10:30:00")
+            _seed_trade(conn, ticker=f"P{i}", exit_time=None,
+                        entry_time=f"2026-04-2{i}T10:30:00")
+        # Distractor with order id — must not count.
+        _seed(conn, ticker="REAL", status="CLOSED", alpaca_order_id="ord-real")
+        _seed_trade(conn, ticker="REAL", exit_time="2026-04-28T13:00:00")
+        conn.commit()
+
+        candidate_count = conn.execute(
+            """
+            SELECT COUNT(*) FROM positions p
+            LEFT JOIN trades t
+              ON t.ticker = p.ticker AND t.entry_time = p.entry_time
+            WHERE p.status = 'CLOSED'
+              AND p.alpaca_order_id IS NULL
+              AND (t.exit_time IS NULL OR t.id IS NULL)
+            """
+        ).fetchone()[0]
+
+        _migration_v8(conn)
+        conn.commit()
+
+        converted = conn.execute(
+            "SELECT COUNT(*) FROM positions WHERE status = 'ENTRY_FAILED'"
+        ).fetchone()[0]
+        assert converted == candidate_count == 5
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# run_migrations end-to-end
+# ---------------------------------------------------------------------------
+
+
+def test_run_migrations_applies_v8_on_existing_v7_db(tmp_path) -> None:
+    db = tmp_path / "round_trip.db"
+    run_migrations(str(db))  # creates fresh DB at SCHEMA_VERSION (now 8)
+    conn = sqlite3.connect(str(db))
+    try:
+        version = conn.execute(
+            "SELECT MAX(version) FROM schema_version"
+        ).fetchone()[0]
+        assert version == SCHEMA_VERSION == 8
+    finally:
+        conn.close()
+
+
+def test_run_migrations_is_noop_when_already_at_v8(tmp_path) -> None:
+    db = tmp_path / "noop.db"
+    run_migrations(str(db))
+    # Run again — must complete without error and version stays at 8.
+    run_migrations(str(db))
+    conn = sqlite3.connect(str(db))
+    try:
+        version = conn.execute(
+            "SELECT MAX(version) FROM schema_version"
+        ).fetchone()[0]
+        assert version == 8
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Enum + query call-site coverage
+# ---------------------------------------------------------------------------
+
+
+def test_position_status_includes_entry_failed() -> None:
+    assert PositionStatus.ENTRY_FAILED.value == "ENTRY_FAILED"
+
+
+def test_terminal_status_set_includes_both_terminal_states() -> None:
+    assert PositionStatus.CLOSED.value in TERMINAL_POSITION_STATUSES
+    assert PositionStatus.ENTRY_FAILED.value in TERMINAL_POSITION_STATUSES
+    # In-flight states are NOT terminal.
+    for s in (
+        PositionStatus.ENTRY_PENDING,
+        PositionStatus.POSITION_OPEN,
+        PositionStatus.STOP_AND_TARGET_ACTIVE,
+        PositionStatus.TRAILING_ACTIVE,
+        PositionStatus.CLOSING,
+    ):
+        assert s.value not in TERMINAL_POSITION_STATUSES
+
+
+def test_get_open_positions_excludes_entry_failed(tmp_db) -> None:
+    _seed(tmp_db, ticker="A", status="POSITION_OPEN", alpaca_order_id="o1")
+    _seed(tmp_db, ticker="B", status="ENTRY_FAILED", alpaca_order_id=None)
+    _seed(tmp_db, ticker="C", status="CLOSED", alpaca_order_id="o2")
+    _seed(tmp_db, ticker="D", status="ENTRY_PENDING", alpaca_order_id=None)
+    tmp_db.commit()
+
+    open_rows = repo.get_open_positions(tmp_db)
+    tickers = {r["ticker"] for r in open_rows}
+    assert tickers == {"A", "D"}
+
+
+def test_has_attempted_today_still_counts_entry_failed(tmp_db) -> None:
+    """Dedup gate: ENTRY_FAILED must still count as "attempted today" so the
+    bot does not refire identical orders within the same session.  This was
+    the 2026-04-29 incident — see repository.has_attempted_today docstring.
+    """
+    today = "2026-04-30"
+    _seed(
+        tmp_db,
+        ticker="DEDUP",
+        status="ENTRY_FAILED",
+        alpaca_order_id=None,
+        entry_time=f"{today}T10:30:00",
+        strategy_id="mean_reversion",
+    )
+    tmp_db.commit()
+
+    assert repo.has_attempted_today(
+        tmp_db,
+        ticker="DEDUP",
+        strategy_id="mean_reversion",
+        et_today_iso=today,
+    ) is True
+
+
+def test_reconcile_classifier_short_circuits_on_entry_failed() -> None:
+    """ENTRY_FAILED rows should classify as PHANTOM_CLOSE without an Alpaca
+    round-trip — the V8 migration already vetted the local-DB evidence."""
+    from trading_bot.self_improve.reconcile import (
+        AlpacaState,
+        PositionClass,
+        classify_position,
+    )
+
+    state = AlpacaState(
+        account_id="PA",
+        is_paper=True,
+        fetched_at=datetime.now(),
+        positions_by_symbol={},
+        orders_by_id={},
+        fills_by_symbol={},
+    )
+    pos = {
+        "ticker": "FOO",
+        "quantity": 10,
+        "entry_price": 100.0,
+        "entry_time": "2026-04-28T10:30:00",
+        "status": "ENTRY_FAILED",
+        "strategy_id": "mean_reversion",
+        "alpaca_order_id": None,
+    }
+    out = classify_position(pos, state, {"mean_reversion": True})
+    assert out.classification is PositionClass.PHANTOM_CLOSE
+    assert "V8" in out.evidence

--- a/trading_bot/tests/test_order_manager_lifecycle.py
+++ b/trading_bot/tests/test_order_manager_lifecycle.py
@@ -556,9 +556,13 @@ class TestPlaceExit:
 
 class TestPlaceEntryFailure:
     @pytest.mark.asyncio
-    async def test_alpaca_submit_failure_marks_closed(
+    async def test_alpaca_submit_failure_returns_none(
         self, config, tmp_db_path: str, mock_notifier
     ):
+        """place_entry returns None on submit failure. The position row's
+        terminal status (ENTRY_FAILED) is asserted in
+        test_phase3_regressions.TestB2_FailedEntryGetsEntryFailedStatus.
+        """
         om = _make_om(config, tmp_db_path, mock_notifier)
         om._gw.client.submit_order = MagicMock(side_effect=RuntimeError("rejected"))
         trade_id = await om.place_entry(_entry())

--- a/trading_bot/tests/test_phase3_regressions.py
+++ b/trading_bot/tests/test_phase3_regressions.py
@@ -1,0 +1,433 @@
+"""Phase 3 regression tests — live order logic data-layer fixes.
+
+Each bug from docs/self_improve_followups.md gets a deterministic test that
+fails on the broken code path and passes after the fix lands. These are the
+tests that should fire FIRST if any future change re-introduces one of the
+five regressions Phase 3 closes:
+
+B1. trades INSERT in _create_position_record must persist strategy_id.
+B2. Failed entries (canceled/expired/rejected/timeout/submit-error) must
+    stamp positions with status='ENTRY_FAILED', not 'CLOSED'. ENTRY_FAILED
+    is a terminal state added in Phase 2; CLOSED implies a real round-trip.
+B3. _close_position's UPDATE on trades must hit the trades.id row, not the
+    positions.id row. Pre-fix, the UPDATE used positions.id (called
+    `trade_id` everywhere in the code), which silently matched zero or
+    wrong rows because trades.id and positions.id are independent
+    autoincrements.
+B4. recovery._close_db_position must populate strategy_id, derive side
+    from the position quantity sign (not hardcode 'SELL'), and stamp the
+    ExitReason enum value.
+B5. _update_position_field must log rows_affected so future write-back
+    failures surface immediately instead of silently no-oping.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from trading_bot.constants import PositionStatus, TZ_EASTERN
+from trading_bot.execution.order_manager import (
+    EntryDecision,
+    OrderManager,
+    _ActiveOrder,
+)
+
+ET = TZ_EASTERN
+
+
+# ---------------------------------------------------------------------------
+# Test helpers — match patterns in test_order_manager_lifecycle.py
+# ---------------------------------------------------------------------------
+
+
+def _make_om(config, db_path: str, notifier) -> OrderManager:
+    gw = MagicMock()
+    gw.client = MagicMock()
+    return OrderManager(gw, config, notifier, db_path)
+
+
+def _entry(
+    *,
+    ticker: str = "SPY",
+    strategy_id: str = "mean_reversion",
+    shares: int = 10,
+    price: float = 100.0,
+) -> EntryDecision:
+    return EntryDecision(
+        ticker=ticker,
+        exchange="US",
+        side="BUY",
+        shares=shares,
+        limit_price=price,
+        stop_price=price * 0.98,
+        target_price=price * 1.04,
+        hold_type="intraday",
+        sector="Information Technology",
+        phase=1,
+        sentiment_score=0.2,
+        signals="test",
+        currency="USD",
+        strategy_id=strategy_id,
+    )
+
+
+def _alpaca_order(
+    *,
+    order_id: str = "order-1",
+    status: str = "new",
+    filled_qty: float = 0.0,
+    filled_avg_price: float = 0.0,
+    submitted_at: datetime | None = None,
+    legs: list[Any] | None = None,
+):
+    o = MagicMock()
+    o.id = order_id
+    o.status = MagicMock()
+    o.status.value = status
+    o.filled_qty = filled_qty
+    o.filled_avg_price = filled_avg_price
+    o.submitted_at = submitted_at
+    o.legs = legs
+    return o
+
+
+# ---------------------------------------------------------------------------
+# B1 — strategy_id must be persisted on the entry trades row
+# ---------------------------------------------------------------------------
+
+
+class TestB1_TradesInsertPersistsStrategyId:
+    """Live bug: 54/54 trade rows in the GHA-cached DB had strategy_id NULL.
+    Root cause: _create_position_record's trades INSERT omits strategy_id
+    even though decision.strategy_id is already on hand and is correctly
+    written to the positions row 12 lines above.
+    """
+
+    def test_strategy_id_written_to_trades_row(
+        self, config, tmp_db_path: str, mock_notifier
+    ):
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        om._create_position_record(_entry(strategy_id="overnight_drift"))
+
+        conn = sqlite3.connect(tmp_db_path)
+        try:
+            row = conn.execute(
+                "SELECT strategy_id FROM trades ORDER BY id DESC LIMIT 1"
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row is not None
+        assert row[0] == "overnight_drift", (
+            "trades.strategy_id was NULL on every row in the GHA-cached DB; "
+            "fix: extend the trades INSERT in _create_position_record to "
+            "bind decision.strategy_id."
+        )
+
+    def test_strategy_id_falls_back_to_unknown_when_decision_omits_it(
+        self, config, tmp_db_path: str, mock_notifier
+    ):
+        """Mirrors the positions-side fallback at line 858 so trade rows
+        are never NULL for downstream queries."""
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        decision = _entry()
+        decision.strategy_id = None
+        om._create_position_record(decision)
+
+        conn = sqlite3.connect(tmp_db_path)
+        try:
+            row = conn.execute(
+                "SELECT strategy_id FROM trades ORDER BY id DESC LIMIT 1"
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row[0] == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# B2 — failed entries get ENTRY_FAILED, not CLOSED
+# ---------------------------------------------------------------------------
+
+
+class TestB2_FailedEntryGetsEntryFailedStatus:
+    """Live bug: 52 phantom-CLOSED rows. Three branches in order_manager
+    stamped CLOSED on entries that never filled: canceled-by-broker (line
+    244), submit_order raised (line 384), and entry-timeout-with-zero-fill
+    (line 445). With ENTRY_FAILED added in Phase 2, each must use it instead.
+    """
+
+    @pytest.mark.asyncio
+    async def test_submit_order_failure_stamps_entry_failed(
+        self, config, tmp_db_path: str, mock_notifier
+    ):
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        om._gw.client.submit_order = MagicMock(
+            side_effect=RuntimeError("insufficient buying power")
+        )
+        trade_id = await om.place_entry(_entry())
+        assert trade_id is None
+
+        conn = sqlite3.connect(tmp_db_path)
+        try:
+            row = conn.execute(
+                "SELECT status FROM positions ORDER BY id DESC LIMIT 1"
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row[0] == PositionStatus.ENTRY_FAILED.value, (
+            "submit_order errors used to leave 'CLOSED' rows that polluted "
+            "every report. Must now stamp ENTRY_FAILED."
+        )
+
+    @pytest.mark.asyncio
+    async def test_entry_canceled_by_broker_stamps_entry_failed(
+        self, config, tmp_db_path: str, mock_notifier
+    ):
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        # Successful submission, then on next status poll Alpaca reports canceled.
+        entry_alpaca = _alpaca_order(order_id="entry-1", status="new")
+        om._gw.client.submit_order = MagicMock(return_value=entry_alpaca)
+        trade_id = await om.place_entry(_entry())
+        assert trade_id is not None
+
+        # Now the broker returns 'canceled' on the next status check.
+        canceled = _alpaca_order(order_id="entry-1", status="canceled")
+        om._gw.client.get_order_by_id = MagicMock(return_value=canceled)
+        await om._check_order_statuses()
+
+        conn = sqlite3.connect(tmp_db_path)
+        try:
+            row = conn.execute(
+                "SELECT status FROM positions WHERE id = ?", (trade_id,)
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row[0] == PositionStatus.ENTRY_FAILED.value
+
+    @pytest.mark.asyncio
+    async def test_entry_timeout_zero_fill_stamps_entry_failed(
+        self, config, tmp_db_path: str, mock_notifier
+    ):
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        long_ago = datetime.now(tz=ET) - timedelta(hours=1)
+        entry_alpaca = _alpaca_order(
+            order_id="entry-1", status="new", submitted_at=long_ago,
+        )
+        om._gw.client.submit_order = MagicMock(return_value=entry_alpaca)
+        trade_id = await om.place_entry(_entry())
+
+        om._gw.client.get_order_by_id = MagicMock(return_value=entry_alpaca)
+        om._gw.client.cancel_order_by_id = MagicMock(return_value=None)
+        # Override the entry timeout to a short value so the long_ago
+        # submitted_at trips the cancel branch.
+        om._config._raw["entry"]["entry_timeout_seconds"] = 60
+        await om._check_order_statuses()
+
+        conn = sqlite3.connect(tmp_db_path)
+        try:
+            row = conn.execute(
+                "SELECT status FROM positions WHERE id = ?", (trade_id,)
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row[0] == PositionStatus.ENTRY_FAILED.value
+
+
+# ---------------------------------------------------------------------------
+# B3 — _close_position's exit UPDATE must hit the trades row, not the
+# positions row of the same numeric id
+# ---------------------------------------------------------------------------
+
+
+class TestB3_ExitUpdateHitsCorrectTradesRow:
+    """Live bug: _close_position used `trade_id` (which is positions.id) as
+    the WHERE clause on the trades table. trades.id is an independent
+    autoincrement, so the UPDATE matched whatever trades row happened to
+    share that integer (or zero rows if the ids had drifted). Pre-fix
+    consequence: trade rows never got exit_time / exit_price / exit_reason
+    populated even when the exit path fired correctly.
+    """
+
+    @pytest.mark.asyncio
+    async def test_close_position_writes_exit_data_to_correct_trades_row(
+        self, config, tmp_db_path: str, mock_notifier
+    ):
+        # Pre-seed a row in trades so the row ids drift between tables —
+        # this is what reveals the bug. Without drift the broken WHERE
+        # clause appears to work by accident.
+        conn = sqlite3.connect(tmp_db_path)
+        try:
+            for _ in range(3):
+                conn.execute(
+                    "INSERT INTO trades (ticker, exchange, currency, side, "
+                    "entry_time, entry_price, quantity, hold_type, phase, "
+                    "strategy_id) VALUES "
+                    "('NOOP', 'US', 'USD', 'BUY', '2026-01-01T00:00:00', "
+                    "1.0, 1, 'intraday', 1, 'mean_reversion')"
+                )
+            conn.commit()
+        finally:
+            conn.close()
+
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        # place_entry runs the full path: positions insert, trades insert,
+        # capture trade_id (positions.id), set alpaca_order_id, build _ActiveOrder.
+        entry_alpaca = _alpaca_order(order_id="entry-1", status="new")
+        om._gw.client.submit_order = MagicMock(return_value=entry_alpaca)
+        trade_id = await om.place_entry(_entry(ticker="SPY"))
+        active = om._active_orders[trade_id]
+        active.entry_price = 100.0
+        active.filled_shares = 10.0
+
+        # Trigger the close path.
+        await om._close_position(
+            trade_id, active, exit_price=101.5, exit_reason="stop_loss",
+        )
+
+        conn = sqlite3.connect(tmp_db_path)
+        conn.row_factory = sqlite3.Row
+        try:
+            # The trades row that should have exit data is the SPY one we
+            # just created — find it by ticker, then assert exit_time is set.
+            row = conn.execute(
+                "SELECT exit_time, exit_price, exit_reason "
+                "FROM trades WHERE ticker = 'SPY' "
+                "ORDER BY id DESC LIMIT 1"
+            ).fetchone()
+            # And no NOOP row should ever have been touched.
+            noop_with_exit = conn.execute(
+                "SELECT COUNT(*) FROM trades "
+                "WHERE ticker = 'NOOP' AND exit_time IS NOT NULL"
+            ).fetchone()[0]
+        finally:
+            conn.close()
+
+        assert row is not None
+        assert row["exit_time"] is not None, (
+            "exit UPDATE missed — used positions.id as the WHERE clause "
+            "instead of the trades.id captured at insert time."
+        )
+        assert row["exit_price"] == 101.5
+        assert row["exit_reason"] == "stop_loss"
+        assert noop_with_exit == 0, (
+            "exit UPDATE matched a NOOP trades row — proves the WHERE was "
+            "using a positions.id that collided with an unrelated trades.id."
+        )
+
+
+# ---------------------------------------------------------------------------
+# B4 — recovery._close_db_position writes complete trades row
+# ---------------------------------------------------------------------------
+
+
+class TestB4_RecoveryCloseDbPositionWritesCompleteRow:
+    """Live bug: recovery._close_db_position INSERT INTO trades omitted
+    strategy_id and hardcoded side='SELL'. Result: every recovery-driven
+    close created a trade row that looked like a short entry (side='SELL'
+    is the entry direction in this schema) and had no strategy attribution.
+    """
+
+    def _make_recovery(self, config, tmp_db_path: str, mock_notifier):
+        from trading_bot.gateway.recovery import StateRecovery
+
+        gw = MagicMock()
+        return StateRecovery(gw, tmp_db_path, mock_notifier)
+
+    def _seed_position(
+        self,
+        tmp_db_path: str,
+        *,
+        ticker: str = "QQQ",
+        qty: int = 10,
+        strategy_id: str = "mean_reversion",
+    ) -> int:
+        conn = sqlite3.connect(tmp_db_path)
+        try:
+            cur = conn.execute(
+                "INSERT INTO positions (ticker, exchange, currency, "
+                "quantity, entry_price, entry_time, status, hold_type, "
+                "phase, strategy_id) VALUES "
+                "(?, 'US', 'USD', ?, 100.0, '2026-04-28T10:00:00', "
+                "'POSITION_OPEN', 'intraday', 1, ?)",
+                (ticker, qty, strategy_id),
+            )
+            conn.commit()
+            return int(cur.lastrowid)
+        finally:
+            conn.close()
+
+    def test_close_db_position_writes_strategy_id_from_position_row(
+        self, config, tmp_db_path: str, mock_notifier
+    ):
+        pos_id = self._seed_position(tmp_db_path, strategy_id="overnight_drift")
+        rm = self._make_recovery(config, tmp_db_path, mock_notifier)
+
+        rm._close_db_position(pos_id, "reconciliation_mismatch")
+
+        conn = sqlite3.connect(tmp_db_path)
+        try:
+            row = conn.execute(
+                "SELECT strategy_id, side, exit_reason "
+                "FROM trades ORDER BY id DESC LIMIT 1"
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row is not None
+        assert row[0] == "overnight_drift", (
+            "recovery._close_db_position dropped strategy_id; the trade row "
+            "now lives without attribution."
+        )
+        # Side should reflect the original position direction (long → BUY),
+        # not the closing leg. Trades.side semantics in this codebase = entry
+        # direction; exit_reason captures the close.
+        assert row[1] == "BUY"
+        assert row[2] == "reconciliation_mismatch"
+
+
+# ---------------------------------------------------------------------------
+# B5 — _update_position_field observability
+# ---------------------------------------------------------------------------
+
+
+class TestB5_UpdatePositionFieldLogsRowsAffected:
+    """User asked for observability inside _update_position_field. The
+    investigation already explained every NULL alpaca_order_id (52 from
+    submit_order errors → naturally fixed by B2 stamping ENTRY_FAILED, plus
+    1 from recovery._create_db_position which has no order id to record).
+    This test only pins the new logging contract so a future regression
+    where the UPDATE silently no-ops would surface immediately.
+    """
+
+    def test_update_logs_rows_affected_at_debug(
+        self, config, tmp_db_path: str, mock_notifier, caplog
+    ):
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        trade_id = om._create_position_record(_entry())
+
+        with caplog.at_level(logging.DEBUG, logger="trading_bot.execution.order_manager"):
+            om._update_position_field(trade_id, "alpaca_order_id", "ord-xyz")
+
+        joined = "\n".join(rec.getMessage() for rec in caplog.records)
+        assert "alpaca_order_id" in joined
+        assert "rows_affected=1" in joined, (
+            "missing rows_affected in log — without it, a silently-failing "
+            "UPDATE (e.g. wrong WHERE clause) is invisible."
+        )
+
+    def test_update_warns_when_no_rows_match(
+        self, config, tmp_db_path: str, mock_notifier, caplog
+    ):
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        with caplog.at_level(logging.WARNING, logger="trading_bot.execution.order_manager"):
+            om._update_position_field(99999, "alpaca_order_id", "ord-xyz")
+
+        joined = "\n".join(rec.getMessage() for rec in caplog.records)
+        assert "rows_affected=0" in joined, (
+            "0-row UPDATE must log loud — that's the silent-failure mode "
+            "the live bot was hiding."
+        )

--- a/trading_bot/tests/test_self_improve_reconcile.py
+++ b/trading_bot/tests/test_self_improve_reconcile.py
@@ -1,0 +1,429 @@
+"""Tests for trading_bot.self_improve.reconcile.
+
+Focus is the classification table — every label in PositionClass and TradeClass
+should have a deterministic test that pins its meaning. Alpaca state is built
+by hand as plain dataclasses so no network is touched.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import pytest
+
+from trading_bot.self_improve.reconcile import (
+    AlpacaOrderRec,
+    AlpacaPosition,
+    AlpacaState,
+    PositionClass,
+    TradeClass,
+    build_report,
+    classify_position,
+    classify_trade,
+    load_db_positions,
+    load_db_trades,
+    render_markdown,
+    _position_lookup,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+ENABLED_MAP: dict[str, bool] = {
+    "mean_reversion": True,
+    "overnight_drift": True,
+    "breakout": False,
+    "trend_following": False,
+    "sentiment_combo": False,
+}
+
+ENTRY_TIME = datetime(2026, 4, 28, 10, 30, 0, tzinfo=timezone.utc)
+
+
+def _make_state(
+    *,
+    positions: list[AlpacaPosition] | None = None,
+    orders: list[AlpacaOrderRec] | None = None,
+) -> AlpacaState:
+    by_sym: dict[str, AlpacaPosition] = {p.symbol: p for p in positions or []}
+    by_id: dict[str, AlpacaOrderRec] = {o.order_id: o for o in orders or []}
+    fills: dict[str, list[AlpacaOrderRec]] = {}
+    for o in orders or []:
+        if o.filled_at is not None and o.filled_qty > 0:
+            fills.setdefault(o.symbol, []).append(o)
+    return AlpacaState(
+        account_id="PA-TEST",
+        is_paper=True,
+        fetched_at=datetime.now(tz=timezone.utc),
+        positions_by_symbol=by_sym,
+        orders_by_id=by_id,
+        fills_by_symbol={k: tuple(v) for k, v in fills.items()},
+    )
+
+
+def _db_position(
+    *,
+    pos_id: int = 1,
+    ticker: str = "SPY",
+    qty: int = 10,
+    status: str = "POSITION_OPEN",
+    strategy_id: str | None = "mean_reversion",
+    entry_time: datetime = ENTRY_TIME,
+    alpaca_order_id: str | None = None,
+    alpaca_stop_order_id: str | None = None,
+    alpaca_target_order_id: str | None = None,
+    alpaca_trail_order_id: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "id": pos_id,
+        "ticker": ticker,
+        "exchange": "ARCA",
+        "currency": "USD",
+        "quantity": qty,
+        "entry_price": 100.0,
+        "entry_time": entry_time.isoformat(),
+        "status": status,
+        "strategy_id": strategy_id,
+        "alpaca_order_id": alpaca_order_id,
+        "alpaca_stop_order_id": alpaca_stop_order_id,
+        "alpaca_target_order_id": alpaca_target_order_id,
+        "alpaca_trail_order_id": alpaca_trail_order_id,
+        "hold_type": "intraday",
+        "phase": 1,
+    }
+
+
+def _buy_fill(
+    *,
+    order_id: str = "buy-1",
+    symbol: str = "SPY",
+    qty: float = 10.0,
+    at: datetime = ENTRY_TIME,
+) -> AlpacaOrderRec:
+    return AlpacaOrderRec(
+        order_id=order_id,
+        symbol=symbol,
+        side="buy",
+        status="filled",
+        qty=qty,
+        filled_qty=qty,
+        filled_avg_price=100.0,
+        filled_at=at,
+        submitted_at=at - timedelta(seconds=2),
+    )
+
+
+def _sell_fill(
+    *,
+    order_id: str = "sell-1",
+    symbol: str = "SPY",
+    qty: float = 10.0,
+    at: datetime | None = None,
+) -> AlpacaOrderRec:
+    return AlpacaOrderRec(
+        order_id=order_id,
+        symbol=symbol,
+        side="sell",
+        status="filled",
+        qty=qty,
+        filled_qty=qty,
+        filled_avg_price=101.5,
+        filled_at=at if at is not None else ENTRY_TIME + timedelta(hours=2),
+        submitted_at=ENTRY_TIME + timedelta(hours=2),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Open-side classification
+# ---------------------------------------------------------------------------
+
+
+def test_actual_open_when_db_and_alpaca_agree() -> None:
+    pos = _db_position()
+    state = _make_state(
+        positions=[AlpacaPosition("SPY", qty=10.0, avg_entry_price=100.0, market_value=1000.0)],
+    )
+    out = classify_position(pos, state, ENABLED_MAP)
+    assert out.classification is PositionClass.ACTUAL_OPEN
+
+
+def test_mismatch_qty_when_alpaca_holds_different_quantity() -> None:
+    pos = _db_position(qty=10)
+    state = _make_state(
+        positions=[AlpacaPosition("SPY", qty=7.0, avg_entry_price=100.0, market_value=700.0)],
+    )
+    out = classify_position(pos, state, ENABLED_MAP)
+    assert out.classification is PositionClass.MISMATCH_QTY
+    assert "diff=" in out.evidence
+
+
+def test_orphan_disabled_when_strategy_is_disabled_in_config() -> None:
+    pos = _db_position(strategy_id="breakout")
+    state = _make_state(
+        positions=[AlpacaPosition("SPY", qty=10.0, avg_entry_price=100.0, market_value=1000.0)],
+    )
+    out = classify_position(pos, state, ENABLED_MAP)
+    assert out.classification is PositionClass.ORPHAN_DISABLED
+
+
+def test_orphan_unknown_when_strategy_is_null_or_unknown() -> None:
+    state = _make_state(
+        positions=[AlpacaPosition("SPY", qty=10.0, avg_entry_price=100.0, market_value=1000.0)],
+    )
+    null_pos = _db_position(strategy_id=None)
+    unknown_pos = _db_position(strategy_id="unknown")
+    assert (
+        classify_position(null_pos, state, ENABLED_MAP).classification
+        is PositionClass.ORPHAN_UNKNOWN
+    )
+    assert (
+        classify_position(unknown_pos, state, ENABLED_MAP).classification
+        is PositionClass.ORPHAN_UNKNOWN
+    )
+
+
+def test_orphan_not_held_when_db_open_but_alpaca_zero() -> None:
+    pos = _db_position()
+    state = _make_state(positions=[])
+    out = classify_position(pos, state, ENABLED_MAP)
+    assert out.classification is PositionClass.ORPHAN_NOT_HELD
+
+
+# ---------------------------------------------------------------------------
+# Closed-side classification
+# ---------------------------------------------------------------------------
+
+
+def test_actual_fill_when_both_entry_and_exit_fills_exist() -> None:
+    pos = _db_position(status="CLOSED")
+    state = _make_state(orders=[_buy_fill(), _sell_fill()])
+    out = classify_position(pos, state, ENABLED_MAP)
+    assert out.classification is PositionClass.ACTUAL_FILL
+
+
+def test_actual_fill_uses_explicit_alpaca_order_id_when_present() -> None:
+    pos = _db_position(status="CLOSED", alpaca_order_id="explicit-buy")
+    state = _make_state(
+        orders=[
+            _buy_fill(order_id="explicit-buy"),
+            _sell_fill(),
+        ]
+    )
+    out = classify_position(pos, state, ENABLED_MAP)
+    assert out.classification is PositionClass.ACTUAL_FILL
+    assert "explicit-buy" in out.evidence
+
+
+def test_phantom_close_when_no_buy_fill_exists() -> None:
+    pos = _db_position(status="CLOSED")
+    state = _make_state(orders=[])
+    out = classify_position(pos, state, ENABLED_MAP)
+    assert out.classification is PositionClass.PHANTOM_CLOSE
+
+
+def test_closed_no_exit_when_buy_filled_but_no_sell() -> None:
+    pos = _db_position(status="CLOSED")
+    state = _make_state(orders=[_buy_fill()])  # no sell
+    out = classify_position(pos, state, ENABLED_MAP)
+    assert out.classification is PositionClass.CLOSED_NO_EXIT
+
+
+def test_closed_with_unparseable_entry_time_classes_as_phantom() -> None:
+    pos = _db_position(status="CLOSED")
+    pos["entry_time"] = "not-a-real-date"
+    state = _make_state(orders=[])
+    out = classify_position(pos, state, ENABLED_MAP)
+    assert out.classification is PositionClass.PHANTOM_CLOSE
+
+
+# ---------------------------------------------------------------------------
+# Trades classification
+# ---------------------------------------------------------------------------
+
+
+def _trade_row(
+    *,
+    trade_id: int = 1,
+    ticker: str = "SPY",
+    strategy_id: str | None = None,
+    exit_time: str | None = None,
+    entry_time: datetime = ENTRY_TIME,
+) -> dict[str, Any]:
+    return {
+        "id": trade_id,
+        "ticker": ticker,
+        "exchange": "ARCA",
+        "currency": "USD",
+        "side": "long",
+        "entry_time": entry_time.isoformat(),
+        "entry_price": 100.0,
+        "quantity": 10,
+        "exit_time": exit_time,
+        "exit_price": 101.5 if exit_time else None,
+        "exit_reason": "stop_loss" if exit_time else None,
+        "net_pnl": 15.0 if exit_time else None,
+        "hold_type": "intraday",
+        "phase": 1,
+        "strategy_id": strategy_id,
+    }
+
+
+def test_entry_only_phantom_when_strategy_and_exit_both_null() -> None:
+    trade = _trade_row()
+    paired_pos = _db_position(status="CLOSED", strategy_id="mean_reversion")
+    lookup = _position_lookup([paired_pos])
+    out = classify_trade(trade, lookup)
+    assert out.classification is TradeClass.ENTRY_ONLY_PHANTOM
+    # Confirms which paired-position attribution would have fixed it.
+    assert "mean_reversion" in out.evidence
+
+
+def test_missing_strategy_when_exit_present_but_strategy_null() -> None:
+    trade = _trade_row(exit_time="2026-04-28T13:00:00+00:00", strategy_id=None)
+    out = classify_trade(trade, {})
+    assert out.classification is TradeClass.MISSING_STRATEGY
+
+
+def test_missing_exit_when_strategy_present_but_exit_null() -> None:
+    trade = _trade_row(strategy_id="mean_reversion", exit_time=None)
+    out = classify_trade(trade, {})
+    assert out.classification is TradeClass.MISSING_EXIT
+
+
+def test_complete_when_both_present() -> None:
+    trade = _trade_row(
+        strategy_id="mean_reversion",
+        exit_time="2026-04-28T13:00:00+00:00",
+    )
+    out = classify_trade(trade, {})
+    assert out.classification is TradeClass.COMPLETE
+
+
+# ---------------------------------------------------------------------------
+# Report assembly + rendering
+# ---------------------------------------------------------------------------
+
+
+def _seed_realistic_db(conn: sqlite3.Connection) -> None:
+    """Insert a small realistic mix mirroring the bot-db artifact."""
+    # 1 actual open
+    conn.execute(
+        "INSERT INTO positions (ticker, exchange, currency, quantity, "
+        "entry_price, entry_time, status, hold_type, phase, strategy_id, "
+        "alpaca_order_id) VALUES "
+        "('SPY','ARCA','USD',10,100.0,?, 'POSITION_OPEN','intraday',1,"
+        "'mean_reversion','buy-spy')",
+        (ENTRY_TIME.isoformat(),),
+    )
+    # 1 orphan disabled (breakout)
+    conn.execute(
+        "INSERT INTO positions (ticker, exchange, currency, quantity, "
+        "entry_price, entry_time, status, hold_type, phase, strategy_id) "
+        "VALUES ('XLF','ARCA','USD',5,40.0,?,'STOP_AND_TARGET_ACTIVE',"
+        "'intraday',1,'breakout')",
+        (ENTRY_TIME.isoformat(),),
+    )
+    # 1 orphan unknown
+    conn.execute(
+        "INSERT INTO positions (ticker, exchange, currency, quantity, "
+        "entry_price, entry_time, status, hold_type, phase, strategy_id) "
+        "VALUES ('QQQ','NASDAQ','USD',2,400.0,?,'POSITION_OPEN',"
+        "'intraday',1,'unknown')",
+        (ENTRY_TIME.isoformat(),),
+    )
+    # 1 phantom close (CLOSED but no buy fill)
+    conn.execute(
+        "INSERT INTO positions (ticker, exchange, currency, quantity, "
+        "entry_price, entry_time, status, hold_type, phase, strategy_id) "
+        "VALUES ('IWM','ARCA','USD',8,200.0,?,'CLOSED','intraday',1,"
+        "'mean_reversion')",
+        (ENTRY_TIME.isoformat(),),
+    )
+    # Trades: 1 entry-only phantom + 1 complete
+    conn.execute(
+        "INSERT INTO trades (ticker, exchange, currency, side, entry_time, "
+        "entry_price, quantity, hold_type, phase) VALUES "
+        "('SPY','ARCA','USD','long',?,100.0,10,'intraday',1)",
+        (ENTRY_TIME.isoformat(),),
+    )
+    conn.execute(
+        "INSERT INTO trades (ticker, exchange, currency, side, entry_time, "
+        "entry_price, quantity, exit_time, exit_price, exit_reason, "
+        "net_pnl, hold_type, phase, strategy_id) VALUES "
+        "('IWM','ARCA','USD','long',?,200.0,8,?,201.0,'stop_loss',8.0,"
+        "'intraday',1,'mean_reversion')",
+        (ENTRY_TIME.isoformat(), (ENTRY_TIME + timedelta(hours=1)).isoformat()),
+    )
+    conn.commit()
+
+
+def test_build_report_groups_findings_and_renders_clean_markdown(tmp_db) -> None:
+    _seed_realistic_db(tmp_db)
+    state = _make_state(
+        positions=[AlpacaPosition("SPY", qty=10.0, avg_entry_price=100.0, market_value=1000.0)],
+        orders=[],  # nothing for IWM => phantom close
+    )
+    db_positions = load_db_positions(tmp_db)
+    db_trades = load_db_trades(tmp_db)
+    report = build_report(
+        db_path=":memory:",
+        state=state,
+        db_positions=db_positions,
+        db_trades=db_trades,
+        strategy_enabled=ENABLED_MAP,
+        since=ENTRY_TIME - timedelta(days=30),
+        until=ENTRY_TIME + timedelta(days=1),
+    )
+    classes = {pf.classification for pf in report.position_findings}
+    assert PositionClass.ACTUAL_OPEN in classes
+    assert PositionClass.ORPHAN_DISABLED in classes
+    assert PositionClass.ORPHAN_UNKNOWN in classes
+    assert PositionClass.PHANTOM_CLOSE in classes
+
+    md = render_markdown(report)
+    assert "# Reconciliation report" in md
+    assert "ACTUAL_OPEN" in md
+    assert "ORPHAN_DISABLED" in md
+    assert "PHANTOM_CLOSE" in md
+    assert "Bug-hypothesis confirmation" in md
+    # Account + paper banner.
+    assert "PA-TEST" in md
+    assert "paper" in md
+
+
+def test_build_report_with_no_db_rows_produces_zero_count_table(tmp_db) -> None:
+    state = _make_state()
+    report = build_report(
+        db_path=":memory:",
+        state=state,
+        db_positions=[],
+        db_trades=[],
+        strategy_enabled=ENABLED_MAP,
+        since=ENTRY_TIME - timedelta(days=30),
+        until=ENTRY_TIME + timedelta(days=1),
+    )
+    md = render_markdown(report)
+    # Every classification row should be present with 0.
+    for cls in PositionClass:
+        assert f"| {cls.value} | 0 |" in md
+
+
+# ---------------------------------------------------------------------------
+# Strategy-enabled-map loader
+# ---------------------------------------------------------------------------
+
+
+def test_load_strategy_enabled_map_reads_real_config() -> None:
+    from trading_bot.self_improve.reconcile import load_strategy_enabled_map
+
+    enabled: dict[str, bool] = load_strategy_enabled_map("config.yaml")
+    # Mean reversion must be on; breakout/trend_following are off after the
+    # 2026-04-28 regime-aware rebalance (PR #12).
+    assert enabled.get("mean_reversion") is True
+    assert enabled.get("overnight_drift") is True
+    assert enabled.get("breakout") is False
+    assert enabled.get("trend_following") is False

--- a/trading_bot/tests/test_tick_and_risk_state.py
+++ b/trading_bot/tests/test_tick_and_risk_state.py
@@ -1,4 +1,8 @@
-"""Tests for tick_state / risk_circuit_state persistence (Schema V7)."""
+"""Tests for tick_state / risk_circuit_state persistence (added in Schema V7).
+
+The version assertions reference :data:`trading_bot.constants.SCHEMA_VERSION`
+so future migration bumps don't silently regress these tests.
+"""
 
 from __future__ import annotations
 
@@ -8,6 +12,7 @@ from pathlib import Path
 
 import pytest
 
+from trading_bot.constants import SCHEMA_VERSION
 from trading_bot.db.migrations import run_migrations
 from trading_bot.db.repository import (
     load_risk_state,
@@ -39,7 +44,7 @@ def test_migration_creates_new_tables(tmp_path: Path) -> None:
         assert "risk_circuit_state" in names
 
         version = conn.execute("SELECT MAX(version) FROM schema_version").fetchone()[0]
-        assert version == 7
+        assert version == SCHEMA_VERSION
     finally:
         conn.close()
 
@@ -53,7 +58,7 @@ def test_migration_is_idempotent(tmp_path: Path) -> None:
     conn = sqlite3.connect(str(db_path))
     try:
         version = conn.execute("SELECT MAX(version) FROM schema_version").fetchone()[0]
-        assert version == 7
+        assert version == SCHEMA_VERSION
     finally:
         conn.close()
 


### PR DESCRIPTION
## Summary

Three-phase cleanup of the live bot's data persistence layer. Built while debugging why the new self-improvement agent (PR #15) saw zero closed trades against the GHA-cached SQLite. Investigation found **five concrete bugs** in the entry/close path corrupting `trades` and `positions` on every run.

Each phase is a separate commit so review (and revert if needed) can happen in isolation.

| Commit | Phase | Touches | Risk |
|---|---|---|---|
| `dc8d87a` | 1 | New read-only `reconcile` module | None — never writes to DB or Alpaca |
| `82e2c62` | 2 | `PositionStatus.ENTRY_FAILED` + V8 migration | DB-only, idempotent |
| `80572e7` | 1 | Reconcile output committed as evidence | Doc-only |
| `752c544` | 3 | Five live order-logic fixes (B1–B5) | **Highest** — touches order_manager + recovery |

## Real evidence (from Phase 1 reconcile against `bot-db-25135914687`)

| Class | Count |
|---|---|
| ENTRY_ONLY_PHANTOM (trades) | 54 |
| PHANTOM_CLOSE (positions) | 52 |
| ORPHAN_DISABLED + ORPHAN_UNKNOWN | 3 |
| ACTUAL_FILL | 0 |
| MISSING_EXIT | 0 (masked by bug B1) |

Bugs confirmed; V8 migration's WHERE clause selects exactly 52 — calibrated to the evidence.

## Phase 3 fixes

- **B1** — `order_manager._create_position_record:867` — trades INSERT now binds `decision.strategy_id`.
- **B2** — `order_manager.py:244, 384, 445` — three `CLOSED→ENTRY_FAILED` conversions on canceled/expired/rejected/raised entry.
- **B3** — `order_manager._close_position:803` — captures `trades.lastrowid` from the second insert and threads through `_ActiveOrder.db_trade_id`, fixing the UPDATE that previously matched on the wrong id.
- **B4** — `recovery._close_db_position:491` — INSERT now includes `strategy_id`, derives side from position quantity, computes `net_pnl` from current Alpaca price.
- **B5** — `_update_position_field` — logs `rows_affected`; warns on miss so the next instance is visible immediately.

433 lines of regression tests in `test_phase3_regressions.py`, written first per TDD.

## Tests

- `632 pass / 2 skip / 3 fail` (the 3 failures are `test_daily_metrics_*` — pre-existing, unrelated to data layer).
- New tests: 17 reconcile, 357-line V8 migration suite, 433-line Phase 3 regressions.

## Test plan

- [ ] CI green
- [ ] Inspect Phase 1 reconcile report at `self_improve_reports/reconcile_2026-04-29.md`
- [ ] After merge, trigger 2-3 paper-trade ticks via `gh workflow run bot.yml`, download the `bot-db-*` artifact, verify on the new rows:
  - `trades.strategy_id` populated
  - any closure has `exit_time` + `exit_price` + `exit_reason` + `net_pnl` populated
  - any rejection has `positions.status='ENTRY_FAILED'` (not CLOSED)
  - successful entries have `positions.alpaca_order_id` populated
- [ ] Re-run reconcile against post-V8 DB; PHANTOM_CLOSE should be 0
- [ ] Re-run `python -m trading_bot.self_improve.backfill_cli` to populate exit data for any positions with real Alpaca SELL fills (likely 0 given current state)

## Follow-ups (not in this PR)

- **Task #3 from `docs/self_improve_followups.md`** — the 3 orphan positions on Alpaca (SPY +1 / breakout, XLRE +20 / trend_following, **QQQ -1 / unknown** — short on a long-only bot). Requires a flatten decision before re-enabling the daily-review agent.
- Re-enable the daily-review cron in `.github/workflows/daily-review.yml` (lives on PR #15's branch — uncomment the `schedule:` block once Phase 3 is in production for a few days and trades are accumulating cleanly).