### PR TITLE
fix(strategy_manager): drain_disabled_sleeves verifies Alpaca position before SELL

### DIFF
--- a/docs/self_improve_followups.md
+++ b/docs/self_improve_followups.md
@@ -208,6 +208,63 @@ miniature.
 - An orphan-handling code path exists for the case where a strategy
   goes missing from `STRATEGY_REGISTRY` (config rename, code deletion).
 
+## Bug B6 — drain_disabled_sleeves submitted blind SELLs (2026-04-30)
+
+### Symptom
+
+Each `bot.yml` tick re-shorted the orphan positions on Alpaca. After we
+flattened SPY/XLRE manually via `flatten_orphans --execute`, the next
+bot run submitted SELLs against an already-flat sleeve, building a new
+short. Repeated triggers compounded the short — unbounded short exposure
+on a long-only paper account.
+
+### Evidence (run 25182271744)
+
+```
+18:25:36 [recovery]        DB has position SPY not in Alpaca - marking CLOSED
+18:25:36 [recovery]        DB has position XLRE not in Alpaca - marking CLOSED
+18:25:41 [main]            State recovery: Alpaca positions: 0, DB open positions: 6
+18:26:04 [strategy_manager] Draining orphan position: ticker=SPY  strategy=breakout         qty=1.0000
+18:26:04 [order_manager]    Strategy exit submitted: SELL 1.0  SPY  @ MARKET (reason=orphan_sleeve_drain:breakout)
+18:26:04 [strategy_manager] Draining orphan position: ticker=XLRE strategy=trend_following  qty=20.0000
+18:26:04 [order_manager]    Strategy exit submitted: SELL 20.0 XLRE @ MARKET (reason=orphan_sleeve_drain:trend_following)
+```
+
+The DB's `quantity` column for these rows still held the original LONG
+qty (+1, +20) from the 04-27/04-28 entries — never updated when those
+positions were reduced or flattened by other paths. The drain read the
+DB qty and submitted a SELL "to close the long", but Alpaca had 0
+shares, so the SELL OPENED a new SHORT.
+
+### Fix
+
+Resolved on branch `claude/fix-drain-checks-alpaca`. `drain_disabled_sleeves`
+now calls `_check_alpaca_position(ticker, db_qty)` before submitting any
+exit. Three outcomes:
+
+- **NOT_HELD** — Alpaca holds 0. Skip the order, mark the DB row CLOSED
+  (so subsequent ticks don't keep retrying).
+- **OPPOSITE_SIDE** — DB qty has the opposite sign of Alpaca. Refuse
+  the order with a CRITICAL log and leave the DB row alone for human
+  investigation. Submitting a SELL here would deepen the short.
+- **OK** — Alpaca confirms a same-sign position. Drain proceeds.
+
+Three regression tests pin each branch.
+
+### Lesson for future drain-style code paths
+
+The DB and Alpaca can drift for many reasons:
+
+- Manual flatten (this incident)
+- Broker-side stop fill not yet recorded by the bot
+- State-recovery race (recovery marks DB CLOSED in one transaction;
+  drain reads pre-recovery snapshot in another)
+- Reconcile cycles between bot ticks
+
+Any code path that submits orders based on DB position state MUST
+verify the broker side first. The DB is the bot's intent, not the
+broker's truth.
+
 ## Files referenced
 
 - [trading_bot/execution/order_manager.py](../trading_bot/execution/order_manager.py)

--- a/trading_bot/strategy/strategy_manager.py
+++ b/trading_bot/strategy/strategy_manager.py
@@ -396,6 +396,35 @@ class StrategyManager:
             if qty <= 0:
                 continue
 
+            # Verify the position is actually held on Alpaca before
+            # submitting a SELL. The DB qty can drift from broker truth
+            # (manual flatten, broker-side stop fill not yet recorded,
+            # state-recovery race). Submitting blind opens a NEW position
+            # in the OPPOSITE direction — exactly the
+            # 2026-04-30 incident where a SELL drained against an
+            # already-flat sleeve and built an unbounded short.
+            position_id: int | None = pos.get("id")
+            check = self._check_alpaca_position(ticker, db_qty=qty)
+            if check == "NOT_HELD":
+                logger.warning(
+                    "Drain skip: %s strategy=%s DB qty=%+.4f but Alpaca "
+                    "holds 0 — DB drift; marking position CLOSED instead "
+                    "of submitting drain order",
+                    ticker, sid or "<none>", qty,
+                )
+                if position_id is not None:
+                    self._mark_position_closed(position_id)
+                continue
+            if check == "OPPOSITE_SIDE":
+                logger.critical(
+                    "Drain REFUSING %s strategy=%s: DB qty=%+.4f but Alpaca "
+                    "holds the opposite side. Will not submit a drain order "
+                    "that would deepen the position. Manual reconcile needed.",
+                    ticker, sid or "<none>", qty,
+                )
+                continue
+            # check == "OK" — Alpaca confirms a same-side position.
+
             logger.warning(
                 "Draining orphan position: ticker=%s strategy=%s qty=%.4f",
                 ticker, sid or "<none>", qty,
@@ -423,6 +452,53 @@ class StrategyManager:
             closed += 1
 
         return closed
+
+    def _check_alpaca_position(self, ticker: str, *, db_qty: float) -> str:
+        """Probe Alpaca for the current position on ``ticker``.
+
+        Returns one of:
+          - ``"NOT_HELD"`` — Alpaca holds 0 (or query failed in a way that
+            looks like "no position"). Caller should NOT submit a drain
+            order; should mark DB CLOSED.
+          - ``"OPPOSITE_SIDE"`` — Alpaca holds a position on the opposite
+            sign of ``db_qty``. A drain SELL on an already-short position
+            would deepen the short. Caller should REFUSE.
+          - ``"OK"`` — Alpaca holds a same-sign position. Drain may proceed.
+        """
+        try:
+            client = self._order_manager._gw.client
+            alpaca_pos = client.get_open_position(ticker)
+            alpaca_qty = float(getattr(alpaca_pos, "qty", 0) or 0)
+        except Exception:
+            # alpaca-py raises APIError on "position does not exist".
+            # Treat any lookup failure as not-held; the caller will mark
+            # the DB row CLOSED so we don't retry on every tick.
+            return "NOT_HELD"
+
+        if alpaca_qty == 0:
+            return "NOT_HELD"
+        if (db_qty > 0) != (alpaca_qty > 0):
+            return "OPPOSITE_SIDE"
+        return "OK"
+
+    def _mark_position_closed(self, position_id: int) -> None:
+        """Update positions.status = 'CLOSED' for a single row."""
+        now_str: str = datetime.now(tz=ET).isoformat()
+        try:
+            conn: sqlite3.Connection = sqlite3.connect(self._db_path)
+            try:
+                conn.execute(
+                    "UPDATE positions SET status = 'CLOSED', updated_at = ? "
+                    "WHERE id = ? AND status NOT IN ('CLOSED', 'ENTRY_FAILED')",
+                    (now_str, position_id),
+                )
+                conn.commit()
+            finally:
+                conn.close()
+        except Exception:
+            logger.exception(
+                "Drain: failed to mark positions.id=%d as CLOSED", position_id,
+            )
 
     def _build_om_decision(self, decision: StrategyDecision) -> OMEntryDecision:
         sector: str = GICS_SECTOR.get(decision.ticker, "Unknown")

--- a/trading_bot/tests/test_strategy_manager.py
+++ b/trading_bot/tests/test_strategy_manager.py
@@ -140,6 +140,13 @@ def base_order_manager():
     om = MagicMock()
     om.place_entry = AsyncMock(return_value=42)
     om.place_exit = AsyncMock(return_value="alpaca-exit-1")
+    # Default Alpaca state for drain checks: position IS held same-side as
+    # whatever the test seeds. Tests that want NOT_HELD or OPPOSITE_SIDE
+    # override this attribute.
+    om._gw = MagicMock()
+    pos = MagicMock()
+    pos.qty = "1.0"
+    om._gw.client.get_open_position = MagicMock(return_value=pos)
     return om
 
 
@@ -861,6 +868,189 @@ class TestDrainDisabledSleeves:
         n = await sm.drain_disabled_sleeves()
         assert n == 0
         base_order_manager.place_exit.assert_not_awaited()
+
+    # -----------------------------------------------------------------
+    # Alpaca-side checks (2026-04-30 incident — drain submitted SELLs
+    # against an already-flat sleeve and built an unbounded short on
+    # the paper account every time the bot ticked).
+    # -----------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_drain_skips_when_alpaca_holds_zero(
+        self,
+        base_market_data,
+        base_risk_manager,
+        base_earnings,
+        base_sentiment,
+        base_order_manager,
+        base_portfolio_manager,
+        base_config,
+        tmp_db_path,
+    ):
+        """DB says +1 SPY but Alpaca already holds 0 → don't submit a
+        drain SELL (it would open a new short). Mark DB CLOSED instead."""
+        import sqlite3
+        from alpaca.common.exceptions import APIError
+
+        conn = sqlite3.connect(tmp_db_path)
+        conn.execute(
+            """
+            INSERT INTO positions (
+                id, ticker, exchange, currency, quantity, entry_price,
+                entry_time, status, hold_type, phase, strategy_id
+            ) VALUES (99, 'SPY', 'US', 'USD', 1.0, 100.0,
+                      '2026-04-27T15:40:00-04:00',
+                      'STOP_AND_TARGET_ACTIVE', 'swing', 1, 'breakout')
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        # Alpaca says "no position". alpaca-py raises APIError; our
+        # broad except in _check_alpaca_position catches it.
+        base_order_manager._gw.client.get_open_position.side_effect = (
+            APIError({"code": 40410000, "message": "position does not exist"})
+        )
+
+        sm = StrategyManager(
+            strategies=[_StubStrategy(decision=_make_decision())],
+            portfolio_manager=base_portfolio_manager,
+            market_data=base_market_data,
+            order_manager=base_order_manager,
+            risk_manager=base_risk_manager,
+            sentiment=base_sentiment,
+            earnings=base_earnings,
+            config=base_config,
+            db_path=tmp_db_path,
+        )
+
+        n = await sm.drain_disabled_sleeves()
+        assert n == 0, "should not count a skipped drain as drained"
+        base_order_manager.place_exit.assert_not_awaited()
+
+        # DB row is now CLOSED so we don't retry on every subsequent tick.
+        conn = sqlite3.connect(tmp_db_path)
+        try:
+            row = conn.execute(
+                "SELECT status FROM positions WHERE id = 99"
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row is not None
+        assert row[0] == "CLOSED"
+
+    @pytest.mark.asyncio
+    async def test_drain_refuses_when_alpaca_holds_opposite_side(
+        self,
+        base_market_data,
+        base_risk_manager,
+        base_earnings,
+        base_sentiment,
+        base_order_manager,
+        base_portfolio_manager,
+        base_config,
+        tmp_db_path,
+    ):
+        """DB says +1 SPY, Alpaca says -1 SPY → REFUSE. Submitting a drain
+        SELL here would deepen the short to -2. Position stays in DB so
+        the operator can investigate (no auto-CLOSE)."""
+        import sqlite3
+
+        conn = sqlite3.connect(tmp_db_path)
+        conn.execute(
+            """
+            INSERT INTO positions (
+                id, ticker, exchange, currency, quantity, entry_price,
+                entry_time, status, hold_type, phase, strategy_id
+            ) VALUES (77, 'SPY', 'US', 'USD', 1.0, 100.0,
+                      '2026-04-27T15:40:00-04:00',
+                      'STOP_AND_TARGET_ACTIVE', 'swing', 1, 'breakout')
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        # Alpaca holds OPPOSITE side: -1
+        opposite_pos = MagicMock()
+        opposite_pos.qty = "-1.0"
+        base_order_manager._gw.client.get_open_position.return_value = opposite_pos
+
+        sm = StrategyManager(
+            strategies=[_StubStrategy(decision=_make_decision())],
+            portfolio_manager=base_portfolio_manager,
+            market_data=base_market_data,
+            order_manager=base_order_manager,
+            risk_manager=base_risk_manager,
+            sentiment=base_sentiment,
+            earnings=base_earnings,
+            config=base_config,
+            db_path=tmp_db_path,
+        )
+
+        n = await sm.drain_disabled_sleeves()
+        assert n == 0
+        base_order_manager.place_exit.assert_not_awaited()
+
+        # Position NOT marked CLOSED — opposite-side drift needs human eyes.
+        conn = sqlite3.connect(tmp_db_path)
+        try:
+            row = conn.execute(
+                "SELECT status FROM positions WHERE id = 77"
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row[0] == "STOP_AND_TARGET_ACTIVE"
+
+    @pytest.mark.asyncio
+    async def test_drain_proceeds_when_alpaca_confirms_same_side(
+        self,
+        base_market_data,
+        base_risk_manager,
+        base_earnings,
+        base_sentiment,
+        base_order_manager,
+        base_portfolio_manager,
+        base_config,
+        tmp_db_path,
+    ):
+        """DB says +5 SPY, Alpaca confirms +5 → drain SELL proceeds.
+        Same as the original drain test but with the Alpaca check now
+        explicitly verified."""
+        import sqlite3
+
+        conn = sqlite3.connect(tmp_db_path)
+        conn.execute(
+            """
+            INSERT INTO positions (
+                ticker, exchange, currency, quantity, entry_price,
+                entry_time, status, hold_type, phase, strategy_id
+            ) VALUES ('SPY', 'US', 'USD', 5.0, 100.0,
+                      '2026-04-27T15:40:00-04:00',
+                      'STOP_AND_TARGET_ACTIVE', 'swing', 1, 'breakout')
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        same_side = MagicMock()
+        same_side.qty = "5.0"
+        base_order_manager._gw.client.get_open_position.return_value = same_side
+
+        sm = StrategyManager(
+            strategies=[_StubStrategy(decision=_make_decision())],
+            portfolio_manager=base_portfolio_manager,
+            market_data=base_market_data,
+            order_manager=base_order_manager,
+            risk_manager=base_risk_manager,
+            sentiment=base_sentiment,
+            earnings=base_earnings,
+            config=base_config,
+            db_path=tmp_db_path,
+        )
+
+        n = await sm.drain_disabled_sleeves()
+        assert n == 1
+        base_order_manager.place_exit.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes the bug discovered during today's data-layer validation gate: \`drain_disabled_sleeves\` was reading the DB \`quantity\` column and submitting a SELL to "close the long" without verifying Alpaca actually held the position. When DB and Alpaca had drifted, the SELL opened a NEW short instead of closing anything. Each \`bot.yml\` trigger compounded the short — **unbounded short exposure on a long-only paper account.**

## Real evidence

Run 25182271744 today at 18:25 UTC = 21:25 Riyadh = 14:25 ET (during RTH):

\`\`\`
18:25:36 [recovery]        DB has position SPY  not in Alpaca - marking CLOSED
18:25:36 [recovery]        DB has position XLRE not in Alpaca - marking CLOSED
18:26:04 [strategy_manager] Draining orphan position: ticker=SPY  qty=1.0000
18:26:04 [order_manager]    Strategy exit submitted: SELL 1.0  SPY  @ MARKET
18:26:04 [strategy_manager] Draining orphan position: ticker=XLRE qty=20.0000
18:26:04 [order_manager]    Strategy exit submitted: SELL 20.0 XLRE @ MARKET
\`\`\`

DB qty was \`+1\` SPY / \`+20\` XLRE (stale from 04-27/04-28 entries that were never updated when the positions were flattened). Alpaca held 0 of both. The drain SELL opened a new \`-1\` SPY / \`-20\` XLRE short.

## Fix

\`drain_disabled_sleeves\` now calls \`_check_alpaca_position(ticker, db_qty)\` and branches:

- **NOT_HELD** — Alpaca holds 0 → skip the order AND mark the DB row \`CLOSED\` so subsequent ticks don't keep retrying.
- **OPPOSITE_SIDE** — DB qty has the opposite sign of Alpaca → refuse the order with a CRITICAL log; leave the DB row alone for human investigation.
- **OK** — Alpaca confirms a same-sign position → drain proceeds (existing path).

Three new regression tests pin each branch. Existing drain tests updated to mock \`_gw.client.get_open_position\` so they hit the OK branch (and stay green).

## Tests

\`699 pass / 0 fail\` (down from yesterday's 632 — extra test growth from V8 + Phase 3 work). Drain test class now has 6 tests covering all branches.

## Followups doc

\`docs/self_improve_followups.md\` gets a new \`Bug B6\` section with the full incident chronology, fix description, and a general lesson — **any code path that submits orders based on DB position state MUST verify the broker side first.**

## Test plan

- [ ] \`python3 -m pytest trading_bot/tests/test_strategy_manager.py -k drain -q\` → 6 passed
- [ ] After merge, run \`python3 -m trading_bot.self_improve.flatten_orphans --execute\` → flattens SPY/XLRE shorts
- [ ] Trigger \`gh workflow run bot.yml\` → next run logs \`Drain skip: SPY ... DB drift; marking position CLOSED\` (no SELL submitted)
- [ ] Re-check Alpaca → 0 positions, no rebuild

## Status of related work

- PR #15 / #16 / #18 / #19 → all merged
- This PR closes the orphan-rebuild loop discovered during validation
- After merge + a clean validation run, the daily-review cron in \`.github/workflows/daily-review.yml\` can be re-enabled (separate small PR, uncomment the \`schedule:\` block)