### PR TITLE
fix(daily-review): force-add report file (path is gitignored)

### DIFF
--- a/.github/workflows/daily-review.yml
+++ b/.github/workflows/daily-review.yml
@@ -100,7 +100,11 @@ jobs:
           git config user.name "ai-broker-bot"
           git config user.email "ai-broker-bot@users.noreply.github.com"
           git checkout -b "$BRANCH"
-          git add "$REPORT"
+          # -f required: trading_bot/docs/self_improve_reports/ is in
+          # .gitignore (prevents ad-hoc local runs from polluting the
+          # repo), but the workflow's purpose is to commit the report
+          # as a PR.
+          git add -f "$REPORT"
           if git diff --cached --quiet; then
             echo "Report file unchanged — no PR needed."
             exit 0


### PR DESCRIPTION
## Summary

One-line fix uncovered when triggering daily-review.yml manually for the first time after PR #24's folder restructure.

PR #24 moved \`self_improve_reports/\` under \`trading_bot/docs/\` and the \`.gitignore\` rule moved with it (intentional — keeps ad-hoc local runs from polluting the repo). But the workflow's whole purpose is to commit the report file as a PR, so it needs \`git add -f\`.

## Evidence (run 25190660372)

\`\`\`
The following paths are ignored by one of your .gitignore files:
  trading_bot/docs/self_improve_reports
hint: Use -f if you really want to add them.
##[error]Process completed with exit code 1.
\`\`\`

## Fix

\`git add "$REPORT"\` → \`git add -f "$REPORT"\` plus a comment explaining the asymmetry so a future reader doesn't strip the \`-f\`.

## Test plan

- [ ] Merge
- [ ] \`gh workflow run daily-review.yml\` manually
- [ ] Confirm the run succeeds and a draft PR is opened with the report file