### PR TITLE
feat: one-shot orphan flatten tool (operational, --dry-run default)

### DIFF
--- a/trading_bot/self_improve/flatten_orphans.py
+++ b/trading_bot/self_improve/flatten_orphans.py
@@ -1,0 +1,284 @@
+"""One-shot operational tool: flatten orphan positions on Alpaca.
+
+Surfaced by the Phase 1 reconcile report (see
+docs/self_improve_followups.md task #3). Three open positions on the
+paper account no live tick code is managing:
+
+  - SPY +1   strategy=breakout            (DISABLED in config)
+  - XLRE +20 strategy=trend_following     (DISABLED in config)
+  - QQQ -1   strategy=unknown             (SHORT — not a strategy archetype)
+
+For each orphan this script:
+  1. Re-checks the position is still live on Alpaca (idempotent).
+  2. Cancels any open child orders (stop / target / trail).
+  3. Submits a MARKET order for the OPPOSITE side & matching qty
+     (SELL for long, BUY for short).
+  4. Updates positions.status = 'CLOSED' in the local DB.
+
+SAFETY:
+  - --dry-run is the default. The script prints what it would do and
+    exits without touching Alpaca or the DB.
+  - --execute is required to actually submit orders.
+  - --tickers can scope the run to a subset (default: SPY,XLRE,QQQ).
+  - Each ticker runs independently; one failure does not block the rest.
+  - Submitted orders are always MARKET DAY — fills near current price,
+    expires at session close if untouched.
+
+Run:
+    python -m trading_bot.self_improve.flatten_orphans               # dry-run
+    python -m trading_bot.self_improve.flatten_orphans --execute     # send orders
+    python -m trading_bot.self_improve.flatten_orphans --tickers QQQ # one only
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sqlite3
+import sys
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable
+from zoneinfo import ZoneInfo
+
+from trading_bot.config import Config
+from trading_bot.env import resolve_alpaca_env
+from trading_bot.log_setup import setup_logging
+
+logger = logging.getLogger(__name__)
+
+ET = ZoneInfo("US/Eastern")
+
+# Default scope. Edit only if reconcile shows different orphans.
+DEFAULT_ORPHAN_TICKERS: tuple[str, ...] = ("SPY", "XLRE", "QQQ")
+
+
+@dataclass(frozen=True)
+class OrphanPlan:
+    """What we'd do to flatten a single orphan position."""
+
+    ticker: str
+    alpaca_qty: float          # signed: negative = short
+    flatten_side: str          # "BUY" or "SELL"
+    flatten_qty: float         # absolute value
+    db_position_id: int | None
+    child_order_ids_to_cancel: list[str]
+
+
+def _build_plan(
+    alpaca_position,
+    db_position_id: int | None,
+    child_order_ids: list[str],
+) -> OrphanPlan:
+    qty = float(alpaca_position.qty)
+    abs_qty = abs(qty)
+    side = "BUY" if qty < 0 else "SELL"
+    return OrphanPlan(
+        ticker=str(alpaca_position.symbol),
+        alpaca_qty=qty,
+        flatten_side=side,
+        flatten_qty=abs_qty,
+        db_position_id=db_position_id,
+        child_order_ids_to_cancel=child_order_ids,
+    )
+
+
+def _find_db_position(conn: sqlite3.Connection, ticker: str) -> tuple[int | None, list[str]]:
+    """Return (position_id, child_order_ids) for the live DB row for ``ticker``.
+
+    "Live" = not yet CLOSED / ENTRY_FAILED. Returns (None, []) if no row.
+    """
+    row = conn.execute(
+        """
+        SELECT id, alpaca_stop_order_id, alpaca_target_order_id, alpaca_trail_order_id
+          FROM positions
+         WHERE ticker = ?
+           AND status NOT IN ('CLOSED', 'ENTRY_FAILED')
+         ORDER BY entry_time DESC
+         LIMIT 1
+        """,
+        (ticker,),
+    ).fetchone()
+    if row is None:
+        return None, []
+    pos_id, stop_id, target_id, trail_id = row
+    child_ids = [oid for oid in (stop_id, target_id, trail_id) if oid]
+    return int(pos_id), child_ids
+
+
+def _execute_one(
+    plan: OrphanPlan,
+    client,
+    conn: sqlite3.Connection,
+) -> bool:
+    """Cancel children, submit flatten market order, update DB.
+
+    Returns True on full success. On failure, logs and returns False so
+    the next orphan can still be attempted.
+    """
+    from alpaca.trading.requests import MarketOrderRequest
+    from alpaca.trading.enums import OrderSide, OrderType, TimeInForce
+
+    # 1. Cancel child orders. Best-effort; an already-canceled child is fine.
+    for child_id in plan.child_order_ids_to_cancel:
+        try:
+            client.cancel_order_by_id(child_id)
+            logger.info("Cancelled child order %s for %s", child_id, plan.ticker)
+        except Exception as exc:
+            logger.warning(
+                "Could not cancel child order %s for %s (may already be done): %s",
+                child_id, plan.ticker, exc,
+            )
+
+    # 2. Submit the flatten order. Refuse if Alpaca side enum doesn't match.
+    side_enum = OrderSide.BUY if plan.flatten_side == "BUY" else OrderSide.SELL
+    request = MarketOrderRequest(
+        symbol=plan.ticker,
+        qty=plan.flatten_qty,
+        side=side_enum,
+        type=OrderType.MARKET,
+        time_in_force=TimeInForce.DAY,
+    )
+    try:
+        order = client.submit_order(order_data=request)
+    except Exception:
+        logger.exception("FAILED to submit flatten order for %s", plan.ticker)
+        return False
+
+    logger.info(
+        "Submitted FLATTEN %s %s %.6f (alpaca_id=%s)",
+        plan.flatten_side, plan.ticker, plan.flatten_qty, order.id,
+    )
+
+    # 3. Update DB only after the order is accepted by Alpaca.
+    if plan.db_position_id is not None:
+        try:
+            now_str = datetime.now(tz=ET).isoformat()
+            conn.execute(
+                "UPDATE positions SET status = 'CLOSED', updated_at = ? "
+                "WHERE id = ? AND status NOT IN ('CLOSED', 'ENTRY_FAILED')",
+                (now_str, plan.db_position_id),
+            )
+            conn.commit()
+            logger.info("Updated DB positions.id=%d -> CLOSED", plan.db_position_id)
+        except Exception:
+            logger.exception(
+                "Order accepted but DB update failed for positions.id=%d. "
+                "Reconcile after the fill.", plan.db_position_id,
+            )
+            return False
+
+    return True
+
+
+def plan_and_execute(
+    *,
+    db_path: str,
+    tickers: Iterable[str],
+    execute: bool,
+) -> int:
+    """Return shell exit code. 0 = all planned/executed cleanly."""
+    target_tickers = {t.upper() for t in tickers}
+
+    api_key, secret_key, is_paper = resolve_alpaca_env()
+    if not api_key or not secret_key:
+        logger.error(
+            "Alpaca credentials not found. Set ALPACA_PAPER_KEY_ID + "
+            "ALPACA_PAPER_SECRET (or ALPACA_API_KEY + ALPACA_SECRET_KEY)."
+        )
+        return 2
+
+    from alpaca.trading.client import TradingClient
+    client = TradingClient(api_key, secret_key, paper=is_paper)
+    logger.info("Connected to Alpaca (%s, paper=%s)",
+                "live" if not is_paper else "paper", is_paper)
+
+    if not Path(db_path).exists():
+        logger.error("DB not found at %s", db_path)
+        return 2
+
+    # Pull live Alpaca positions and build per-ticker plans.
+    alpaca_positions = client.get_all_positions()
+    by_ticker = {str(p.symbol): p for p in alpaca_positions if float(p.qty) != 0}
+    logger.info("Alpaca holds %d non-zero positions: %s",
+                len(by_ticker), sorted(by_ticker.keys()))
+
+    plans: list[OrphanPlan] = []
+    conn = sqlite3.connect(db_path)
+    try:
+        for ticker in target_tickers:
+            if ticker not in by_ticker:
+                logger.info("%s: not held on Alpaca — nothing to flatten", ticker)
+                continue
+            pos_id, child_ids = _find_db_position(conn, ticker)
+            plans.append(_build_plan(by_ticker[ticker], pos_id, child_ids))
+    finally:
+        if not execute:
+            conn.close()
+
+    if not plans:
+        logger.info("No orphans to flatten. Done.")
+        return 0
+
+    # Print the plan unconditionally so dry-run is the same as the first
+    # half of an execute run.
+    print()
+    print("=== Flatten plan ===")
+    for p in plans:
+        print(
+            f"  {p.ticker:6s} alpaca_qty={p.alpaca_qty:+.4f}  "
+            f"action={p.flatten_side} {p.flatten_qty} @ MARKET  "
+            f"db_id={p.db_position_id}  cancel_children={len(p.child_order_ids_to_cancel)}"
+        )
+    print()
+
+    if not execute:
+        print("DRY RUN — re-run with --execute to send these orders.")
+        return 0
+
+    print("EXECUTING — submitting market orders to Alpaca...")
+    print()
+
+    failures = 0
+    try:
+        conn.row_factory = sqlite3.Row
+        for plan in plans:
+            ok = _execute_one(plan, client, conn)
+            if not ok:
+                failures += 1
+    finally:
+        conn.close()
+
+    if failures:
+        logger.error("%d/%d flatten action(s) failed — check log", failures, len(plans))
+        return 1
+    logger.info("All %d orphan(s) flattened successfully", len(plans))
+    return 0
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description=__doc__.split("\n\n")[0] if __doc__ else "",
+    )
+    p.add_argument("--config", default="config.yaml", help="Path to config.yaml")
+    p.add_argument("--db", default=None,
+                   help="SQLite path (default: config's database.path)")
+    p.add_argument("--tickers", default=",".join(DEFAULT_ORPHAN_TICKERS),
+                   help="Comma-separated tickers to consider (default: SPY,XLRE,QQQ)")
+    p.add_argument("--execute", action="store_true",
+                   help="Actually submit orders. Without this flag the script is read-only.")
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    setup_logging("flatten_orphans")
+    args = _parse_args(argv)
+    config = Config.load(args.config)
+    db_path = args.db or config.db_path
+    tickers = [t.strip() for t in args.tickers.split(",") if t.strip()]
+    return plan_and_execute(db_path=db_path, tickers=tickers, execute=args.execute)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/trading_bot/tests/test_flatten_orphans.py
+++ b/trading_bot/tests/test_flatten_orphans.py
@@ -1,0 +1,152 @@
+"""Tests for trading_bot.self_improve.flatten_orphans plan-building.
+
+Order submission and Alpaca round-trips are intentionally not exercised
+here — those run only behind --execute and require a paper account.
+We verify: long/short side derivation, DB child-order discovery,
+status filter (don't touch already-CLOSED rows), idempotency.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from trading_bot.self_improve.flatten_orphans import (
+    _build_plan,
+    _find_db_position,
+)
+
+
+@dataclass
+class _FakeAlpacaPosition:
+    symbol: str
+    qty: str  # alpaca-py returns qty as string
+
+
+@pytest.mark.unit
+def test_long_position_flattens_via_sell():
+    plan = _build_plan(
+        _FakeAlpacaPosition(symbol="SPY", qty="1.0"),
+        db_position_id=42,
+        child_order_ids=["stop-1"],
+    )
+    assert plan.ticker == "SPY"
+    assert plan.alpaca_qty == 1.0
+    assert plan.flatten_side == "SELL"
+    assert plan.flatten_qty == 1.0
+    assert plan.db_position_id == 42
+    assert plan.child_order_ids_to_cancel == ["stop-1"]
+
+
+@pytest.mark.unit
+def test_short_position_flattens_via_buy():
+    plan = _build_plan(
+        _FakeAlpacaPosition(symbol="QQQ", qty="-1.0"),
+        db_position_id=None,
+        child_order_ids=[],
+    )
+    assert plan.alpaca_qty == -1.0
+    assert plan.flatten_side == "BUY"
+    assert plan.flatten_qty == 1.0
+
+
+@pytest.mark.unit
+def test_fractional_long_flattens_via_sell_with_full_qty():
+    plan = _build_plan(
+        _FakeAlpacaPosition(symbol="XLRE", qty="20.5"),
+        db_position_id=7,
+        child_order_ids=[],
+    )
+    assert plan.flatten_side == "SELL"
+    assert plan.flatten_qty == 20.5
+
+
+@pytest.mark.unit
+def test_find_db_position_returns_none_when_missing(tmp_db):
+    pos_id, child_ids = _find_db_position(tmp_db, "GHOST")
+    assert pos_id is None
+    assert child_ids == []
+
+
+@pytest.mark.unit
+def test_find_db_position_skips_already_closed(tmp_db):
+    tmp_db.execute(
+        """
+        INSERT INTO positions
+          (ticker, exchange, currency, quantity, entry_price, entry_time,
+           status, hold_type, phase, strategy_id)
+        VALUES ('XLRE', 'NYSE', 'USD', 20, 50.0, '2026-04-28T11:50:00-04:00',
+                'CLOSED', 'swing', 1, 'trend_following')
+        """
+    )
+    tmp_db.commit()
+    pos_id, child_ids = _find_db_position(tmp_db, "XLRE")
+    assert pos_id is None
+    assert child_ids == []
+
+
+@pytest.mark.unit
+def test_find_db_position_returns_open_row_with_child_orders(tmp_db):
+    tmp_db.execute(
+        """
+        INSERT INTO positions
+          (ticker, exchange, currency, quantity, entry_price, entry_time,
+           status, hold_type, phase, strategy_id,
+           alpaca_stop_order_id, alpaca_target_order_id, alpaca_trail_order_id)
+        VALUES ('SPY', 'NYSE', 'USD', 1, 700.0, '2026-04-27T15:40:00-04:00',
+                'STOP_AND_TARGET_ACTIVE', 'swing', 1, 'breakout',
+                'stop-abc', 'target-def', NULL)
+        """
+    )
+    tmp_db.commit()
+    pos_id, child_ids = _find_db_position(tmp_db, "SPY")
+    assert pos_id is not None
+    assert sorted(child_ids) == ["stop-abc", "target-def"]
+
+
+@pytest.mark.unit
+def test_find_db_position_returns_most_recent_when_history_exists(tmp_db):
+    # Older row CLOSED, newer row OPEN — should pick the open one.
+    tmp_db.execute(
+        """
+        INSERT INTO positions
+          (ticker, exchange, currency, quantity, entry_price, entry_time,
+           status, hold_type, phase, strategy_id)
+        VALUES ('QQQ', 'NASDAQ', 'USD', -1, 650.0, '2026-04-20T10:00:00-04:00',
+                'CLOSED', 'swing', 1, 'unknown')
+        """
+    )
+    tmp_db.execute(
+        """
+        INSERT INTO positions
+          (ticker, exchange, currency, quantity, entry_price, entry_time,
+           status, hold_type, phase, strategy_id)
+        VALUES ('QQQ', 'NASDAQ', 'USD', -1, 650.0, '2026-04-27T10:26:29-04:00',
+                'POSITION_OPEN', 'swing', 1, 'unknown')
+        """
+    )
+    tmp_db.commit()
+    pos_id, _ = _find_db_position(tmp_db, "QQQ")
+    assert pos_id is not None
+    row = tmp_db.execute(
+        "SELECT entry_time FROM positions WHERE id = ?", (pos_id,)
+    ).fetchone()
+    assert row[0].startswith("2026-04-27")
+
+
+@pytest.mark.unit
+def test_find_db_position_skips_entry_failed(tmp_db):
+    tmp_db.execute(
+        """
+        INSERT INTO positions
+          (ticker, exchange, currency, quantity, entry_price, entry_time,
+           status, hold_type, phase, strategy_id)
+        VALUES ('SPY', 'NYSE', 'USD', 1, 700.0, '2026-04-27T15:40:00-04:00',
+                'ENTRY_FAILED', 'swing', 1, 'breakout')
+        """
+    )
+    tmp_db.commit()
+    pos_id, child_ids = _find_db_position(tmp_db, "SPY")
+    assert pos_id is None
+    assert child_ids == []


### PR DESCRIPTION
## Summary

Operational follow-up to PR #16 (data-layer cleanup) and \`docs/self_improve_followups.md\` task #3. Adds a standalone CLI to flatten the three orphan positions the Phase 1 reconcile surfaced:

- **SPY +1** strategy=\`breakout\` (DISABLED)
- **XLRE +20** strategy=\`trend_following\` (DISABLED)
- **QQQ -1** strategy=\`unknown\` (SHORT — long-only bot)

For each orphan: re-check on Alpaca → cancel any open child orders → submit MARKET DAY on the opposite side & matching qty → update \`positions.status = 'CLOSED'\` in the local DB.

## Safety

- \`--dry-run\` is the default. The first run prints the plan and exits.
- \`--execute\` is required to actually submit orders.
- Standalone — does not call into \`order_manager\`. Phase 3 fixes apply to the strategy-driven entry/close path; this is a one-shot operator action.
- Per-ticker isolation: a failure on one orphan does not block the others.
- DB update happens only after Alpaca accepts the order.

## How to use

\`\`\`bash
# 1. See the plan (no orders, no DB writes)
python -m trading_bot.self_improve.flatten_orphans

# 2. Review the printed plan. Then execute:
python -m trading_bot.self_improve.flatten_orphans --execute

# Or scope to one ticker:
python -m trading_bot.self_improve.flatten_orphans --tickers QQQ --execute
\`\`\`

## Tests

8 unit tests cover plan-building. Order submission runs only behind \`--execute\` against your paper account — intentionally not exercised in CI.

## Test plan

- [ ] \`python3 -m pytest trading_bot/tests/test_flatten_orphans.py -q\` → 8 passed
- [ ] \`python3 -m trading_bot.self_improve.flatten_orphans\` (dry-run) prints exactly 3 planned actions: SELL 1 SPY, SELL 20 XLRE, BUY 1 QQQ
- [ ] After \`--execute\`, \`gh workflow run bot.yml\` followed by re-run of \`python -m trading_bot.self_improve.reconcile\` shows 0 ORPHAN_DISABLED + 0 ORPHAN_UNKNOWN