### PR TITLE
fix: harden silent-failure paths surfaced by review

### DIFF
--- a/trading_bot/env.py
+++ b/trading_bot/env.py
@@ -54,5 +54,18 @@ def resolve_alpaca_env() -> tuple[str, str, bool]:
     if key and secret:
         os.environ["ALPACA_API_KEY"] = key
         os.environ["ALPACA_SECRET_KEY"] = secret
+    else:
+        # Surface the misconfiguration explicitly. The previous behavior
+        # silently returned empty strings, making downstream Alpaca
+        # connection failures hard to root-cause. CI runs and live trading
+        # MUST have these set — only offline backtests can legitimately
+        # proceed without them.
+        suffix: str = "PAPER" if is_paper else "LIVE"
+        logger.error(
+            "Alpaca credentials missing for env=%s — bot will fail to connect. "
+            "Set ALPACA_%s_KEY_ID + ALPACA_%s_SECRET (or ALPACA_API_KEY + "
+            "ALPACA_SECRET_KEY directly).",
+            env, suffix, suffix,
+        )
 
     return key, secret, is_paper

--- a/trading_bot/execution/risk_manager.py
+++ b/trading_bot/execution/risk_manager.py
@@ -447,7 +447,7 @@ class RiskManager:
         while self._recent_rejections and self._recent_rejections[0] < cutoff:
             self._recent_rejections.popleft()
 
-        if len(self._recent_rejections) > max_count:
+        if len(self._recent_rejections) >= max_count:
             # Already triggered, check if pause has expired
             if self._pause_until is not None:
                 if datetime.now(tz=ET) >= self._pause_until:
@@ -564,10 +564,19 @@ class RiskManager:
     # ------------------------------------------------------------------
 
     def record_trade(self, pnl_usd: float, commission_usd: float) -> None:
-        """Record a completed trade for daily tracking."""
+        """Record a completed trade for daily tracking.
+
+        ``_daily_gross_pnl_usd`` is the sum of WINNING trade gross profits
+        only — used as the denominator in the commission-budget ratio
+        (commissions / gross_profits). The previous formula
+        ``abs(pnl) + commission`` inflated the denominator by counting
+        losses and commissions, making the commission stop fire late or
+        never. Dormant on Alpaca today (commission_usd is always 0) but
+        wrong for any future non-zero commission environment.
+        """
         self._trade_count += 1
         self._daily_pnl_usd += pnl_usd
-        self._daily_gross_pnl_usd += abs(pnl_usd) + commission_usd
+        self._daily_gross_pnl_usd += max(pnl_usd, 0.0)
         self._daily_commissions_usd += commission_usd
 
         logger.info(

--- a/trading_bot/main.py
+++ b/trading_bot/main.py
@@ -555,7 +555,13 @@ class TradingBot:
             # broader rename that also touches the daily_summaries DB
             # column. Pass through as USD here for the new
             # StrategyManager API.
-            account_equity_usd: float = await self._get_account_equity_usd()
+            account_equity_usd: float | None = await self._get_account_equity_usd()
+            if account_equity_usd is None:
+                logger.warning(
+                    "Skipping entry scan for %s — equity unavailable",
+                    market.value,
+                )
+                return
             await self._strategy_manager.scan_for_entries(
                 watchlist=watchlist,
                 get_5min_bars=self._get_5min_bars,
@@ -577,7 +583,14 @@ class TradingBot:
         if not watchlist:
             return
 
-        account_equity_usd: float = await self._get_account_equity_usd()
+        account_equity_usd_opt: float | None = await self._get_account_equity_usd()
+        if account_equity_usd_opt is None:
+            logger.warning(
+                "Skipping entry scan for %s — equity unavailable",
+                market.value,
+            )
+            return
+        account_equity_usd: float = account_equity_usd_opt
 
         # Update risk manager with today's P&L
         self._risk_manager.check_daily_loss_limit(
@@ -1365,8 +1378,8 @@ class TradingBot:
         if now_et.time() < check_after:
             return
 
-        equity: float = await self._get_account_equity_usd()
-        if equity > 0:
+        equity: float | None = await self._get_account_equity_usd()
+        if equity is not None and equity > 0:
             await self._check_phase_transition(equity)
         flags["phase_check_done"] = True
         self._save_day_flags(today, flags)
@@ -1398,7 +1411,17 @@ class TradingBot:
     async def _save_daily_summary(self, today: date) -> bool:
         """Compute and persist daily metrics, then send a summary notification."""
         today_str: str = today.isoformat()
-        equity: float = await self._get_account_equity_usd()
+        equity: float | None = await self._get_account_equity_usd()
+        if equity is None:
+            # Don't pollute daily_summaries with a 0.0 equity row when
+            # Alpaca is briefly unreachable.  The flag stays False so the
+            # next tick retries.  daily_summaries.account_equity_usd is
+            # NOT NULL — there is no good sentinel for "unknown".
+            logger.warning(
+                "Skipping daily_summary save for %s — equity unavailable; "
+                "will retry next tick", today_str,
+            )
+            return False
 
         try:
             metrics: dict[str, Any] = self._performance.calculate_daily_metrics(today_str)
@@ -1461,16 +1484,25 @@ class TradingBot:
     # Utility helpers
     # ------------------------------------------------------------------
 
-    async def _get_account_equity_usd(self) -> float:
-        """Return account NetLiquidation in USD; 0.0 on failure."""
+    async def _get_account_equity_usd(self) -> float | None:
+        """Return account NetLiquidation in USD, or ``None`` on failure.
+
+        Pre-fix returned ``0.0`` on failure, which silently polluted the
+        ``daily_summaries`` write (the column is NOT NULL, so a transient
+        Alpaca outage at end-of-day stamped a 0.0 equity row).  Callers
+        must now guard explicitly: skip the work, retry next tick.
+        """
         try:
             summary: dict[str, Any] = await self._gateway.get_account_summary()
             equity_str: str | None = summary.get("NetLiquidation")
             if equity_str:
                 return float(equity_str)
+            logger.warning(
+                "get_account_summary returned no NetLiquidation field"
+            )
         except Exception:
             logger.warning("get_account_equity_usd failed", exc_info=True)
-        return 0.0
+        return None
 
     async def _refresh_phase_from_equity(self) -> None:
         """Re-resolve the operating phase using the broker's live equity.
@@ -1480,8 +1512,8 @@ class TradingBot:
         always pinned MICRO. We reset the cache and re-resolve with
         live equity so per-tick phase-aware accessors match reality.
         """
-        equity_usd: float = await self._get_account_equity_usd()
-        if equity_usd <= 0:
+        equity_usd: float | None = await self._get_account_equity_usd()
+        if equity_usd is None or equity_usd <= 0:
             return
 
         prior: Phase | None = getattr(self._config, "_phase", None)

--- a/trading_bot/strategy/exit.py
+++ b/trading_bot/strategy/exit.py
@@ -226,8 +226,18 @@ class ExitManager:
         else:
             return False
 
-        # Ensure timezone-aware
+        # Ensure timezone-aware. The bot's writers always stamp ET via
+        # ``datetime.now(tz=ET).isoformat()`` so naive strings are
+        # exceptional — fixtures, manual DB inserts, or legacy rows.
+        # Stamp them as ET (the writer's convention) and warn loudly so
+        # the source can be fixed; treating a UTC-naive string as ET
+        # would skew the time-stop by 4–5 hours.
         if entry_time.tzinfo is None:
+            logger.warning(
+                "Position has naive entry_time (%s) — stamping as ET. "
+                "Investigate the writer; this row may have legacy data.",
+                entry_time_raw,
+            )
             entry_time = entry_time.replace(tzinfo=ET)
         if current_time.tzinfo is None:
             current_time = current_time.replace(tzinfo=ET)

--- a/trading_bot/tests/test_risk_manager.py
+++ b/trading_bot/tests/test_risk_manager.py
@@ -233,6 +233,18 @@ class TestOrderRejections:
         paused = risk_manager.check_order_rejections()
         assert paused is False
 
+    def test_order_rejection_pauses_at_threshold_exactly(
+        self, risk_manager: RiskManager
+    ) -> None:
+        """Regression: pre-fix used `len > max_count` (=4), so 3
+        rejections did not trip despite `max_count=3` config naming.
+        The rule is now `len >= max_count`."""
+        for i in range(3):
+            risk_manager.record_rejection("PLTR", f"r{i}")
+        with patch("asyncio.ensure_future", _noop_ensure_future):
+            paused = risk_manager.check_order_rejections()
+        assert paused is True
+
     def test_rejection_count_increments(
         self, risk_manager: RiskManager
     ) -> None:
@@ -320,3 +332,17 @@ class TestDailyReset:
         risk_manager.record_trade(-3.0, 0.5)
         assert risk_manager.trade_count == 2
         assert abs(risk_manager.daily_pnl_usd - 2.0) < 0.01
+
+    def test_record_trade_gross_pnl_excludes_losses(
+        self, risk_manager: RiskManager
+    ) -> None:
+        """Regression: ``_daily_gross_pnl_usd`` is the denominator in
+        ``commissions / gross_pnl``. Pre-fix it was ``abs(pnl) + comm``,
+        which counted losses (and double-counted commissions), inflating
+        the denominator and making the commission stop fire late or
+        never. Should be the sum of WINNING trade gross profits only."""
+        risk_manager.record_trade(10.0, 0.0)   # winner +10
+        risk_manager.record_trade(-5.0, 0.0)   # loser -5 — must NOT contribute
+        risk_manager.record_trade(3.0, 0.0)    # winner +3
+        # Expected gross profit = 10 + 3 = 13 (losses excluded)
+        assert abs(risk_manager._daily_gross_pnl_usd - 13.0) < 0.01


### PR DESCRIPTION
Five low-severity findings from the original sanity-check review. None are blockers; all are silent-failure or dormant edge cases. Bundled into a single PR since each is 1-2 lines.

## Fixes

### #4 — `risk_manager.check_order_rejections` off-by-one
`len > max_count` triggered at `max_count + 1`. With `max_count=3` the breaker required **4** rejections before pausing despite the config name. Fix: `>=`. Pins the threshold at exactly `max_count`.

### #6 — `env.resolve_alpaca_env` silent empty-creds return
When neither key pair was set, returned `("", "", is_paper)` with **no log**. Downstream Alpaca connection errors were hard to root-cause. Fix: log an explicit error naming the env vars to set.

### #7 — `risk_manager.record_trade` gross-PnL formula
`_daily_gross_pnl_usd += abs(pnl) + commission` inflated the commission-budget denominator (counted losses, double-counted commissions), making the commission stop fire late or never. The denominator should be the sum of **winning** trade gross profits only. Dormant on Alpaca today (commission_usd is always 0) but wrong for any future non-zero commission environment.

### #8 — `_get_account_equity_usd` polluted `daily_summaries` on transient Alpaca failure
Returned `0.0` on outage; `_save_daily_summary` then wrote a row with `account_equity_usd = 0.0` into `daily_summaries` (column is NOT NULL, no good sentinel). Fix: return `None` on failure. Callers (`_save_daily_summary`, `scan_for_entries`, `_refresh_phase_from_equity`, `_maybe_check_phase_transition`) now skip the work explicitly so the next tick retries cleanly.

### #9 — `exit.check_time_stop` naive-tz silent stamping
The bot's writers always produce tz-aware ET strings, so the naive branch only fires on fixtures, manual DB inserts, or legacy rows. If any of those happened to be UTC-naive, the time stop would fire 4-5h early. Fix: keep the ET stamp (matches writer convention) but log a WARNING so the source can be investigated.

## Test plan
- [x] `pytest trading_bot/tests/` — 688 passed, 2 skipped (was 686; +2 new regression cases for #4 and #7)