### PR TITLE
fix(flatten_orphans): broker-atomic close_all_positions when planned == live

### DIFF
--- a/docs/self_improve_followups.md
+++ b/docs/self_improve_followups.md
@@ -233,3 +233,66 @@ WHERE p.status = 'CLOSED' AND p.strategy_id IS NOT NULL AND p.strategy_id != 'un
 SELECT id, ticker, entry_time FROM trades
 WHERE exit_time IS NULL OR strategy_id IS NULL ORDER BY entry_time DESC LIMIT 20;
 ```
+
+## Lessons learned — Alpaca order behavior outside RTH
+
+Captured 2026-04-30 while iterating on `trading_bot/self_improve/flatten_orphans.py`
+to flatten the three orphan positions identified by Phase 1 reconcile.
+Each item below cost real cycles to discover — leave them here so the
+next operator does not re-learn them.
+
+### `held_for_orders` is enforced at submission time, regardless of TIF
+
+Submitting a flatten while a stop on the same symbol is in
+`PENDING_CANCEL` returns:
+
+```
+APIError: {
+  "code": 40310000,
+  "message": "insufficient qty available for order (requested: 1, available: 0)",
+  "existing_qty": "1",
+  "held_for_orders": "1",
+  "related_orders": ["<the pending-cancel stop id>"]
+}
+```
+
+This fires for `TimeInForce.DAY` AND for `TimeInForce.OPG`. OPG does not
+bypass the qty check — Alpaca validates `held_for_orders` at the
+`POST /v2/orders` endpoint, before the order ever reaches the auction
+queue. Don't reach for OPG as a workaround.
+
+### Stop-order cancellations stay in PENDING_CANCEL until the next open
+
+`DELETE /v2/orders/{id}` against a stop placed during a previous session
+returns `200` immediately, but the order's status sits at
+`PENDING_CANCEL` and the held qty stays reserved until the next
+opening cross. Polling with `GetOrdersRequest(status=OPEN)` will keep
+returning the same stop the entire pre-market window — there is no
+amount of waiting (within reason) that releases the qty before 09:30 ET.
+
+### `close_all_positions(cancel_orders=True)` is the broker-atomic flatten
+
+When the planned-flatten set exactly matches the live position set,
+prefer this endpoint over per-ticker submit. It cancels every open
+order AND closes every position in a single broker-side operation, so
+it bypasses the manual cancel + qty-release dance entirely.
+
+Caveat: even this endpoint can return `503 Service Unavailable` from
+the paper API outside RTH (observed 2026-04-30 08:29 ET against
+`paper-api.alpaca.markets`). Whether that's a transient outage or a
+documented restriction is unclear, but in practice the cleanest path is
+to run any flatten/close operation **during regular trading hours**.
+Pre-market, every available approach hits one wall or another.
+
+### Operational rule
+
+For one-shot flatten / liquidation tools:
+- Run **inside RTH** (09:30–16:00 ET).
+- Use `close_all_positions(cancel_orders=True)` when planned == live.
+- Per-ticker `close_position` is the fallback when planned ⊊ live.
+- Never assume a `200` from `DELETE /v2/orders` means qty has released.
+
+For the live bot's continuous order management, the existing pattern
+(bracket orders + tick-time fill detection) sidesteps this entirely
+because every cancel + flatten happens during RTH by definition.
+```

--- a/trading_bot/self_improve/flatten_orphans.py
+++ b/trading_bot/self_improve/flatten_orphans.py
@@ -313,16 +313,40 @@ def plan_and_execute(
         print("DRY RUN — re-run with --execute to send these orders.")
         return 0
 
-    print("EXECUTING — submitting market orders to Alpaca...")
+    print("EXECUTING — submitting flatten orders to Alpaca...")
     print()
+
+    # If the planned orphans are exactly the live position set, use the
+    # broker-atomic close_all_positions(cancel_orders=True). That endpoint
+    # cancels every open order AND closes every position in one operation
+    # — broker-side, so it works pre-market when manual cancel + submit
+    # is blocked by held_for_orders on PENDING_CANCEL stops.
+    planned_tickers = {p.ticker for p in plans}
+    live_tickers = set(by_ticker.keys())
+    use_bulk = planned_tickers == live_tickers
 
     failures = 0
     try:
         conn.row_factory = sqlite3.Row
-        for plan in plans:
-            ok = _execute_one(plan, client, conn, is_market_open=is_market_open)
-            if not ok:
-                failures += 1
+        if use_bulk:
+            logger.info(
+                "Planned orphans (%s) == live Alpaca positions; using "
+                "close_all_positions(cancel_orders=True) for atomic flatten",
+                sorted(planned_tickers),
+            )
+            failures = _execute_bulk(plans, client, conn)
+        else:
+            extra = live_tickers - planned_tickers
+            logger.warning(
+                "Live Alpaca positions (%s) include non-orphan tickers (%s); "
+                "falling back to per-ticker close. Some flattens may fail "
+                "pre-market due to held_for_orders on pending stop cancels.",
+                sorted(live_tickers), sorted(extra),
+            )
+            for plan in plans:
+                ok = _execute_one(plan, client, conn, is_market_open=is_market_open)
+                if not ok:
+                    failures += 1
     finally:
         conn.close()
 
@@ -331,6 +355,55 @@ def plan_and_execute(
         return 1
     logger.info("All %d orphan(s) flattened successfully", len(plans))
     return 0
+
+
+def _execute_bulk(
+    plans: list[OrphanPlan],
+    client,
+    conn: sqlite3.Connection,
+) -> int:
+    """Atomic bulk flatten via close_all_positions. Returns failure count."""
+    try:
+        responses = client.close_all_positions(cancel_orders=True)
+    except Exception:
+        logger.exception("close_all_positions raised; nothing flattened")
+        return len(plans)
+
+    # Each response carries .symbol and .status (HTTP code from the broker).
+    # 200 / 207 = accepted; anything else means that ticker did not flatten.
+    by_symbol_status: dict[str, int] = {}
+    for r in responses:
+        sym = str(getattr(r, "symbol", "?"))
+        status = int(getattr(r, "status", 0))
+        by_symbol_status[sym] = status
+        body = getattr(r, "body", None)
+        order_id = getattr(body, "id", None) if body is not None else None
+        logger.info("Bulk close: %s -> status=%d order_id=%s", sym, status, order_id)
+
+    failures = 0
+    now_str = datetime.now(tz=ET).isoformat()
+    for plan in plans:
+        status = by_symbol_status.get(plan.ticker)
+        if status is None or status >= 300:
+            logger.error("Bulk close did not flatten %s (status=%s)", plan.ticker, status)
+            failures += 1
+            continue
+        if plan.db_position_id is not None:
+            try:
+                conn.execute(
+                    "UPDATE positions SET status = 'CLOSED', updated_at = ? "
+                    "WHERE id = ? AND status NOT IN ('CLOSED', 'ENTRY_FAILED')",
+                    (now_str, plan.db_position_id),
+                )
+                conn.commit()
+                logger.info("Updated DB positions.id=%d -> CLOSED", plan.db_position_id)
+            except Exception:
+                logger.exception(
+                    "Order accepted but DB update failed for positions.id=%d. "
+                    "Reconcile after the fill.", plan.db_position_id,
+                )
+                failures += 1
+    return failures
 
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:

--- a/trading_bot/tests/test_flatten_orphans.py
+++ b/trading_bot/tests/test_flatten_orphans.py
@@ -13,9 +13,14 @@ from dataclasses import dataclass
 
 import pytest
 
+from datetime import datetime
+from unittest.mock import MagicMock
+
 from trading_bot.self_improve.flatten_orphans import (
+    OrphanPlan,
     _build_plan,
     _choose_tif,
+    _execute_bulk,
     _find_db_position,
 )
 
@@ -167,8 +172,95 @@ def test_choose_tif_market_open_returns_day():
 
 @pytest.mark.unit
 def test_choose_tif_market_closed_returns_opg():
-    """OPG queues for the opening auction and bypasses the held_for_orders
-    check that would block a DAY order while stop-cancellations are stuck
-    in PENDING_CANCEL pre-market."""
+    """OPG queues for the opening auction. Note: in practice OPG also
+    fails the held_for_orders check pre-market, so the script prefers
+    close_all_positions(cancel_orders=True) when planned == live; this
+    helper is the per-ticker fallback path."""
     from alpaca.trading.enums import TimeInForce
     assert _choose_tif(is_market_open=False) == TimeInForce.OPG
+
+
+# ---------------------------------------------------------------------------
+# _execute_bulk — broker-atomic close_all_positions path
+# ---------------------------------------------------------------------------
+
+
+def _plan(ticker: str, db_id: int | None = None) -> OrphanPlan:
+    return OrphanPlan(
+        ticker=ticker,
+        alpaca_qty=1.0,
+        flatten_side="SELL",
+        flatten_qty=1.0,
+        db_position_id=db_id,
+        child_order_ids_to_cancel=[],
+    )
+
+
+def _bulk_response(symbol: str, status: int, order_id: str = "ord-1"):
+    body = MagicMock()
+    body.id = order_id
+    resp = MagicMock()
+    resp.symbol = symbol
+    resp.status = status
+    resp.body = body
+    return resp
+
+
+@pytest.mark.unit
+def test_execute_bulk_marks_db_closed_on_accepted_response(tmp_db):
+    tmp_db.execute(
+        """INSERT INTO positions
+           (id, ticker, exchange, currency, quantity, entry_price, entry_time,
+            status, hold_type, phase, strategy_id)
+           VALUES (5, 'SPY', 'NYSE', 'USD', 1, 700.0,
+                   '2026-04-27T15:40:00-04:00', 'POSITION_OPEN', 'swing', 1, 'breakout')"""
+    )
+    tmp_db.commit()
+
+    client = MagicMock()
+    client.close_all_positions.return_value = [_bulk_response("SPY", 200)]
+
+    failures = _execute_bulk([_plan("SPY", db_id=5)], client, tmp_db)
+    assert failures == 0
+    client.close_all_positions.assert_called_once_with(cancel_orders=True)
+    row = tmp_db.execute("SELECT status FROM positions WHERE id = 5").fetchone()
+    assert row[0] == "CLOSED"
+
+
+@pytest.mark.unit
+def test_execute_bulk_counts_failure_on_non_2xx(tmp_db):
+    client = MagicMock()
+    # Bulk endpoint returned 422 for SPY — broker rejected it.
+    client.close_all_positions.return_value = [_bulk_response("SPY", 422)]
+
+    failures = _execute_bulk([_plan("SPY")], client, tmp_db)
+    assert failures == 1
+
+
+@pytest.mark.unit
+def test_execute_bulk_counts_failure_when_ticker_missing_from_response(tmp_db):
+    client = MagicMock()
+    client.close_all_positions.return_value = [_bulk_response("XLRE", 200)]
+
+    failures = _execute_bulk([_plan("SPY"), _plan("XLRE")], client, tmp_db)
+    assert failures == 1  # SPY missing from response
+
+
+@pytest.mark.unit
+def test_execute_bulk_handles_endpoint_exception(tmp_db):
+    client = MagicMock()
+    client.close_all_positions.side_effect = RuntimeError("network down")
+
+    failures = _execute_bulk([_plan("SPY"), _plan("QQQ")], client, tmp_db)
+    assert failures == 2  # all plans failed
+
+
+@pytest.mark.unit
+def test_execute_bulk_skips_db_update_when_no_db_id(tmp_db):
+    """A planned orphan with db_id=None still counts as success when
+    Alpaca accepts the close — there's just no local row to mark."""
+    client = MagicMock()
+    client.close_all_positions.return_value = [_bulk_response("SPY", 200)]
+
+    failures = _execute_bulk([_plan("SPY", db_id=None)], client, tmp_db)
+    assert failures == 0


### PR DESCRIPTION
## Summary

Follow-up to PR #18 (the OPG fix). Real test against the paper account at 08:25 ET showed OPG also gets rejected with \`insufficient qty available for order\` when stop-cancellations are stuck in PENDING_CANCEL pre-market — Alpaca's qty validation runs at submission time regardless of TIF, not auction-deferred.

## Fix

When the planned orphans exactly match the set of live Alpaca positions, use \`client.close_all_positions(cancel_orders=True)\`. This is Alpaca's broker-atomic flatten endpoint that cancels every open order AND closes every position in one server-side operation. Works pre-market because the broker handles the sequencing.

When the sets don't match (e.g. a real strategy trade is also open), fall back to per-ticker \`_execute_one\` with a clear warning that pre-market may still fail. The OPG path stays as the per-ticker fallback.

## Tests

5 new tests for \`_execute_bulk\` covering: accepted response marks DB closed, non-2xx counts as failure, missing ticker counts as failure, endpoint exception fails every plan, db_id=None still succeeds when ticker is accepted. Existing 10 tests still pass — total 15/15.

## Test plan

- [ ] \`python3 -m pytest trading_bot/tests/test_flatten_orphans.py -q\` → 15 passed
- [ ] \`python3 -m trading_bot.self_improve.flatten_orphans --execute\` (pre-market) succeeds — log should show \`Planned orphans (...) == live Alpaca positions; using close_all_positions(cancel_orders=True)\`
- [ ] After the open, \`client.get_all_positions()\` returns empty