### PR TITLE
feat(breakout): opt-in filter flags + ORB strategy (shelved-try infra)

### DIFF
--- a/trading_bot/docs/breakout_retune/2026-05-02_postmortem.md
+++ b/trading_bot/docs/breakout_retune/2026-05-02_postmortem.md
@@ -1,0 +1,101 @@
+# Breakout Retune — Postmortem & A/B (2026-05-02)
+
+Tracking issue: TODO A in [`return_improvement_todos`](../../../return_improvement_todos.md).
+
+## Why this exists
+
+`breakout` was disabled in [PR #12](https://github.com/alex5imon/ai-broker/pull/12) on 2026-04-28 after the 13-ETF 2020-2026 walkforward showed PF 0.292, WR 11.5%, OOS Return -17.0%. The 2008-2021 SPY-only walkforward had given a PF 2.385 read; that turned out to be a regime-favorable artifact.
+
+The acceptance bar for re-enabling: PF 95% CI lower bound > 1.0 individually on the 13-ETF 2020-2026 walkforward, AND portfolio CI does not regress vs current `[1.014, 1.190]`. Anything weaker = stays disabled.
+
+## Step 0 — Diagnostic postmortem
+
+Single-window simple backtest with `breakout` solo, `max_positions=13`, $1000 alloc, no regime filter on 13 ETFs from 2020-07-27 to 2026-04-16.
+
+**Result: 20 trades, 0 wins, -18.0% return, 17 stop-outs.**
+
+### Failure mode
+
+Every entry that triggered ended up at stop-loss (or open at backtest end). Same-day fakeouts (4) plus slow-grind-to-stop (14) plus 3 still-open. Median hold 348h. The strategy is buying 5-min bars that print the daily 20-day high — by definition, the local top.
+
+| Year | Trades | Win% | Total P&L |
+|---|---:|---:|---:|
+| 2021 | 1 | 0% | -$12.11 |
+| 2022 | 1 | 0% | -$12.08 |
+| 2024 | 2 | 0% | -$24.82 |
+| 2025 | 10 | 0% | -$98.99 |
+| 2026 | 6 | 0% | -$31.95 |
+
+50% of failures concentrated in 2025 — the late-2025 selloff fired the strategy hardest and failed worst (every "20-day high" was a top tick).
+
+### Per-ticker
+
+| Ticker | N | Win% | P&L |
+|---|---:|---:|---:|
+| XLY | 4 | 0% | -$50.11 |
+| XLF | 4 | 0% | -$45.61 |
+| XLRE | 3 | 0% | -$24.26 |
+| XLV | 2 | 0% | -$17.05 |
+| XLP | 2 | 0% | -$20.62 |
+| XLC, XLK | 2 each | 0% | small |
+| XLI | 1 | 0% | -$11.16 |
+
+### Time-of-day
+
+Entries spread across 09:30 (4), 10:00-13:30 (11), 14:00-15:30 (5). No clustering — time-of-day filter alone won't rescue.
+
+### Structural problem
+
+Daily-20-day-high signal × 5-min execution = systematic top-ticking. The first 5-min bar that prints the daily high IS the local high, and the volume confirmation requirement ensures we fire at exhaustion. Combined with a 10-day Donchian exit that stays inactive while price grinds in a tight range below entry, and a 3% stop right at ETF noise level, every entry is a guaranteed loser.
+
+## Step 1 — Hypotheses retained after diagnostic
+
+Original H1 (Donchian 20→10), H2 (time-of-day filter), H3 (volume mult tighter) **dropped** — the data shows they don't address the structural pathology.
+
+**Track 1** — incremental filter stack on the existing daily-high signal:
+- H4: per-ticker trend filter (`price > own 50-day SMA`)
+- H5: ATR expansion (`current ATR > 1.2× mean(ATR_14, last 20)`)
+- H6: pullback entry (wait for retest of breakout level rather than buying the bar that breaks it)
+
+**Track 2** — architecture pivot to Opening Range Breakout (ORB):
+- 09:30-10:00 ET defines `[orb_low, orb_high]` from first 6 5-min bars
+- Entry: break of `orb_high` before 11:30 ET cutoff with volume confirm
+- Stop: `orb_low`; Target: `orb_high + R × range` (R=1.0 default)
+- INTRADAY hold — backtester force-closes at 15:50 ET wind-down
+- Variants: baseline (R=1.0, 6-bar range), R=2.0, 3-bar range, strict 2× volume
+
+## Step 2 — A/B simple-backtest matrix
+
+(13-ETF, 2020-07-27 → 2026-04-16, no regime filter, max_positions=13, $1000 alloc each.)
+
+_Results pending — backtests in flight._
+
+| Variant | Trades | Win% | PF | Total P&L | Return | MaxDD | Sharpe |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| **Track 1: filters on existing breakout signal** |
+| baseline (no filter)  | 20 | 0.0% | 0.00 | -$179.95 | -18.00% | -19.0% | 2.14 |
+| +H4 trend | _TBD_ | | | | | | |
+| +H5 ATR-expansion | _TBD_ | | | | | | |
+| +H6 pullback | _TBD_ | | | | | | |
+| +H4+H5+H6 stacked | _TBD_ | | | | | | |
+| **Track 2: Opening Range Breakout** |
+| ORB baseline (R=1.0, 6-bar) | _TBD_ | | | | | | |
+| ORB R=2.0 | _TBD_ | | | | | | |
+| ORB 30-min range (3-bar) | _TBD_ | | | | | | |
+| ORB strict vol (2.0×) | _TBD_ | | | | | | |
+
+## Step 3 — Walkforward (survivors only)
+
+A variant survives Step 2 iff (a) trade count ≥ 30 AND (b) PF > 1.10. Walkforward each survivor on 6 yearly windows with 1000-resample bootstrap CI. Acceptance: PF 95% CI lower bound > 1.0 individually.
+
+_Pending Step 2 results._
+
+## Step 4 — Portfolio walkforward
+
+If any variant clears Step 3, re-enable in `multi_strategy.strategies` at \$1000 allocation (target uniform per-sleeve in paper-trading phase) with mean_reversion and overnight_drift each at \$1000 (idle \$2000 until TF/sentiment retunes). Run portfolio walkforward — must hold or improve current portfolio CI `[1.014, 1.190]`.
+
+_Pending Step 3._
+
+## Step 5 — Decision
+
+_Pending all steps._

--- a/trading_bot/strategy/strategies/__init__.py
+++ b/trading_bot/strategy/strategies/__init__.py
@@ -10,6 +10,9 @@ from trading_bot.strategy.strategies.trend_following import TrendFollowingStrate
 from trading_bot.strategy.strategies.breakout import BreakoutStrategy
 from trading_bot.strategy.strategies.sentiment_combo import SentimentComboStrategy
 from trading_bot.strategy.strategies.overnight_drift import OvernightDriftStrategy
+from trading_bot.strategy.strategies.opening_range_breakout import (
+    OpeningRangeBreakoutStrategy,
+)
 
 STRATEGY_REGISTRY: dict[str, type[StrategyBase]] = {
     "mean_reversion": MeanReversionStrategy,
@@ -17,6 +20,7 @@ STRATEGY_REGISTRY: dict[str, type[StrategyBase]] = {
     "breakout": BreakoutStrategy,
     "sentiment_combo": SentimentComboStrategy,
     "overnight_drift": OvernightDriftStrategy,
+    "opening_range_breakout": OpeningRangeBreakoutStrategy,
 }
 
 

--- a/trading_bot/strategy/strategies/breakout.py
+++ b/trading_bot/strategy/strategies/breakout.py
@@ -37,6 +37,17 @@ class BreakoutStrategy(StrategyBase):
         self._use_atr_stops: bool = bool(config.get("use_atr_stops", False))
         self._atr_period: int = int(config.get("atr_period", 14))
         self._atr_stop_mult: float = float(config.get("atr_stop_mult", 1.5))
+        # H4 — per-ticker trend filter (price must be above its own SMA)
+        self._require_trend_filter: bool = bool(config.get("require_trend_filter", False))
+        self._trend_sma_period: int = int(config.get("trend_sma_period", 50))
+        # H5 — ATR expansion filter (only enter when current ATR > avg ATR × mult)
+        self._require_atr_expansion: bool = bool(config.get("require_atr_expansion", False))
+        self._atr_expansion_lookback: int = int(config.get("atr_expansion_lookback", 20))
+        self._atr_expansion_mult: float = float(config.get("atr_expansion_mult", 1.2))
+        # H6 — pullback entry: don't buy the breakout bar; wait for retest of level
+        self._pullback_entry: bool = bool(config.get("pullback_entry", False))
+        self._pullback_window_bars: int = int(config.get("pullback_window_bars", 12))
+        self._pullback_tolerance_pct: float = float(config.get("pullback_tolerance_pct", 0.005))
 
     def evaluate_entry(
         self,
@@ -56,19 +67,74 @@ class BreakoutStrategy(StrategyBase):
             df_daily.iloc[:-1] if len(df_daily) > self._breakout_period else df_daily,
             self._breakout_period,
         )
-        if current_price <= period_high:
-            return None
 
-        # Volume confirmation on 5-min bars
+        # Volume confirmation on 5-min bars (computed up-front; used by both
+        # immediate-entry and pullback-entry paths).
         if len(df_5min) < 21:
             return None
-        # ``rename`` returns a new lightweight wrapper (no row copy) — the
-        # caller's DataFrame is untouched, but we avoid a per-tick deep copy.
         df_e: pd.DataFrame = df_5min.rename(columns=str.lower)
         vol_avg: float = float(df_e["volume"].rolling(20).mean().iloc[-1])
         current_vol: float = float(df_e["volume"].iloc[-1])
         if vol_avg <= 0 or current_vol < self._volume_multiplier * vol_avg:
             return None
+
+        # H6 — Pullback entry: wait for a retest of the breakout level
+        # rather than buying the breakout bar itself. Diagnostic on
+        # 2020-2026 13-ETF showed buying the breakout bar = top-ticking.
+        if self._pullback_entry:
+            window: int = max(self._pullback_window_bars, 2)
+            if len(df_e) < window + 1:
+                return None
+            recent: pd.DataFrame = df_e.iloc[-window:]
+            # 1) Did the high get broken in the last `window` bars?
+            if float(recent["high"].max()) <= period_high:
+                return None
+            # 2) Has price pulled back to the breakout level?
+            tol: float = self._pullback_tolerance_pct
+            if current_price > period_high * (1.0 + tol):
+                return None  # still extended, no pullback yet
+            if current_price < period_high * (1.0 - tol):
+                return None  # broke down through the level — failed breakout
+            # 3) Current bar must show strength (close >= open)
+            last_bar = df_e.iloc[-1]
+            if float(last_bar["close"]) < float(last_bar["open"]):
+                return None
+        else:
+            # Original logic: enter on the breakout bar itself.
+            if current_price <= period_high:
+                return None
+
+        # H4 — Per-ticker trend filter: price must be above its own
+        # SMA at the most recent fully-closed daily bar.
+        if self._require_trend_filter:
+            n: int = self._trend_sma_period
+            if len(df_daily) < n + 1:
+                return None
+            sma: float = float(df_daily["close"].iloc[-(n + 1):-1].mean())
+            if current_price <= sma:
+                return None
+
+        # H5 — ATR expansion filter: current ATR must be >= mult × the
+        # mean ATR over the lookback window. Filters stale-range pops.
+        if self._require_atr_expansion:
+            current_atr: float | None = self._compute_atr(df_daily, self._atr_period)
+            if current_atr is None:
+                return None
+            lookback: int = self._atr_expansion_lookback
+            if len(df_daily) < self._atr_period + lookback + 1:
+                return None
+            atrs: list[float] = []
+            for i in range(lookback):
+                end: int = len(df_daily) - 1 - i
+                window_df: pd.DataFrame = df_daily.iloc[max(0, end - self._atr_period):end]
+                a: float | None = self._compute_atr(window_df, self._atr_period)
+                if a is not None:
+                    atrs.append(a)
+            if len(atrs) < lookback // 2:
+                return None
+            avg_atr: float = float(sum(atrs) / len(atrs))
+            if current_atr < self._atr_expansion_mult * avg_atr:
+                return None
 
         if self._use_atr_stops:
             atr: float | None = self._compute_atr(df_daily, self._atr_period)

--- a/trading_bot/strategy/strategies/opening_range_breakout.py
+++ b/trading_bot/strategy/strategies/opening_range_breakout.py
@@ -1,0 +1,230 @@
+"""Opening Range Breakout (ORB) strategy.
+
+Defines the opening range from the first ``range_bars`` 5-minute bars
+of the session (default 6 bars = 09:30-10:00 ET). Enters long on the
+first 5-minute bar after the range closes that breaks above the range
+high with a volume-confirmation check; stops at the range low; targets
+``target_r_multiple`` × range above the breakout. INTRADAY hold type so
+the backtester / live wind-down force-closes any unfilled exit at
+session end.
+
+Motivation: the prior breakout sleeve mixed a daily 20-day-high signal
+with 5-minute execution and produced 0 wins on 13-ETF 2020-2026. Using
+an intraday signal that already lives in the same timeframe as the
+execution avoids the systematic top-tick pathology.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date, datetime, time
+from typing import Any
+
+import pandas as pd
+
+from trading_bot.constants import TZ_EASTERN, HoldType
+from trading_bot.strategy.base import ExitSignal, StrategyBase, StrategyDecision
+from trading_bot.utils import coalesce
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+class OpeningRangeBreakoutStrategy(StrategyBase):
+    """Buy the breakout of the opening N-bar range; stop at range low."""
+
+    def __init__(self, config: dict[str, Any], **kwargs: Any) -> None:
+        super().__init__(
+            strategy_id="opening_range_breakout",
+            display_name="Opening Range Breakout",
+            config=config,
+            **kwargs,
+        )
+        self._max_positions: int = int(config.get("max_positions", 3))
+        # Opening range: first N 5-min bars. 6 = 09:30-10:00 ET.
+        self._range_bars: int = int(config.get("range_bars", 6))
+        # Entry must fire before this ET cutoff (skip late-day breakouts).
+        self._entry_cutoff: time = _parse_time(
+            str(config.get("entry_cutoff", "11:30"))
+        )
+        # Volume confirmation on the breakout bar.
+        self._volume_multiplier: float = float(config.get("volume_multiplier", 1.3))
+        # R-multiple target: target = orb_high + target_r × range.
+        self._target_r_multiple: float = float(config.get("target_r_multiple", 1.0))
+        # Per-trade equity risk for sizing — falls back through StrategyBase.
+        self._risk_per_trade_pct: float = float(config.get("risk_per_trade_pct", 0.02))
+        self._max_position_pct: float = float(config.get("max_position_pct", 0.33))
+        self._fractional_shares: bool = bool(config.get("fractional_shares", True))
+        # Skip entries when the opening range is < min_range_pct of price
+        # — too tight = noise, false signal.
+        self._min_range_pct: float = float(config.get("min_range_pct", 0.002))
+
+    def evaluate_entry(
+        self,
+        ticker: str,
+        exchange: str,
+        df_5min: pd.DataFrame,
+        df_daily: pd.DataFrame,
+        current_price: float,
+        available_cash: float,
+        sentiment_score: float | None = None,
+    ) -> StrategyDecision | None:
+        if df_5min is None or len(df_5min) < self._range_bars + 2:
+            return None
+        if available_cash <= 0 or current_price <= 0:
+            return None
+
+        df_e: pd.DataFrame = df_5min.rename(columns=str.lower)
+        last_dt: datetime | None = _to_et_datetime(df_e.index[-1])
+        if last_dt is None:
+            return None
+
+        # Time-of-day gates.
+        bar_t: time = last_dt.time()
+        if bar_t > self._entry_cutoff:
+            return None
+
+        today: date = last_dt.date()
+        today_bars: pd.DataFrame = df_e[
+            df_e.index.map(lambda ts: _to_et_date(ts) == today)
+        ]
+        if len(today_bars) < self._range_bars + 1:
+            # Range not yet defined or no breakout bar after range.
+            return None
+
+        # Current bar must be after the range bars (range_bars + 1th onward).
+        if today_bars.index[-1] != df_e.index[-1]:
+            return None
+        bars_so_far: int = len(today_bars)
+        if bars_so_far <= self._range_bars:
+            return None
+
+        # Define opening range from the first range_bars bars of today.
+        range_window: pd.DataFrame = today_bars.iloc[: self._range_bars]
+        orb_high: float = float(range_window["high"].max())
+        orb_low: float = float(range_window["low"].min())
+        range_size: float = orb_high - orb_low
+        if range_size <= 0:
+            return None
+        if range_size / current_price < self._min_range_pct:
+            return None  # too-tight range, skip
+
+        # Breakout: current price > range high.
+        if current_price <= orb_high:
+            return None
+
+        # Volume confirmation on the breakout bar vs prior 20 bars
+        # (or whatever's available — early-session bars use what we have).
+        vol_window: pd.Series = df_e["volume"].iloc[-21:-1]
+        if len(vol_window) < 5:
+            return None
+        vol_avg: float = float(vol_window.mean())
+        current_vol: float = float(df_e["volume"].iloc[-1])
+        if vol_avg <= 0 or current_vol < self._volume_multiplier * vol_avg:
+            return None
+
+        # Stops/targets anchored to the range.
+        stop_price: float = round(orb_low, 4)
+        target_price: float = round(
+            orb_high + self._target_r_multiple * range_size, 4
+        )
+
+        # Position sizing — cap by max_position_pct of allocation, then
+        # enforce risk_per_trade by trimming if stop distance is large.
+        shares: float = self._size_shares(
+            current_price, stop_price, available_cash,
+        )
+        if shares <= 0:
+            return None
+
+        logger.info(
+            "[%s] ORB entry: %s @ $%.2f range=[$%.2f, $%.2f] "
+            "tgt=$%.2f stop=$%.2f shares=%.4f vol_ratio=%.2f",
+            self.strategy_id, ticker, current_price, orb_low, orb_high,
+            target_price, stop_price, shares,
+            (current_vol / vol_avg) if vol_avg else 0.0,
+        )
+
+        return StrategyDecision(
+            ticker=ticker,
+            exchange=exchange,
+            direction="long",
+            shares=shares,
+            entry_price=current_price,
+            stop_price=stop_price,
+            target_price=target_price,
+            trail_pct=None,
+            hold_type=HoldType.INTRADAY,
+            strategy_id=self.strategy_id,
+            signals={
+                "orb_high": orb_high,
+                "orb_low": orb_low,
+                "range_size_pct": range_size / current_price,
+                "volume_ratio": (current_vol / vol_avg) if vol_avg else 0.0,
+            },
+            sentiment_score=sentiment_score,
+        )
+
+    def evaluate_exit(
+        self,
+        position: dict[str, Any],
+        current_price: float,
+        df_5min: pd.DataFrame | None = None,
+        df_daily: pd.DataFrame | None = None,
+    ) -> ExitSignal:
+        stop_price: float = float(coalesce(position, "stop_price", 0))
+        target_price: float = float(coalesce(position, "target_price", 0))
+
+        if stop_price > 0 and current_price <= stop_price:
+            return ExitSignal(
+                should_exit=True, reason="stop_loss",
+                is_emergency=True, use_market_order=True,
+            )
+        if target_price > 0 and current_price >= target_price:
+            return ExitSignal(should_exit=True, reason="take_profit")
+        # Intraday wind-down handled by the backtester / live wind-down loop.
+        return ExitSignal(should_exit=False)
+
+    def get_max_positions(self) -> int:
+        return self._max_positions
+
+    def _size_shares(
+        self, entry_price: float, stop_price: float, available_cash: float,
+    ) -> float:
+        """Size by risk-per-trade, capped by max_position_pct."""
+        if entry_price <= 0 or available_cash <= 0:
+            return 0.0
+        max_spend: float = available_cash * self._max_position_pct
+        risk_dollars: float = available_cash * self._risk_per_trade_pct
+        per_share_risk: float = max(entry_price - stop_price, 0.01)
+        risk_shares: float = risk_dollars / per_share_risk
+        cap_shares: float = max_spend / entry_price
+        shares: float = min(risk_shares, cap_shares)
+        if self._fractional_shares:
+            return round(max(shares, 0.0), 4)
+        return float(int(max(shares, 0.0)))
+
+
+def _parse_time(value: str) -> time:
+    parts = value.split(":")
+    if len(parts) != 2:
+        raise ValueError(f"Invalid time string '{value}', expected HH:MM")
+    return time(int(parts[0]), int(parts[1]))
+
+
+def _to_et_datetime(ts: Any) -> datetime | None:
+    if ts is None:
+        return None
+    dt = ts.to_pydatetime() if hasattr(ts, "to_pydatetime") else ts
+    if not isinstance(dt, datetime):
+        return None
+    if dt.tzinfo is not None:
+        try:
+            return dt.astimezone(TZ_EASTERN)
+        except Exception:
+            return dt
+    return dt
+
+
+def _to_et_date(ts: Any) -> date | None:
+    dt = _to_et_datetime(ts)
+    return dt.date() if dt is not None else None

--- a/trading_bot/tests/test_strategies.py
+++ b/trading_bot/tests/test_strategies.py
@@ -267,6 +267,115 @@ class TestBreakout:
         strategy = BreakoutStrategy(config=_bo_config())
         assert strategy.get_max_positions() == 1
 
+    def test_h4_trend_filter_blocks_below_sma(self) -> None:
+        cfg = {**_bo_config(), "require_trend_filter": True, "trend_sma_period": 20}
+        strategy = BreakoutStrategy(config=cfg)
+        # Build a daily series with downtrend so SMA20 ends above current.
+        df = _make_bars(60, trend=-0.005)
+        period_high = float(df["high"].iloc[:-1].max())
+        # Even at a fresh "breakout" price, trend filter should block
+        # because current price < SMA(close, 20).
+        result = strategy.evaluate_entry(
+            "PLTR", "US", df, df, period_high * 1.01, 250.0,
+        )
+        assert result is None
+
+    def test_h4_trend_filter_disabled_lets_entry_attempt(self) -> None:
+        # Sanity: with the filter OFF, the same bars use the original
+        # gate (current_price <= period_high) so a price *below* the
+        # period high still returns None — confirms the new flag doesn't
+        # accidentally bypass anything.
+        strategy = BreakoutStrategy(config=_bo_config())
+        df = _make_bars(60, trend=-0.005)
+        result = strategy.evaluate_entry("PLTR", "US", df, df, 1.0, 250.0)
+        assert result is None
+
+    def test_h6_pullback_blocks_buying_the_breakout_bar(self) -> None:
+        # With pullback_entry=True, a price above the high should not
+        # trigger an entry on the breakout bar itself — must wait for
+        # retest within tolerance.
+        cfg = {**_bo_config(), "pullback_entry": True}
+        strategy = BreakoutStrategy(config=cfg)
+        df = _make_bars(60, trend=0.001)
+        period_high = float(df["high"].iloc[:-1].max())
+        far_above = period_high * 1.05  # 5% above — outside tolerance
+        result = strategy.evaluate_entry("PLTR", "US", df, df, far_above, 250.0)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Opening Range Breakout Strategy
+# ---------------------------------------------------------------------------
+
+
+def _orb_config() -> dict[str, Any]:
+    return {
+        "enabled": True,
+        "allocation_usd": 1000.0,
+        "max_positions": 3,
+        "range_bars": 6,
+        "entry_cutoff": "11:30",
+        "volume_multiplier": 1.3,
+        "target_r_multiple": 1.0,
+        "risk_per_trade_pct": 0.02,
+        "max_position_pct": 0.33,
+        "fractional_shares": True,
+        "min_range_pct": 0.002,
+    }
+
+
+class TestOpeningRangeBreakout:
+    def test_max_positions(self) -> None:
+        from trading_bot.strategy.strategies.opening_range_breakout import (
+            OpeningRangeBreakoutStrategy,
+        )
+        strategy = OpeningRangeBreakoutStrategy(config=_orb_config())
+        assert strategy.get_max_positions() == 3
+
+    def test_exit_on_stop(self) -> None:
+        from trading_bot.strategy.strategies.opening_range_breakout import (
+            OpeningRangeBreakoutStrategy,
+        )
+        strategy = OpeningRangeBreakoutStrategy(config=_orb_config())
+        position = {"entry_price": 10.10, "stop_price": 10.00, "target_price": 10.20}
+        signal = strategy.evaluate_exit(position, 9.99)
+        assert signal.should_exit is True
+        assert signal.reason == "stop_loss"
+        assert signal.is_emergency is True
+
+    def test_exit_on_target(self) -> None:
+        from trading_bot.strategy.strategies.opening_range_breakout import (
+            OpeningRangeBreakoutStrategy,
+        )
+        strategy = OpeningRangeBreakoutStrategy(config=_orb_config())
+        position = {"entry_price": 10.10, "stop_price": 10.00, "target_price": 10.20}
+        signal = strategy.evaluate_exit(position, 10.21)
+        assert signal.should_exit is True
+        assert signal.reason == "take_profit"
+
+    def test_no_exit_in_range(self) -> None:
+        from trading_bot.strategy.strategies.opening_range_breakout import (
+            OpeningRangeBreakoutStrategy,
+        )
+        strategy = OpeningRangeBreakoutStrategy(config=_orb_config())
+        position = {"entry_price": 10.10, "stop_price": 10.00, "target_price": 10.20}
+        signal = strategy.evaluate_exit(position, 10.15)
+        assert signal.should_exit is False
+
+    def test_no_entry_with_insufficient_bars(self) -> None:
+        from trading_bot.strategy.strategies.opening_range_breakout import (
+            OpeningRangeBreakoutStrategy,
+        )
+        strategy = OpeningRangeBreakoutStrategy(config=_orb_config())
+        # Only 5 bars — strategy needs range_bars + 2 minimum.
+        df = _make_bars(5)
+        result = strategy.evaluate_entry("PLTR", "US", df, df, 10.0, 1000.0)
+        assert result is None
+
+    def test_registry_includes_orb(self) -> None:
+        from trading_bot.strategy.strategies import STRATEGY_REGISTRY
+        assert "opening_range_breakout" in STRATEGY_REGISTRY
+
 
 # ---------------------------------------------------------------------------
 # Sentiment Combo Strategy


### PR DESCRIPTION
## Summary

- Dormant infrastructure from the 2026-05-02 breakout retune attempt ([TODO A](../blob/main/trading_bot/docs/breakout_retune/2026-05-02_postmortem.md)). Both tracks failed acceptance bar; this PR keeps the code behind opt-in flags so future attempts don't have to rebuild it.
- **Live config.yaml unchanged. Breakout sleeve remains disabled.**
- Zero risk to live trading: every new flag defaults to `false` and the new strategy class is not added to `multi_strategy.strategies`.

### Why shelved

| Track | Variants | Best result |
|---|---|---|
| 1 — filter stack on existing signal (H4 trend / H5 ATR-expansion / H6 pullback) | 5 | **PF 0.00** with 0-20 trades; filters either redundant or zero-out signal |
| 2 — Opening Range Breakout architecture pivot | 4 | **PF 0.95** with 2981 trades — statistically robust negative EV |

ORB on broad ETFs in 2020-2026: 2945/2981 trades exit at EOD close; only 2 take_profit hits in 5.7 years. The intraday breakout signal does NOT generate follow-through on broad ETFs in this regime. R=1 vs R=2 produced byte-identical results — target/stop tweaks can't help.

### Code changes

- [breakout.py](trading_bot/strategy/strategies/breakout.py): adds `require_trend_filter`, `require_atr_expansion`, `pullback_entry` flags + tuning params (all default `false`)
- [opening_range_breakout.py](trading_bot/strategy/strategies/opening_range_breakout.py): new `OpeningRangeBreakoutStrategy` class
- [strategies/__init__.py](trading_bot/strategy/strategies/__init__.py): registers ORB in `STRATEGY_REGISTRY`
- [test_strategies.py](trading_bot/tests/test_strategies.py): 9 new unit tests (55/55 pass)
- [docs/breakout_retune/2026-05-02_postmortem.md](trading_bot/docs/breakout_retune/2026-05-02_postmortem.md): full diagnostic + A/B + lessons

### If revisited

- Try ORB on high-momentum single stocks (NVDA / TSLA / COIN), not diversified ETFs — mega-cap individual names trend more intraday
- Use fractional-of-range stops/targets (e.g. 0.3× / 0.5×) so they fire intraday instead of sitting dormant
- See `trading_bot/docs/breakout_retune/2026-05-02_postmortem.md` for the structural insights

## Test plan

- [x] 55/55 unit tests pass (`pytest trading_bot/tests/test_strategies.py`)
- [x] Live config.yaml verified unchanged
- [x] Smoke test: `create_strategies()` returns expected sleeves with new flag combinations