### PR TITLE
ops: re-enable daily-review cron — data layer is fixed

### DIFF
--- a/.github/workflows/daily-review.yml
+++ b/.github/workflows/daily-review.yml
@@ -9,15 +9,16 @@ name: daily-review
 # self_improve_reports/. Humans review and apply patches by hand.
 
 on:
-  # NOTE: scheduled cron deliberately disabled until the data layer is
-  # fixed. The agent's postmortem reads from the `trades` table, but the
-  # live bot is not currently persisting closed trades correctly (see
-  # docs/self_improve_followups.md tasks #2 and #3). Running on cron
-  # would just open empty draft PRs every weekday. Re-enable the schedule
-  # below once those tasks are resolved and a real trade history exists.
   workflow_dispatch: {}
-  # schedule:
-  #   - cron: "30 21 * * 1-5"
+  schedule:
+    # 21:30 UTC = 17:30 ET (standard) / 16:30 ET (DST). Either way, after
+    # the 16:00 close. Weekdays only.
+    #
+    # Originally deferred until the data-layer bugs (followups doc tasks
+    # #2/#3 + bug B6) were fixed — those landed in PRs #16 / #19 / #20.
+    # Re-enabled 2026-04-30 once the live bot was confirmed writing
+    # complete trade rows and the drain path was verified safe.
+    - cron: "30 21 * * 1-5"
 
 concurrency:
   group: daily-review


### PR DESCRIPTION
## Summary

Closes the original PR #15 deferral. Re-enables the \`schedule:\` block in \`.github/workflows/daily-review.yml\` (was commented out with a note pointing to followups doc tasks #2/#3).

All blocking work shipped:
- PR #16 — data-layer Phase 1+2+3 (trades persistence, schema migration)
- PR #19 — broker-atomic flatten via close_all_positions
- PR #20 — drain checks Alpaca position before submitting SELL
- Live verification today: drain correctly skips with NOT_HELD instead of submitting a SELL on an already-flat sleeve

## Behavior after merge

- Cron fires 21:30 UTC weekdays (= ~17:30 Riyadh, after the 16:00 ET close)
- workflow_dispatch retained so manual runs still work
- Agent opens a draft PR nightly with the postmortem report
- Hypothesis rules require >= 20 closed trades in the rolling window before any proposal fires — first few weeks may be empty as trade history accumulates

## Test plan

- [ ] Workflow YAML is valid (\`actionlint\` or just \`gh workflow view daily-review.yml\` after merge)
- [ ] Tomorrow at 21:30 UTC, the scheduled run fires
- [ ] First scheduled run produces a report file (even if empty proposals) and opens a draft PR