### PR TITLE
feat(config): warn on missing daily_summaries rows at startup

### DIFF
--- a/trading_bot/config.py
+++ b/trading_bot/config.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import date, time
+from datetime import date, datetime, time, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -596,6 +596,74 @@ class Config:
                 f"Drain will attempt to flatten on the next tick — verify "
                 f"Alpaca state matches expectations."
             )
+        return warnings
+
+    def detect_missing_daily_summaries(
+        self,
+        db_path: str,
+        *,
+        lookback_days: int = 5,
+        today: date | None = None,
+    ) -> list[str]:
+        """Return warnings for past trading days with no daily_summary row.
+
+        ``_save_daily_summary`` retries on every tick until it succeeds
+        and only sets the persistent flag on success. The remaining
+        failure mode is "no tick happened after wind-down ended" — e.g.
+        a GHA outage, a cancelled cron, or the bot crashing during
+        wind-down. This check catches that pattern by sampling the last
+        ``lookback_days`` calendar days, filtering to trading days, and
+        asserting each has a row.
+
+        ``today`` is excluded — the bot won't have written today's
+        summary until after wind-down + 10 min. Pass an explicit ``today``
+        for tests; defaults to the current ET calendar date.
+
+        Read-only. Returns empty list (with warning log) on DB failure
+        rather than crashing bot startup.
+        """
+        import sqlite3
+        from trading_bot.constants import TZ_EASTERN
+
+        today_d = today or datetime.now(tz=TZ_EASTERN).date()
+        candidates: list[date] = []
+        for offset in range(1, lookback_days + 1):
+            d = today_d - timedelta(days=offset)
+            if self.is_trading_day(d, Market.US):
+                candidates.append(d)
+
+        if not candidates:
+            return []
+
+        date_strs = [d.isoformat() for d in candidates]
+        try:
+            conn = sqlite3.connect(db_path)
+            try:
+                placeholders = ",".join("?" * len(date_strs))
+                rows = conn.execute(
+                    f"SELECT date FROM daily_summaries WHERE date IN ({placeholders})",
+                    date_strs,
+                ).fetchall()
+            finally:
+                conn.close()
+        except Exception:
+            logger.warning(
+                "detect_missing_daily_summaries: DB read failed (db_path=%s); "
+                "skipping check", db_path,
+                exc_info=True,
+            )
+            return []
+
+        present: set[str] = {row[0] for row in rows}
+        warnings: list[str] = []
+        for d_str in date_strs:
+            if d_str not in present:
+                warnings.append(
+                    f"No daily_summaries row for trading day {d_str}. "
+                    f"Bot likely did not tick after wind-down completed "
+                    f"that day, or _save_daily_summary kept failing. "
+                    f"Postmortem reports for that day will be empty."
+                )
         return warnings
 
     # Repr

--- a/trading_bot/main.py
+++ b/trading_bot/main.py
@@ -306,7 +306,24 @@ class TradingBot:
                     exc_info=True,
                 )
 
-            # --- 5b. Anchor phase to live equity ---
+            # --- 5b. Daily-summary backfill check ---
+            # If we missed a daily_summaries write (no tick after the
+            # previous day's wind-down) the postmortem agent will see a
+            # gap. Surface it loudly so the operator can manually
+            # backfill or investigate.
+            try:
+                missing = self._config.detect_missing_daily_summaries(
+                    self._db_path, lookback_days=5,
+                )
+                for warning in missing:
+                    logger.critical("Missing daily_summary: %s", warning)
+            except Exception:
+                logger.warning(
+                    "Daily-summary consistency check failed (non-fatal)",
+                    exc_info=True,
+                )
+
+            # --- 5c. Anchor phase to live equity ---
             # ``__init__`` logs the cached default phase (MICRO) because
             # equity isn't known yet at construction time. After Alpaca
             # connects, refresh from real NetLiquidation so the per-tick

--- a/trading_bot/tests/test_config_missing_daily_summaries.py
+++ b/trading_bot/tests/test_config_missing_daily_summaries.py
@@ -1,0 +1,167 @@
+"""Tests for Config.detect_missing_daily_summaries.
+
+Catches the failure pattern where the bot doesn't tick after wind-down
+ended on a given day — _save_daily_summary needs a tick to fire after
+~16:10 ET to write the row. If the cron skips, GHA is down, or the
+bot crashes during wind-down, the row is missing and postmortem
+reports for that day will be empty.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from trading_bot.config import Config
+
+
+def _build_config() -> Config:
+    """Construct a Config that knows weekends are non-trading days."""
+    raw = {
+        # 2026 holidays — empty for this test (we only need
+        # weekend-detection logic, which is hardcoded)
+        "holidays": {"us_2026": []},
+    }
+    return Config(raw)
+
+
+def _insert_summary(conn, d: str) -> None:
+    conn.execute(
+        "INSERT INTO daily_summaries (date, account_equity_gbp, phase) VALUES (?, 1000, 1)",
+        (d,),
+    )
+
+
+@pytest.mark.unit
+def test_returns_empty_when_all_trading_days_have_rows(tmp_db_path):
+    """5 lookback days, all trading days, all rows present → no warnings."""
+    import sqlite3
+
+    cfg = _build_config()
+    today = date(2026, 4, 30)  # Thursday
+    # Lookback 5 days from 2026-04-30 → 04-29 (Wed), 04-28 (Tue),
+    # 04-27 (Mon), 04-26 (Sun, skip), 04-25 (Sat, skip)
+    # Trading days: 04-27, 04-28, 04-29
+    conn = sqlite3.connect(tmp_db_path)
+    for d_str in ("2026-04-27", "2026-04-28", "2026-04-29"):
+        _insert_summary(conn, d_str)
+    conn.commit()
+    conn.close()
+
+    out = cfg.detect_missing_daily_summaries(
+        tmp_db_path, lookback_days=5, today=today,
+    )
+    assert out == []
+
+
+@pytest.mark.unit
+def test_warns_for_missing_trading_day(tmp_db_path):
+    """One trading day in window has no row → exactly one warning."""
+    import sqlite3
+
+    cfg = _build_config()
+    today = date(2026, 4, 30)
+    conn = sqlite3.connect(tmp_db_path)
+    # Insert 04-27 + 04-29 but skip 04-28
+    for d_str in ("2026-04-27", "2026-04-29"):
+        _insert_summary(conn, d_str)
+    conn.commit()
+    conn.close()
+
+    out = cfg.detect_missing_daily_summaries(
+        tmp_db_path, lookback_days=5, today=today,
+    )
+    assert len(out) == 1
+    assert "2026-04-28" in out[0]
+
+
+@pytest.mark.unit
+def test_does_not_warn_for_today(tmp_db_path):
+    """Today is excluded — bot hasn't written today's summary yet."""
+    cfg = _build_config()
+    today = date(2026, 4, 30)
+    # No summaries inserted at all — but today should not appear
+    out = cfg.detect_missing_daily_summaries(
+        tmp_db_path, lookback_days=5, today=today,
+    )
+    for warning in out:
+        assert today.isoformat() not in warning
+
+
+@pytest.mark.unit
+def test_skips_weekends(tmp_db_path):
+    """Saturday and Sunday are not trading days — never appear in
+    warnings."""
+    cfg = _build_config()
+    today = date(2026, 4, 30)  # Thursday
+    out = cfg.detect_missing_daily_summaries(
+        tmp_db_path, lookback_days=5, today=today,
+    )
+    # Nothing in DB → all 3 trading days in window are missing
+    assert len(out) == 3
+    weekend_dates = {"2026-04-25", "2026-04-26"}
+    for warning in out:
+        for wd in weekend_dates:
+            assert wd not in warning
+
+
+@pytest.mark.unit
+def test_skips_holidays(tmp_path):
+    """Configured US holidays are not trading days."""
+    import sqlite3
+
+    raw = {"holidays": {"us_2026": ["2026-04-29"]}}  # mark Wed as holiday
+    cfg = Config(raw)
+    today = date(2026, 4, 30)
+    db = str(tmp_path / "x.db")
+    # Build empty DB
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "CREATE TABLE daily_summaries (date TEXT PRIMARY KEY, "
+        "account_equity_gbp REAL, phase INTEGER)"
+    )
+    conn.commit()
+    conn.close()
+
+    out = cfg.detect_missing_daily_summaries(db, lookback_days=5, today=today)
+    # Without 04-29 (now a holiday), only 04-27 and 04-28 should warn
+    assert len(out) == 2
+    for warning in out:
+        assert "2026-04-29" not in warning
+
+
+@pytest.mark.unit
+def test_returns_empty_on_db_failure(tmp_path):
+    """DB unreachable → empty list (not crash). Bot startup must
+    survive a corrupt or missing DB file."""
+    cfg = _build_config()
+    bad_path = str(tmp_path)  # directory → connect ok, query fails
+    out = cfg.detect_missing_daily_summaries(
+        bad_path, lookback_days=5, today=date(2026, 4, 30),
+    )
+    assert out == []
+
+
+@pytest.mark.unit
+def test_lookback_days_bounds_the_window(tmp_db_path):
+    """lookback_days=2 from Thursday → only Wed + Tue checked."""
+    import sqlite3
+
+    cfg = _build_config()
+    today = date(2026, 4, 30)  # Thursday
+    conn = sqlite3.connect(tmp_db_path)
+    # Insert nothing
+    conn.commit()
+    conn.close()
+
+    out = cfg.detect_missing_daily_summaries(
+        tmp_db_path, lookback_days=2, today=today,
+    )
+    # 04-29 (Wed) + 04-28 (Tue) → 2 warnings
+    assert len(out) == 2
+    joined = " | ".join(out)
+    assert "2026-04-29" in joined
+    assert "2026-04-28" in joined
+    # 04-27 (Mon, outside window) must NOT appear
+    assert "2026-04-27" not in joined


### PR DESCRIPTION
## Summary

Closes the second part of \`docs/self_improve_followups.md\` task #2 — "daily_summaries gets a row at end of day" verification.

## Why

\`_save_daily_summary\` already retries on every tick until it succeeds and only sets the persistent flag on success (the 2026-04-29 incident fix). The remaining failure mode is **"no tick happened after wind-down ended"** — GHA outage, cancelled cron, bot crash during wind-down. Until now that pattern went undetected: the postmortem agent would silently see a gap in the data.

## What

New \`Config.detect_missing_daily_summaries(db_path, lookback_days=5, today=None)\`:

- Samples the last \`lookback_days\` calendar days
- Filters to trading days (skips weekends + configured holidays)
- Excludes today (bot hasn't written today's row until after wind-down + 10 min)
- Returns one human-readable warning per trading day with no row
- Read-only; returns empty list (with warning log) on DB failure
- \`today\` is injectable for deterministic tests

Wired into \`main.py\` tick after state recovery (new step 5b). Each warning logged at CRITICAL.

## Tests

7 new unit tests: all-rows-present baseline, single-missing warning, today-excluded, weekend-skip, holiday-skip, DB-failure resilience, lookback-window bounds. Full suite: **706 pass / 0 fail.**

## Test plan

- [ ] \`python3 -m pytest trading_bot/tests/test_config_missing_daily_summaries.py -q\` → 7 passed
- [ ] After merge, the next bot tick will log CRITICAL line(s) for any past trading day in the 5-day window without a daily_summaries row (likely ≥1 given recent operational chaos)
- [ ] Operator action on warnings: investigate whether the day genuinely had no activity (then nothing to do) or the bot missed the wind-down (then optional: hand-insert via repo.save_daily_summary, OR accept the gap)

## Status of task #2

This + PR #16 + PR #20 close all three task #2 acceptance criteria:
- ✅ After a position closes, trades has a complete row (PR #16 / Phase 3)
- ✅ daily_summaries gets a row at end of day — write path retries (existing) + missing-row warning (this PR)
- ✅ Regression test for the close path exists (PR #16 / test_phase3_regressions.py)