### PR TITLE
feat(config): surface open positions on disabled strategies at startup

### DIFF
--- a/trading_bot/config.py
+++ b/trading_bot/config.py
@@ -538,6 +538,66 @@ class Config:
         strategies: dict[str, Any] = self.get_strategy_configs()
         return dict(strategies.get(strategy_id, {}))
 
+    def detect_disabled_strategy_orphans(self, db_path: str) -> list[str]:
+        """Find open positions tagged with a strategy that's now disabled.
+
+        This is the failure pattern from the 2026-04-28 regime rebalance:
+        the operator flips a sleeve to ``enabled: false`` while it still
+        has live positions, leaving them outside the bot's per-tick
+        management loop. Drain (``StrategyManager.drain_disabled_sleeves``,
+        with the B6 Alpaca-position guard from PR #20) handles this
+        safely going forward, but we still want to surface the mismatch
+        loudly so the operator knows their config edit produced
+        unmanaged exposure.
+
+        Returns one human-readable warning string per disabled-strategy /
+        ticker / qty mismatch. Empty list = no inconsistency. Caller
+        should log each warning at CRITICAL and (if wired) fire an
+        ntfy alert.
+
+        Read-only — never mutates the DB. Safe to call any time after
+        ``Config.load()``. Returns empty list (with a warning log) if
+        the DB is unavailable; this routine should never crash the bot.
+        """
+        import sqlite3
+
+        enabled_ids: set[str] = {
+            sid for sid, cfg in self.get_strategy_configs().items()
+            if cfg.get("enabled", True)
+        }
+
+        try:
+            conn = sqlite3.connect(db_path)
+            try:
+                rows = conn.execute(
+                    "SELECT strategy_id, ticker, quantity, status FROM positions "
+                    "WHERE status NOT IN ('CLOSED', 'ENTRY_FAILED') "
+                    "  AND strategy_id IS NOT NULL "
+                    "  AND strategy_id != 'unknown' "
+                    "ORDER BY strategy_id, ticker"
+                ).fetchall()
+            finally:
+                conn.close()
+        except Exception:
+            logger.warning(
+                "detect_disabled_strategy_orphans: DB read failed "
+                "(db_path=%s); skipping check", db_path,
+                exc_info=True,
+            )
+            return []
+
+        warnings: list[str] = []
+        for sid, ticker, qty, status in rows:
+            if sid in enabled_ids:
+                continue
+            warnings.append(
+                f"Strategy '{sid}' is disabled in config but holds an open "
+                f"position: ticker={ticker} qty={qty} status={status}. "
+                f"Drain will attempt to flatten on the next tick — verify "
+                f"Alpaca state matches expectations."
+            )
+        return warnings
+
     # Repr
     # -----------------------------------------------------------------------
 

--- a/trading_bot/main.py
+++ b/trading_bot/main.py
@@ -288,6 +288,24 @@ class TradingBot:
             except Exception:
                 logger.exception("State recovery failed (non-fatal)")
 
+            # --- 5a. Disabled-strategy consistency check ---
+            # Surface the case where config sets enabled=false on a
+            # sleeve that still has live positions. Drain will safely
+            # flatten on the next tick (guarded by PR #20's Alpaca
+            # check), but the operator should know their config edit
+            # produced unmanaged exposure.
+            try:
+                inconsistencies = self._config.detect_disabled_strategy_orphans(
+                    self._db_path,
+                )
+                for warning in inconsistencies:
+                    logger.critical("Disabled-strategy orphan: %s", warning)
+            except Exception:
+                logger.warning(
+                    "Disabled-strategy consistency check failed (non-fatal)",
+                    exc_info=True,
+                )
+
             # --- 5b. Anchor phase to live equity ---
             # ``__init__`` logs the cached default phase (MICRO) because
             # equity isn't known yet at construction time. After Alpaca

--- a/trading_bot/tests/test_config_disabled_strategy_guard.py
+++ b/trading_bot/tests/test_config_disabled_strategy_guard.py
@@ -1,0 +1,189 @@
+"""Tests for Config.detect_disabled_strategy_orphans.
+
+Surfaces the failure mode that produced the 2026-04-28 orphan incident:
+operator flips a sleeve to enabled=false in config.yaml while it still
+has live positions, leaving them outside the per-tick management loop
+until the drain path catches up.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from trading_bot.config import Config
+
+
+def _build_config(strategies: dict[str, dict]) -> Config:
+    """Construct a Config directly from a raw dict (skips file IO)."""
+    raw = {
+        "multi_strategy": {
+            "enabled": True,
+            "strategies": strategies,
+        }
+    }
+    return Config(raw)
+
+
+def _insert_position(
+    conn,
+    *,
+    ticker: str,
+    strategy_id: str,
+    status: str = "POSITION_OPEN",
+    quantity: float = 1.0,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO positions (
+            ticker, exchange, currency, quantity, entry_price,
+            entry_time, status, hold_type, phase, strategy_id
+        ) VALUES (?, 'NYSE', 'USD', ?, 100.0,
+                  '2026-04-27T15:40:00-04:00', ?, 'swing', 1, ?)
+        """,
+        (ticker, quantity, status, strategy_id),
+    )
+
+
+@pytest.mark.unit
+def test_returns_empty_when_all_positions_on_enabled_strategies(tmp_db_path):
+    import sqlite3
+
+    cfg = _build_config({
+        "mean_reversion": {"enabled": True},
+        "breakout": {"enabled": False},
+    })
+    conn = sqlite3.connect(tmp_db_path)
+    _insert_position(conn, ticker="SPY", strategy_id="mean_reversion")
+    conn.commit()
+    conn.close()
+
+    assert cfg.detect_disabled_strategy_orphans(tmp_db_path) == []
+
+
+@pytest.mark.unit
+def test_warns_for_open_position_on_disabled_strategy(tmp_db_path):
+    import sqlite3
+
+    cfg = _build_config({
+        "mean_reversion": {"enabled": True},
+        "breakout": {"enabled": False},
+    })
+    conn = sqlite3.connect(tmp_db_path)
+    _insert_position(conn, ticker="SPY", strategy_id="breakout",
+                     status="STOP_AND_TARGET_ACTIVE", quantity=1.0)
+    conn.commit()
+    conn.close()
+
+    out = cfg.detect_disabled_strategy_orphans(tmp_db_path)
+    assert len(out) == 1
+    assert "breakout" in out[0]
+    assert "SPY" in out[0]
+
+
+@pytest.mark.unit
+def test_skips_closed_and_entry_failed_positions(tmp_db_path):
+    """Terminal-state rows aren't live exposure — drain doesn't touch
+    them, neither should this guard."""
+    import sqlite3
+
+    cfg = _build_config({
+        "mean_reversion": {"enabled": True},
+        "breakout": {"enabled": False},
+    })
+    conn = sqlite3.connect(tmp_db_path)
+    _insert_position(conn, ticker="SPY", strategy_id="breakout", status="CLOSED")
+    _insert_position(conn, ticker="QQQ", strategy_id="breakout", status="ENTRY_FAILED")
+    conn.commit()
+    conn.close()
+
+    assert cfg.detect_disabled_strategy_orphans(tmp_db_path) == []
+
+
+@pytest.mark.unit
+def test_skips_unknown_strategy_id(tmp_db_path):
+    """'unknown' is the sentinel for unattributed positions (e.g. those
+    discovered on Alpaca but never entered by the bot). It's not a
+    'disabled strategy' — recovery / drain handle it via different
+    paths."""
+    import sqlite3
+
+    cfg = _build_config({
+        "mean_reversion": {"enabled": True},
+    })
+    conn = sqlite3.connect(tmp_db_path)
+    _insert_position(conn, ticker="QQQ", strategy_id="unknown")
+    conn.commit()
+    conn.close()
+
+    assert cfg.detect_disabled_strategy_orphans(tmp_db_path) == []
+
+
+@pytest.mark.unit
+def test_returns_one_warning_per_position(tmp_db_path):
+    """Multiple disabled-strategy positions → multiple warnings, one
+    per row, so the operator can act on each individually."""
+    import sqlite3
+
+    cfg = _build_config({
+        "mean_reversion": {"enabled": True},
+        "breakout": {"enabled": False},
+        "trend_following": {"enabled": False},
+    })
+    conn = sqlite3.connect(tmp_db_path)
+    _insert_position(conn, ticker="SPY", strategy_id="breakout", quantity=1.0)
+    _insert_position(conn, ticker="XLRE", strategy_id="trend_following", quantity=20.0)
+    conn.commit()
+    conn.close()
+
+    out = cfg.detect_disabled_strategy_orphans(tmp_db_path)
+    assert len(out) == 2
+    assert any("breakout" in w and "SPY" in w for w in out)
+    assert any("trend_following" in w and "XLRE" in w for w in out)
+
+
+@pytest.mark.unit
+def test_treats_missing_enabled_flag_as_enabled(tmp_db_path):
+    """A strategy entry with no 'enabled' key is treated as enabled
+    (matches create_strategies() default)."""
+    import sqlite3
+
+    cfg = _build_config({
+        "mean_reversion": {},  # no 'enabled' key — defaults to True
+    })
+    conn = sqlite3.connect(tmp_db_path)
+    _insert_position(conn, ticker="SPY", strategy_id="mean_reversion")
+    conn.commit()
+    conn.close()
+
+    assert cfg.detect_disabled_strategy_orphans(tmp_db_path) == []
+
+
+@pytest.mark.unit
+def test_returns_empty_on_db_failure(tmp_path):
+    """If the DB doesn't exist, return empty rather than crashing the
+    bot's startup. The check is defensive; failure should be silent
+    (with a warning log) rather than fatal."""
+    cfg = _build_config({"mean_reversion": {"enabled": True}})
+    nonexistent = str(tmp_path / "nonexistent.db")
+    # sqlite3.connect creates a file even for a nonexistent path, so
+    # we'd actually succeed. Force a real failure with a directory path.
+    bad_path = str(tmp_path)  # path is a directory → connect succeeds, query fails
+    assert cfg.detect_disabled_strategy_orphans(bad_path) == []
+
+
+@pytest.mark.unit
+def test_warning_message_includes_status_and_qty(tmp_db_path):
+    import sqlite3
+
+    cfg = _build_config({"breakout": {"enabled": False}})
+    conn = sqlite3.connect(tmp_db_path)
+    _insert_position(conn, ticker="SPY", strategy_id="breakout",
+                     status="STOP_AND_TARGET_ACTIVE", quantity=1.0)
+    conn.commit()
+    conn.close()
+
+    out = cfg.detect_disabled_strategy_orphans(tmp_db_path)
+    assert len(out) == 1
+    msg = out[0]
+    assert "STOP_AND_TARGET_ACTIVE" in msg
+    assert "1" in msg  # qty


### PR DESCRIPTION
## Summary

Closes acceptance criterion #2 of \`docs/self_improve_followups.md\` task #3 — a guard against the operator flipping a sleeve to \`enabled: false\` in \`config.yaml\` while it still has live positions.

## Why

The 2026-04-28 regime rebalance was the original incident: \`breakout\` and \`trend_following\` were disabled while still holding 2 \`STOP_AND_TARGET\` positions. PR #20's drain-side Alpaca check now ensures those positions flatten safely going forward, but the operator should still know their config edit produced unmanaged exposure.

## What

New \`Config.detect_disabled_strategy_orphans(db_path)\`:
- Read-only DB query for open positions (\`status NOT IN ('CLOSED', 'ENTRY_FAILED')\`) whose \`strategy_id\` is missing from the enabled-strategy set
- Returns one human-readable warning per row
- Skips \`strategy_id='unknown'\` (handled via a different path)
- Treats missing \`enabled\` key as enabled (matches \`create_strategies\` default)
- Returns empty on DB failure with a logged warning — never crashes bot startup

Wired into \`main.py\` tick after state recovery (new step 5a). Each warning logged at CRITICAL.

## Tests

8 new unit tests for the guard: enabled-only baseline, disabled-with-position warning, terminal-state skip, unknown-strategy skip, multiple warnings, missing-flag default, DB-failure resilience, message content. Full suite: **707 pass / 0 fail.**

## Test plan

- [ ] \`python3 -m pytest trading_bot/tests/test_config_disabled_strategy_guard.py -q\` → 8 passed
- [ ] After merge, next bot tick log should show CRITICAL line(s) if any disabled-strategy positions exist (currently 0 — local DB is clean post-PR-#20 verification)
- [ ] Manual: temporarily flip \`mean_reversion.enabled: false\` in config (with positions held), trigger \`gh workflow run bot.yml\`, confirm CRITICAL log appears, then revert

## Status of task #3

This + PR #20 + PR #19 together cover all three acceptance criteria:
- ✅ Live orphans flattened (PR #19 + manual run)
- ✅ Config edit guard (this PR)
- ✅ Drain handles missing-from-registry strategies (PR #20 + existing tests)