### PR TITLE
fix(exit): route limit-exits through OrderManager to prevent double-submit

### DIFF
--- a/trading_bot/execution/order_manager.py
+++ b/trading_bot/execution/order_manager.py
@@ -677,6 +677,92 @@ class OrderManager:
                 )
             return None
 
+    async def place_limit_exit(
+        self,
+        ticker: str,
+        qty: float,
+        limit_price: float,
+        reason: str,
+    ) -> str | None:
+        """Submit a strategy-driven limit-sell exit.
+
+        Mirrors :meth:`place_exit` but uses a DAY limit order instead of
+        a market order, and — critically — transitions the matching
+        position to ``CLOSING`` and persists the exit order_id BEFORE
+        returning. This prevents the next stateless tick from
+        re-evaluating the same exit condition and double-submitting.
+
+        Returns the Alpaca order id on submission, or ``None`` on
+        failure. On failure the caller should fall back to
+        :meth:`emergency_flatten`.
+        """
+        if qty <= 0:
+            logger.warning(
+                "place_limit_exit called with non-positive qty for %s: %s",
+                ticker, qty,
+            )
+            return None
+
+        # Find the matching active order so we can cancel bracket legs
+        # and pin the exit order_id back to the trade.
+        matching_trade_id: int | None = None
+        matching_active: _ActiveOrder | None = None
+        for tid, active in self._active_orders.items():
+            if active.ticker == ticker and active.status not in (
+                PositionStatus.CLOSED,
+                PositionStatus.ENTRY_FAILED,
+            ):
+                matching_trade_id = tid
+                matching_active = active
+                break
+
+        if matching_active is not None:
+            for oid in (
+                matching_active.alpaca_stop_order_id,
+                matching_active.alpaca_target_order_id,
+                matching_active.alpaca_trail_order_id,
+            ):
+                if oid is not None:
+                    await self.cancel_order(oid)
+        else:
+            await self.cancel_all_for_ticker(ticker)
+
+        client: TradingClient = self._gw.client
+        try:
+            request = LimitOrderRequest(
+                symbol=ticker,
+                qty=qty,
+                side=OrderSide.SELL,
+                type=OrderType.LIMIT,
+                time_in_force=TimeInForce.DAY,
+                limit_price=round(limit_price, 2),
+            )
+            order: AlpacaOrder = await asyncio.to_thread(
+                client.submit_order, order_data=request,
+            )
+            order_id: str = str(order.id)
+            logger.info(
+                "Limit exit submitted: SELL %s %s @ %.2f (reason=%s, alpaca_id=%s)",
+                qty, ticker, limit_price, reason, order_id,
+            )
+
+            # Pin order_id → trade_id and transition position state so
+            # the next tick doesn't re-fire the same exit. The fill
+            # detection in _check_order_statuses will move CLOSING ->
+            # CLOSED once the fill confirms.
+            if matching_trade_id is not None:
+                self._alpaca_to_trade[order_id] = matching_trade_id
+                self._update_position_status(
+                    matching_trade_id, PositionStatus.CLOSING,
+                )
+            return order_id
+        except Exception:
+            logger.exception(
+                "Failed to place limit exit for %s (qty=%s, reason=%s)",
+                ticker, qty, reason,
+            )
+            return None
+
     async def flatten_all(self) -> None:
         """Flatten all positions with market orders (kill switch)."""
         try:

--- a/trading_bot/main.py
+++ b/trading_bot/main.py
@@ -868,7 +868,12 @@ class TradingBot:
                 await self._order_manager.emergency_flatten(ticker, qty, exchange)
                 self._clear_spread_defer(ticker)
             else:
-                # Limit sell at mid-price
+                # Limit sell at mid-price.  Routed through OrderManager so
+                # the position transitions to CLOSING and the exit order_id
+                # is persisted BEFORE the next tick — without that step, a
+                # slow Alpaca fill leaves the row at POSITION_OPEN and the
+                # next tick re-evaluates the exit condition, risking a
+                # double-submit.
                 bid_ask = self._market_data.get_bid_ask(ticker)
                 limit_price: float
                 if bid_ask is not None:
@@ -876,30 +881,18 @@ class TradingBot:
                 else:
                     limit_price = current_price
 
-                try:
-                    from alpaca.trading.requests import LimitOrderRequest
-                    from alpaca.trading.enums import OrderSide, OrderType, TimeInForce
-
-                    request = LimitOrderRequest(
-                        symbol=ticker,
-                        qty=qty,
-                        side=OrderSide.SELL,
-                        type=OrderType.LIMIT,
-                        time_in_force=TimeInForce.DAY,
-                        limit_price=round(limit_price, 2),
-                    )
-                    self._gateway.client.submit_order(order_data=request)
-                    logger.info(
-                        "Exit limit order: SELL %d %s @ %.2f (reason=%s)",
-                        qty, ticker, limit_price, exit_decision.reason,
-                    )
-                except Exception:
-                    logger.exception(
-                        "Limit exit failed for %s — falling back to market", ticker
+                order_id: str | None = await self._order_manager.place_limit_exit(
+                    ticker=ticker,
+                    qty=qty,
+                    limit_price=limit_price,
+                    reason=exit_decision.reason,
+                )
+                if order_id is None:
+                    logger.warning(
+                        "Limit exit failed for %s — falling back to market", ticker,
                     )
                     await self._order_manager.emergency_flatten(ticker, qty, exchange)
-                else:
-                    self._clear_spread_defer(ticker)
+                self._clear_spread_defer(ticker)
 
     # ------------------------------------------------------------------
     # Spread defer tracking (per-ticker tick_state rows)
@@ -1039,30 +1032,21 @@ class TradingBot:
                 await self._order_manager.emergency_flatten(ticker, qty, exchange)
                 continue
 
-            # Tick-model wind-down: place a DAY limit sell and exit.  Alpaca
-            # auto-cancels the DAY order at close, so any unfilled portion
-            # becomes a market-on-close candidate for the next wind-down tick
-            # (or for the exit-check logic driving emergency_flatten).
-            try:
-                from alpaca.trading.requests import LimitOrderRequest
-                from alpaca.trading.enums import OrderSide, OrderType, TimeInForce
-
-                request = LimitOrderRequest(
-                    symbol=ticker,
-                    qty=qty,
-                    side=OrderSide.SELL,
-                    type=OrderType.LIMIT,
-                    time_in_force=TimeInForce.DAY,
-                    limit_price=round(limit_price, 2),
-                )
-                order = self._gateway.client.submit_order(order_data=request)
-                logger.info(
-                    "Wind-down limit placed: SELL %d %s @ %.2f (order_id=%s)",
-                    qty, ticker, limit_price, str(order.id),
-                )
-            except Exception:
-                logger.exception(
-                    "Wind-down order error for %s — trying market flatten", ticker
+            # Tick-model wind-down: place a DAY limit sell via OrderManager
+            # so the position transitions to CLOSING and the exit order_id
+            # is persisted before the next tick.  Alpaca auto-cancels the
+            # DAY order at close, so any unfilled portion gets picked up by
+            # the exit-check logic on the next tick (driving emergency_flatten).
+            order_id: str | None = await self._order_manager.place_limit_exit(
+                ticker=ticker,
+                qty=qty,
+                limit_price=limit_price,
+                reason="wind_down",
+            )
+            if order_id is None:
+                logger.warning(
+                    "Wind-down limit failed for %s — falling back to market",
+                    ticker,
                 )
                 await self._order_manager.emergency_flatten(ticker, qty, exchange)
 

--- a/trading_bot/tests/test_order_manager_lifecycle.py
+++ b/trading_bot/tests/test_order_manager_lifecycle.py
@@ -608,3 +608,108 @@ def test_active_count_and_getters(config, tmp_db_path: str, mock_notifier):
     assert om.active_count == 0
     assert om.get_active_orders() == {}
     assert om.get_active_order(99) is None
+
+
+# ---------------------------------------------------------------------------
+# place_limit_exit — prevents double-exit by transitioning state before tick
+# ---------------------------------------------------------------------------
+
+
+class TestPlaceLimitExit:
+    """The exit-path regression test for the double-submit bug.
+
+    Pre-fix, ``check_exits`` and ``wind_down`` called
+    ``self._gateway.client.submit_order`` directly: the order id was
+    discarded and the position row stayed at ``POSITION_OPEN``, so the
+    next stateless tick re-evaluated the same exit condition and
+    re-submitted.  Routing through ``OrderManager.place_limit_exit``
+    fixes both: the order_id is mapped back to the trade and the
+    position transitions to ``CLOSING`` synchronously.
+    """
+
+    @pytest.mark.asyncio
+    async def test_transitions_position_to_closing_before_returning(
+        self, config, tmp_db_path: str, mock_notifier
+    ):
+        om = _make_om(config, tmp_db_path, mock_notifier)
+
+        # Seed an open position so the OrderManager has something to match.
+        conn = sqlite3.connect(tmp_db_path)
+        conn.execute(
+            """INSERT INTO positions
+               (ticker, exchange, currency, sector, quantity, entry_price,
+                entry_time, status, hold_type, phase, strategy_id)
+               VALUES (?,?,?,?,?,?,?,?,?,?,?)""",
+            (
+                "SPY", "NASDAQ", "USD", "Information Technology",
+                10, 100.0, datetime.now(tz=ET).isoformat(),
+                "POSITION_OPEN", "intraday", 1, "mean_reversion",
+            ),
+        )
+        trade_id = conn.execute(
+            "SELECT id FROM positions WHERE ticker = 'SPY'"
+        ).fetchone()[0]
+        conn.commit()
+        conn.close()
+
+        om._active_orders[trade_id] = _ActiveOrder(
+            trade_id=trade_id,
+            ticker="SPY",
+            exchange="NASDAQ",
+            alpaca_entry_order_id="entry-1",
+            status=PositionStatus.POSITION_OPEN,
+            entry_shares=10,
+            filled_shares=10,
+            entry_price=100.0,
+            stop_price=98.0,
+            target_price=104.0,
+            hold_type="intraday",
+        )
+
+        # Stub Alpaca — limit submit returns an order id.
+        submitted = _alpaca_order("limit-exit-1", status="new")
+        om._gw.client.submit_order = MagicMock(return_value=submitted)
+
+        order_id = await om.place_limit_exit(
+            ticker="SPY", qty=10, limit_price=100.5, reason="take_profit",
+        )
+
+        assert order_id == "limit-exit-1"
+
+        # CRITICAL: position must be CLOSING in the DB before the next tick.
+        conn = sqlite3.connect(tmp_db_path)
+        row = conn.execute(
+            "SELECT status FROM positions WHERE id = ?", (trade_id,),
+        ).fetchone()
+        conn.close()
+        assert row[0] == PositionStatus.CLOSING.value, (
+            f"position must transition to CLOSING before returning, got {row[0]}"
+        )
+
+        # And the order_id must be pinned back to the trade so a subsequent
+        # fill notification routes to the right position.
+        assert om._alpaca_to_trade["limit-exit-1"] == trade_id
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_alpaca_error(
+        self, config, tmp_db_path: str, mock_notifier
+    ):
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        om._gw.client.submit_order = MagicMock(side_effect=RuntimeError("boom"))
+
+        order_id = await om.place_limit_exit(
+            ticker="SPY", qty=10, limit_price=100.0, reason="time_stop",
+        )
+
+        # Caller is expected to fall back to emergency_flatten when None.
+        assert order_id is None
+
+    @pytest.mark.asyncio
+    async def test_rejects_non_positive_qty(
+        self, config, tmp_db_path: str, mock_notifier
+    ):
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        order_id = await om.place_limit_exit(
+            ticker="SPY", qty=0, limit_price=100.0, reason="bug",
+        )
+        assert order_id is None

--- a/trading_bot/tests/test_reporting_and_ops.py
+++ b/trading_bot/tests/test_reporting_and_ops.py
@@ -89,7 +89,7 @@ def test_daily_metrics_no_trades(tmp_db_path):
 
 def test_daily_metrics_with_wins_and_losses(tmp_db_path):
     pc = PerformanceCalculator(tmp_db_path)
-    today_str = date.today().isoformat()
+    today_str = datetime.now(tz=ET).date().isoformat()
     today_iso = datetime.now(tz=ET).isoformat()
     # Two wins, one loss
     _seed_trade(tmp_db_path, ticker="A", exit_time=today_iso, pnl_usd=10.0, gross_pnl=12.5)
@@ -108,7 +108,7 @@ def test_daily_metrics_with_wins_and_losses(tmp_db_path):
 def test_daily_metrics_usd_passthrough(tmp_db_path):
     """Account is USD-only — gross_pnl flows through unchanged."""
     pc = PerformanceCalculator(tmp_db_path)
-    today_str = date.today().isoformat()
+    today_str = datetime.now(tz=ET).date().isoformat()
     today_iso = datetime.now(tz=ET).isoformat()
     _seed_trade(
         tmp_db_path, ticker="X", exit_time=today_iso,


### PR DESCRIPTION
## Summary

Pre-fix, both `check_exits` and `wind_down` in `main.py` called `self._gateway.client.submit_order` **directly** to place a DAY limit sell. The returned order was discarded (or only logged), and the position row stayed at `POSITION_OPEN` in SQLite. In the stateless GHA tick model — every 5 min — the next tick re-evaluated the same exit condition and saw the same open position, so **a slow Alpaca fill risked a double-submit**.

> Stacked on top of #27 (USD-only refactor) — merge that one first.

## What changed

Added `OrderManager.place_limit_exit` that mirrors the existing `place_exit` but uses LIMIT/DAY instead of MARKET, and — critically — **transitions the position to `CLOSING` and pins the new order_id to the trade BEFORE returning**. The fill detector (`_check_order_statuses`) then advances `CLOSING → CLOSED` on the next tick when the fill confirms.

Both call sites in `main.py` now route through this helper:
- `check_exits` limit branch (line ~870)
- `wind_down` (line ~1040)

On submit failure the caller falls back to `emergency_flatten` (a market order), preserving the previous fail-safe behavior.

## Regression tests

Added `TestPlaceLimitExit` to `test_order_manager_lifecycle.py`:

1. `test_transitions_position_to_closing_before_returning` — the core invariant: position must be `CLOSING` in the DB before the helper returns, and the new order_id must be mapped back to the trade.
2. `test_returns_none_on_alpaca_error` — submit failure path so callers can fall back to `emergency_flatten`.
3. `test_rejects_non_positive_qty` — defensive guard.

Also fixes a pre-existing timezone bug in two reporting tests (`test_daily_metrics_with_wins_and_losses`, `test_daily_metrics_usd_passthrough`) that mixed system-local `date.today()` with ET-stamped trade `exit_time`. Surfaced today under the UTC/ET date-rollover boundary; the fix uses ET consistently in both test sites.

## Test plan
- [x] `pytest trading_bot/tests/` — 686 passed, 2 skipped (was 683; +3 new TestPlaceLimitExit cases).
- [ ] After merge, verify the next exit fires the new code path (`Limit exit submitted: SELL ... alpaca_id=...` log line) and that the position transitions to `CLOSING` in SQLite within the same tick.
- [ ] Confirm no `Wind-down limit placed: ... order_id=...` log lines appear from the OLD direct-submit path on subsequent runs.