### PR TITLE
fix(overnight_drift): use ET-aware date in evaluate_exit fallback

### DIFF
--- a/trading_bot/strategy/strategies/overnight_drift.py
+++ b/trading_bot/strategy/strategies/overnight_drift.py
@@ -151,7 +151,14 @@ class OvernightDriftStrategy(StrategyBase):
         bar_date: date | None = _latest_bar_date(df_5min)
         if bar_date is None:
             # No bar data — fall back to "now" (live path may not pass bars).
-            bar_date = datetime.now().date()
+            # Use ET (the trading calendar's timezone) explicitly so this
+            # check doesn't skew when run from a non-UTC machine or in the
+            # 00:00–05:00 UTC window where naive `datetime.now().date()`
+            # would return tomorrow's UTC date and force a premature
+            # overnight_exit.  GHA cron firings all land at safe UTC times
+            # but manual / off-cron runs (backfills, dry-runs from non-UTC
+            # systems) hit this path.
+            bar_date = datetime.now(tz=TZ_EASTERN).date()
 
         # Exit on the first bar of any later trading day.
         if bar_date > entry_date:


### PR DESCRIPTION
Finishing the cleanup of the original review's #5 finding. 1-line behavioral fix.

## Why this matters now

I previously (incorrectly) waved this away as "GHA cron only runs during NYSE hours so the bug is dormant." That ignores three other workflows:

- `pre-open-check.yml` runs a dry-run tick at 13:00 UTC (~30 min pre-open)
- `daily-review.yml` runs the self-improve agent at 21:30 UTC (post-close)
- `heartbeat.yml` runs every 30 min around the clock

All of them happen to fire at UTC times where the UTC calendar date matches the ET calendar date, so the specific date-skew bug doesn't trigger under any current cron — but **manual runs from non-UTC operator machines** (the project owner is in Riyadh, GMT+3) and **any future workflow scheduled between 00:00–05:00 UTC** would hit it: `datetime.now().date()` returns the UTC/local date, comparing against the ET-stored `entry_date` produces `bar_date > entry_date`, and `overnight_drift.evaluate_exit` fires a spurious `overnight_exit` on a position entered the same session.

## Fix

```python
# was:
bar_date = datetime.now().date()
# now:
bar_date = datetime.now(tz=TZ_EASTERN).date()
```

`TZ_EASTERN` is already imported. The trading calendar is already ET everywhere else in the strategy, so this just fixes the one drift.

## Test plan
- [x] `pytest trading_bot/tests/` — 688 passed, 2 skipped (no new tests; the fix doesn't change behavior under the current GHA schedule, only off-cron correctness)