### PR TITLE
fix(order_manager): floor fractional shares + close trades row on entry-fail

### DIFF
--- a/trading_bot/docs/self_improve_followups.md
+++ b/trading_bot/docs/self_improve_followups.md
@@ -5,6 +5,12 @@ These are real problems uncovered while building the daily-review agent
 out of that PR because they touch live order logic and your CLAUDE.md
 says "exercise extreme care with all order logic."
 
+## Active tracking
+
+- **#39 — Replace bracket entry with plain-limit + standalone-stop** (must land before `$1k` live).
+  Whole-share floor in PR #38 is a Monday-morning unblocker; backtests show it
+  drops ~50% of mean_reversion signals at $1k account size.
+
 ## How they were found
 
 - **Date:** 2026-04-30

--- a/trading_bot/execution/order_manager.py
+++ b/trading_bot/execution/order_manager.py
@@ -350,6 +350,22 @@ class OrderManager:
 
     async def place_entry(self, decision: EntryDecision) -> int | None:
         """Place an entry limit order.  Returns the internal trade_id on success."""
+        # Alpaca rejects fractional+bracket combos with code 42210000
+        # ("fractional orders must be simple orders"), and we always submit
+        # bracketed entries so stop+target attach atomically. Floor to whole
+        # shares so the bracket path is legal. The proper fix — plain entry +
+        # standalone stop on fill — is required before live deployment because
+        # this floor drops ~50% of signals on a $1k account; tracked separately.
+        whole_shares: int = int(decision.shares)
+        if whole_shares <= 0:
+            logger.info(
+                "[%s] Entry skipped: whole-share floor produces 0 shares (raw=%.4f, price=%.2f)",
+                decision.ticker, decision.shares, decision.limit_price,
+            )
+            return None
+        if whole_shares != decision.shares:
+            decision.shares = whole_shares
+
         trade_id: int | None = self._create_position_record(decision)
         if trade_id is None:
             logger.error("Failed to create position record for %s", decision.ticker)
@@ -416,9 +432,13 @@ class OrderManager:
             # submit so no order ever existed. CLOSED implies a real
             # round-trip and pollutes every postmortem report.
             self._update_position_status(trade_id, PositionStatus.ENTRY_FAILED)
-            # Drop the unused mapping so it can't leak into a stale
-            # _ActiveOrder if the same positions.id is later rehydrated.
-            self._pending_db_trade_ids.pop(trade_id, None)
+            # Mark the trades row as entry_failed so daily_summaries and the
+            # self-improvement postmortem don't see a permanently-open ghost.
+            # UPDATE rather than DELETE so the audit trail (rejection reason
+            # via _log_rejection below) remains pinned to a real trades.id.
+            db_trade_id: int | None = self._pending_db_trade_ids.pop(trade_id, None)
+            if db_trade_id is not None:
+                self._mark_trade_entry_failed(db_trade_id, decision.limit_price)
             self._log_rejection(
                 ticker=decision.ticker,
                 exchange=decision.exchange,
@@ -1071,6 +1091,48 @@ class OrderManager:
 
     def _update_position_status(self, trade_id: int, status: PositionStatus) -> None:
         self._update_position_field(trade_id, "status", status.value)
+
+    def _mark_trade_entry_failed(self, db_trade_id: int, entry_price: float) -> None:
+        """Mark a trades row as entry_failed when Alpaca rejected the submit.
+
+        Closes the row at the original entry price with zero P&L so it is
+        excluded from win/loss aggregations but remains visible to the
+        reconciler under exit_reason='entry_failed'.
+        """
+        now_str: str = datetime.now(tz=ET).isoformat()
+        try:
+            conn: sqlite3.Connection = sqlite3.connect(self._db_path)
+            try:
+                cursor = conn.execute(
+                    """
+                    UPDATE trades
+                       SET exit_time   = ?,
+                           exit_price  = ?,
+                           exit_reason = 'entry_failed',
+                           gross_pnl   = 0,
+                           net_pnl     = 0,
+                           pnl_usd     = 0
+                     WHERE id = ?
+                    """,
+                    (now_str, entry_price, db_trade_id),
+                )
+                conn.commit()
+                rows_affected: int = cursor.rowcount
+            finally:
+                conn.close()
+        except Exception:
+            logger.exception(
+                "Failed to mark trade entry_failed for db_trade_id=%d",
+                db_trade_id,
+            )
+            return
+
+        if rows_affected != 1:
+            logger.warning(
+                "trades UPDATE entry_failed db_trade_id=%d rows_affected=%d "
+                "(expected 1) — silent write-back failure",
+                db_trade_id, rows_affected,
+            )
 
     # Pre-built UPDATE statements per allowed column. The column name is
     # part of the static SQL; misuse of this helper (e.g. attacker- or

--- a/trading_bot/tests/test_order_manager_lifecycle.py
+++ b/trading_bot/tests/test_order_manager_lifecycle.py
@@ -597,6 +597,89 @@ class TestPlaceEntryFailure:
         assert "insufficient buying power" in reason
         assert reason.startswith("alpaca_submit_error")
 
+    @pytest.mark.asyncio
+    async def test_entry_failure_marks_trades_row_entry_failed(
+        self, config, tmp_db_path: str, mock_notifier
+    ):
+        """2026-05-01 incident: every fractional+bracket entry was rejected by
+        Alpaca, but the trades row inserted by _create_position_record was left
+        with no exit_time/exit_reason, polluting daily_summaries (60 phantom
+        'closed' rows in 2026-04-30 with NULL net_pnl). The exception handler
+        must close the trades row at exit_reason='entry_failed', net_pnl=0."""
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        om._gw.client.submit_order = MagicMock(side_effect=RuntimeError("boom"))
+
+        await om.place_entry(_entry(ticker="XLF", shares=10, price=51.0))
+
+        conn = sqlite3.connect(tmp_db_path)
+        try:
+            row = conn.execute(
+                "SELECT exit_time, exit_price, exit_reason, gross_pnl, net_pnl, pnl_usd "
+                "FROM trades ORDER BY id DESC LIMIT 1"
+            ).fetchone()
+        finally:
+            conn.close()
+
+        assert row is not None, "trades row missing"
+        exit_time, exit_price, exit_reason, gross_pnl, net_pnl, pnl_usd = row
+        assert exit_time is not None, "trades.exit_time still NULL — phantom row"
+        assert abs(float(exit_price) - 51.0) < 1e-6
+        assert exit_reason == "entry_failed"
+        assert float(gross_pnl) == 0.0
+        assert float(net_pnl) == 0.0
+        assert float(pnl_usd) == 0.0
+
+
+class TestFractionalShareFloor:
+    """2026-05-01 incident: Alpaca rejects fractional+bracket combos (code
+    42210000). Floor to whole shares so the bracket path is legal. Until the
+    standalone-stop refactor lands, this is the gate that keeps live trading
+    from no-op'ing every signal."""
+
+    @pytest.mark.asyncio
+    async def test_fractional_shares_floored_before_submit(
+        self, config, tmp_db_path: str, mock_notifier
+    ):
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        captured: list = []
+
+        def _capture(order_data):
+            captured.append(order_data)
+            return _alpaca_order("entry-1", "new")
+
+        om._gw.client.submit_order = MagicMock(side_effect=_capture)
+
+        decision = _entry(ticker="XLF", shares=10, price=51.0)
+        decision.shares = 2.7  # type: ignore[assignment]
+        trade_id = await om.place_entry(decision)
+
+        assert trade_id is not None
+        assert len(captured) == 1
+        assert int(captured[0].qty) == 2, f"expected qty=2, got {captured[0].qty}"
+
+    @pytest.mark.asyncio
+    async def test_zero_share_floor_skips_without_db_insert(
+        self, config, tmp_db_path: str, mock_notifier
+    ):
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        om._gw.client.submit_order = MagicMock()
+
+        decision = _entry(ticker="SPY", shares=10, price=700.0)
+        decision.shares = 0.43  # type: ignore[assignment]
+        trade_id = await om.place_entry(decision)
+
+        assert trade_id is None
+        om._gw.client.submit_order.assert_not_called()
+        # No DB pollution — neither a position nor a trades row.
+        conn = sqlite3.connect(tmp_db_path)
+        try:
+            n_pos = conn.execute("SELECT COUNT(*) FROM positions").fetchone()[0]
+            n_trades = conn.execute("SELECT COUNT(*) FROM trades").fetchone()[0]
+        finally:
+            conn.close()
+        assert n_pos == 0
+        assert n_trades == 0
+
 
 # ---------------------------------------------------------------------------
 # get_active_orders helpers


### PR DESCRIPTION
## Summary

Two surgical fixes for the 2026-05-01 incident where every entry signal was rejected by Alpaca and silently logged as a phantom trades row.

**1. Whole-share floor in \`place_entry\`** — before \`_create_position_record\`, floor \`decision.shares\` to int. If 0, log and skip (no DB row, no submit). Keeps the bracket order path legal until the standalone-stop refactor lands.

**2. UPDATE trades row on entry-submit failure** — exception handler already marked \`positions.status = ENTRY_FAILED\`, but the trades row was left with NULL \`exit_time\` / \`exit_reason\`, polluting \`daily_summaries\` and the self-improvement postmortem. Now closes the trades row at \`exit_reason='entry_failed'\`, \`net_pnl=0\`, \`exit_price=entry_price\`. UPDATE rather than DELETE so the audit trail in \`order_rejections\` stays linked.

## Why

On 2026-05-01, every \`place_entry\` call hit \`APIError: fractional orders must be simple orders\` (code 42210000). Alpaca rejected the bracket because the qty was fractional. 8 signals fired; 0 orders made it to Alpaca; 8 phantom trades rows polluted the DB. This pattern was present all week but masked by the data-layer bugs already addressed in #16/#20.

## Backtest A/B (multi-intraday cache, 2024-01 → 2026-04, SPY+QQQ+XLF+XLK)

| | \$1k account | \$100k account |
|---|---:|---:|
| **Mean Reversion** | -52% trades, -90% P&L | identical to fractional, -0.05pp |
| **Overnight Drift** | -33% trades, -35% P&L | identical to fractional, -0.05pp |
| **Combined return** | +26.76% → +14.05% (-12.71pp) | +26.76% → +26.71% (-0.05pp) |

Whole-share floor is **safe at \$100k paper** (effectively noise) but **gates ~50% of signals at \$1k live** because SPY/QQQ/XLK at >\$400 always floor to 0 under the max-position-pct cap. The proper fix (plain entry + standalone stop on fill) is required before live and is tracked separately.

## Test plan

- [x] \`TestPlaceEntryFailure::test_entry_failure_marks_trades_row_entry_failed\` — submit_order raises, trades row gets entry_failed/0/0/0
- [x] \`TestFractionalShareFloor::test_fractional_shares_floored_before_submit\` — shares=2.7 → submit_order called with qty=2
- [x] \`TestFractionalShareFloor::test_zero_share_floor_skips_without_db_insert\` — shares=0.43 → no DB row, no submit, returns None
- [x] All 29 tests in \`test_order_manager_lifecycle.py\` pass
- [ ] Monday open smoke test: confirm a real order lands in Alpaca's order log

## Pre-existing test failures (not addressed here)

\`test_reporting_and_ops.py\` has two failures on \`main\` that look symptomatic of the same data-layer drift the postmortem has been hunting all week:

- \`test_daily_metrics_with_wins_and_losses\` — seeds 3 closed trades, calculator returns 0
- \`test_daily_metrics_usd_passthrough\` — same pattern

Worth a separate look — fixing in this PR would conflate the entry-path fix with a reporting-layer fix.

## Tracking — proper fix required before \$1k live

Plain limit entry + standalone stop on fill is needed to support fractional sizing without the bracket constraint. This PR is a Monday-morning unblocker for the paper account; it must not be the last word before live deployment. (Tracking issue to follow.)