### PR TITLE
fix(daily-review): make same-day re-runs idempotent

### DIFF
--- a/.github/workflows/daily-review.yml
+++ b/.github/workflows/daily-review.yml
@@ -97,6 +97,15 @@ jobs:
           fi
 
           BRANCH="${{ steps.dates.outputs.branch }}"
+
+          # Idempotent: if the branch already exists on origin, an earlier run
+          # today already opened a PR. Don't push a competing tip (would fail
+          # non-fast-forward) or force-push over the existing PR.
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            echo "Branch $BRANCH already exists on origin — earlier run today already opened a PR. Skipping."
+            exit 0
+          fi
+
           git config user.name "ai-broker-bot"
           git config user.email "ai-broker-bot@users.noreply.github.com"
           git checkout -b "$BRANCH"


### PR DESCRIPTION
## Summary
- Skip the push step when \`daily-review/\$DATE\` already exists on origin
- Prevents the non-fast-forward failure observed on 2026-04-30 22:27 UTC, where a re-run after the 22:21 success tried to push a competing tip onto the branch already used by [PR #33](https://github.com/alex5imon/ai-broker/pull/33)

## Why
The branch name is fixed per calendar day (\`daily-review/\$REPORT_DATE\`). Once an earlier run today has pushed and opened a PR, any subsequent \`workflow_dispatch\` re-trigger generates a fresh local commit on a fresh branch, then fails non-fast-forward against the existing remote tip. Force-pushing would silently overwrite the existing PR — not what we want for an advisory research artifact a human may have already started reviewing.

The check is a single \`git ls-remote --exit-code --heads\`; if the branch is already there, we exit 0 and the report still ships as an upload-artifact.

## Test plan
- [ ] Manually re-trigger \`daily-review\` after a successful same-day run; confirm the second run logs the skip message and exits 0
- [ ] First run of a new calendar day still creates the branch and opens the draft PR as before