### PR TITLE
fix(recovery): include ENTRY_FAILED in terminal-status filter

### DIFF
--- a/trading_bot/gateway/recovery.py
+++ b/trading_bot/gateway/recovery.py
@@ -165,7 +165,9 @@ class StateRecovery:
         conn: sqlite3.Connection = sqlite3.connect(self._db_path)
         conn.row_factory = sqlite3.Row
         try:
-            cursor = conn.execute("SELECT * FROM positions WHERE status != 'CLOSED'")
+            cursor = conn.execute(
+                "SELECT * FROM positions WHERE status NOT IN ('CLOSED', 'ENTRY_FAILED')"
+            )
             rows: list[dict[str, Any]] = [dict(row) for row in cursor.fetchall()]
             logger.debug("Loaded %d open positions from DB", len(rows))
             return rows
@@ -404,7 +406,7 @@ class StateRecovery:
         try:
             cursor = conn.execute(
                 "SELECT ticker FROM positions "
-                "WHERE status != 'CLOSED' AND hold_type = 'intraday'"
+                "WHERE status NOT IN ('CLOSED', 'ENTRY_FAILED') AND hold_type = 'intraday'"
             )
             return {row[0] for row in cursor.fetchall()}
         except sqlite3.OperationalError:


### PR DESCRIPTION
## Summary

`gateway/recovery.py` filtered open positions with `status != 'CLOSED'`, missing the `ENTRY_FAILED` terminal status. Two queries affected:

- `_load_db_open_positions` (line 168) — produced spurious "DB has position not in Alpaca" warnings during reconcile.
- `_intraday_tickers_in_db` (line 407) — could fire EOD market orders for tickers that were never actually held.

`main.py` writes `ENTRY_FAILED` at lines 806 and 1010, and every other module already used the correct two-status filter (config.py, daily_report.py, health/server.py, flatten_orphans.py, virtual_portfolio.py). Only recovery.py was missed.

## Test plan
- [x] `pytest trading_bot/tests/` — 712 passed, 2 skipped
- [ ] Verify next reconcile run does not re-flag any historical `ENTRY_FAILED` rows