### PR TITLE
feat(calendar_overlay): add turn-of-month, FOMC, OPEX, pre-long-weekend overlays (ai-broker#47)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -180,6 +180,39 @@ event_gate:
     - "2026-12-16"
 
 # -----------------------------------------------------------------------------
+# Calendar-Effect Overlay (research, ai-broker#47)
+# -----------------------------------------------------------------------------
+# Sizing multipliers and entry blocks based on persistent calendar
+# anomalies (turn-of-month, FOMC drift, OPEX, pre-long-weekend). All
+# overlays ship DISABLED — flip on individually after passing the per-
+# overlay A/B acceptance bar in the issue. Multipliers compose
+# multiplicatively and clamp to [0.0, 2.0].
+calendar_overlay:
+  enabled: false                      # master switch
+  turn_of_month:
+    enabled: false
+    days_before_month_end: 4
+    days_after_month_start: 3
+    long_multiplier: 1.2
+    short_multiplier: 0.8
+    applies_to: ["mean_reversion", "overnight_drift"]
+  fomc_drift:
+    enabled: false
+    hours_before_announcement: 24
+    long_multiplier: 1.3
+    applies_to: ["overnight_drift"]
+  pre_long_weekend:
+    enabled: false
+    min_weekend_days: 3
+    block_strategies: ["overnight_drift"]
+  opex:
+    enabled: false
+    weekday: 4                        # Friday
+    week_of_month: 3                  # 3rd Friday
+    multiplier: 0.7
+    applies_to: ["mean_reversion", "overnight_drift"]
+
+# -----------------------------------------------------------------------------
 # Watchlist Quality Criteria
 # -----------------------------------------------------------------------------
 watchlist_criteria:

--- a/scripts/run_calendar_overlay_ab.py
+++ b/scripts/run_calendar_overlay_ab.py
@@ -1,0 +1,195 @@
+"""A/B harness for the calendar-effect overlay (issue ai-broker#47).
+
+Runs six backtests against the 13-ETF universe over 2020-07-27 to
+2026-04-16 (the issue's specified window):
+
+  1. baseline  — overlay disabled (--no-calendar-overlay)
+  2. turn_of_month only
+  3. fomc_drift only
+  4. pre_long_weekend only
+  5. opex only
+  6. composite — all four overlays enabled
+
+Per-overlay config is written to a temp YAML so the live config.yaml is
+never mutated. Backtest stdout is captured to per-run log files; the
+JSON result paths emitted by the backtester are gathered for reporting.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+
+PROJECT_ROOT: Path = Path(__file__).resolve().parents[1]
+REPORTS_DIR: Path = PROJECT_ROOT / "backtest_results" / "calendar_overlay_ab"
+
+UNIVERSE: str = "SPY,QQQ,XLF,XLK,XLE,XLV,XLI,XLY,XLP,XLU,XLB,XLRE,XLC"
+DATE_FROM: str = "2020-07-27"
+DATE_TO: str = "2026-04-16"
+
+
+@dataclass(frozen=True)
+class RunSpec:
+    name: str
+    overrides: dict
+    no_overlay_flag: bool = False
+
+
+def _enable(only: str | None) -> dict:
+    """Return calendar_overlay block with master on and ``only`` enabled."""
+    base = {
+        "calendar_overlay": {
+            "enabled": True,
+            "turn_of_month": {
+                "enabled": only == "turn_of_month",
+                "days_before_month_end": 4,
+                "days_after_month_start": 3,
+                "long_multiplier": 1.2,
+                "short_multiplier": 0.8,
+                "applies_to": ["mean_reversion", "overnight_drift"],
+            },
+            "fomc_drift": {
+                "enabled": only == "fomc_drift",
+                "hours_before_announcement": 24,
+                "long_multiplier": 1.3,
+                "applies_to": ["overnight_drift"],
+            },
+            "pre_long_weekend": {
+                "enabled": only == "pre_long_weekend",
+                "min_weekend_days": 4,  # see PR notes — 4 = true long weekend
+                "block_strategies": ["overnight_drift"],
+            },
+            "opex": {
+                "enabled": only == "opex",
+                "weekday": 4,
+                "week_of_month": 3,
+                "multiplier": 0.7,
+                "applies_to": ["mean_reversion", "overnight_drift"],
+            },
+        }
+    }
+    if only == "all":
+        for k in ("turn_of_month", "fomc_drift", "pre_long_weekend", "opex"):
+            base["calendar_overlay"][k]["enabled"] = True
+    return base
+
+
+RUNS: list[RunSpec] = [
+    RunSpec("baseline", {}, no_overlay_flag=True),
+    RunSpec("turn_of_month", _enable("turn_of_month")),
+    RunSpec("fomc_drift", _enable("fomc_drift")),
+    RunSpec("pre_long_weekend", _enable("pre_long_weekend")),
+    RunSpec("opex", _enable("opex")),
+    RunSpec("composite_all", _enable("all")),
+]
+
+
+def _write_temp_config(name: str, overrides: dict) -> Path:
+    src: Path = PROJECT_ROOT / "config.yaml"
+    with src.open() as f:
+        cfg = yaml.safe_load(f)
+    if overrides:
+        merged = copy.deepcopy(cfg)
+        for k, v in overrides.items():
+            merged[k] = v
+    else:
+        merged = cfg
+    REPORTS_DIR.mkdir(parents=True, exist_ok=True)
+    out: Path = REPORTS_DIR / f"config_{name}.yaml"
+    with out.open("w") as f:
+        yaml.safe_dump(merged, f, sort_keys=False)
+    return out
+
+
+def _run_one(spec: RunSpec) -> dict:
+    cfg_path: Path = _write_temp_config(spec.name, spec.overrides)
+    log_path: Path = REPORTS_DIR / f"{spec.name}.log"
+    cmd: list[str] = [
+        sys.executable, "-m", "trading_bot.multi_strategy_backtest",
+        "--from", DATE_FROM, "--to", DATE_TO,
+        "--multi-intraday",
+        "--tickers", UNIVERSE,
+        "--config", str(cfg_path),
+        # Daily-bar cache only covers Dec 2025+; running the regime
+        # filter against a 2020-2026 window would block every entry on
+        # 2020-2025 for lack of SMA50 history. The A/B is on the
+        # overlay's effect, not the regime filter, so disable it.
+        "--no-regime-filter",
+    ]
+    if spec.no_overlay_flag:
+        cmd.append("--no-calendar-overlay")
+
+    print(f"\n=== {spec.name} ===\n  cmd: {' '.join(cmd)}", flush=True)
+    with log_path.open("w") as logf:
+        proc = subprocess.run(
+            cmd, cwd=PROJECT_ROOT, stdout=logf, stderr=subprocess.STDOUT,
+            text=True,
+        )
+    print(f"  exit={proc.returncode}  log={log_path}", flush=True)
+
+    output: str = log_path.read_text()
+    json_match = re.search(r"Results saved to:\s*(\S+\.json)", output)
+    json_path: Path | None = Path(json_match.group(1)) if json_match else None
+
+    summary: dict = {
+        "name": spec.name,
+        "exit_code": proc.returncode,
+        "log": str(log_path),
+        "json": str(json_path) if json_path else None,
+    }
+    if json_path and json_path.exists():
+        try:
+            with json_path.open() as f:
+                data = json.load(f)
+            summary["totals"] = _extract_totals(data)
+        except Exception as e:
+            summary["totals_error"] = str(e)
+    return summary
+
+
+def _extract_totals(data: dict) -> dict:
+    """Pull headline metrics per strategy from the backtester JSON."""
+    out: dict = {}
+    for s in data.get("strategies", []) or []:
+        sid = s.get("strategy_id")
+        if not sid:
+            continue
+        out[sid] = {
+            "trades": s.get("total_trades"),
+            "wins": s.get("wins"),
+            "return_pct": s.get("return_pct"),
+            "sharpe": s.get("sharpe_approx"),
+            "max_dd_pct": s.get("max_drawdown_pct"),
+            "win_rate": s.get("win_rate"),
+            "profit_factor": s.get("profit_factor"),
+        }
+    return out
+
+
+def main() -> None:
+    REPORTS_DIR.mkdir(parents=True, exist_ok=True)
+    summary_path: Path = REPORTS_DIR / "summary.json"
+
+    summaries: list[dict] = []
+    for spec in RUNS:
+        summaries.append(_run_one(spec))
+        with summary_path.open("w") as f:
+            json.dump(summaries, f, indent=2, default=str)
+
+    print(f"\n=== A/B summary written to {summary_path} ===")
+    for s in summaries:
+        print(f"\n[{s['name']}] exit={s['exit_code']}")
+        for sid, m in (s.get("totals") or {}).items():
+            print(f"  {sid}: {m}")
+
+
+if __name__ == "__main__":
+    main()

--- a/trading_bot/data/fomc_calendar.py
+++ b/trading_bot/data/fomc_calendar.py
@@ -1,0 +1,71 @@
+"""FOMC announcement-day calendar — hardcoded multi-year list.
+
+Used by the calendar-effect overlay (``calendar_overlay.is_fomc_window``)
+to detect the 24h drift window before each scheduled FOMC announcement.
+
+The legacy gate in ``event_calendar.py`` reads FOMC dates from
+``config.yaml`` for a single-year skip/reduce action. This module is the
+multi-year source for the *overlay* and does not duplicate the config
+plumbing — overlays are a research-only knob, so a hardcoded list keeps
+the code path stable across years and easier to audit.
+
+Refresh procedure (annual, target ~ September each year):
+
+    gh issue create -t "Refresh FOMC dates for $(date +%Y+1)" \
+        -b "Update _FOMC_DATES in trading_bot/data/fomc_calendar.py from \
+            https://www.federalreserve.gov/monetarypolicy/fomccalendars.htm"
+
+Source: https://www.federalreserve.gov/monetarypolicy/fomccalendars.htm
+Each year holds 8 scheduled meetings. Announcement day = the second day
+of each two-day meeting (post-statement Wednesday for most meetings).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+_FOMC_DATES: list[str] = [
+    # 2020
+    "2020-01-29", "2020-03-18", "2020-04-29", "2020-06-10",
+    "2020-07-29", "2020-09-16", "2020-11-05", "2020-12-16",
+    # 2021
+    "2021-01-27", "2021-03-17", "2021-04-28", "2021-06-16",
+    "2021-07-28", "2021-09-22", "2021-11-03", "2021-12-15",
+    # 2022
+    "2022-01-26", "2022-03-16", "2022-05-04", "2022-06-15",
+    "2022-07-27", "2022-09-21", "2022-11-02", "2022-12-14",
+    # 2023
+    "2023-02-01", "2023-03-22", "2023-05-03", "2023-06-14",
+    "2023-07-26", "2023-09-20", "2023-11-01", "2023-12-13",
+    # 2024
+    "2024-01-31", "2024-03-20", "2024-05-01", "2024-06-12",
+    "2024-07-31", "2024-09-18", "2024-11-07", "2024-12-18",
+    # 2025
+    "2025-01-29", "2025-03-19", "2025-05-07", "2025-06-18",
+    "2025-07-30", "2025-09-17", "2025-10-29", "2025-12-10",
+    # 2026
+    "2026-01-28", "2026-03-18", "2026-05-06", "2026-06-17",
+    "2026-07-29", "2026-09-16", "2026-11-04", "2026-12-16",
+    # 2027 — placeholder until Fed publishes; refresh annually.
+    "2027-01-27", "2027-03-17", "2027-04-28", "2027-06-16",
+    "2027-07-28", "2027-09-22", "2027-11-03", "2027-12-15",
+]
+
+
+def get_fomc_dates() -> list[date]:
+    """Return all known FOMC announcement dates as ``date`` objects."""
+    return [date.fromisoformat(d) for d in _FOMC_DATES]
+
+
+def log_staleness(today: date) -> None:
+    """Emit a startup log line so missing future dates are visible."""
+    future: list[date] = [d for d in get_fomc_dates() if d >= today]
+    logger.info(
+        "FOMC dates loaded: %d future dates remaining (last=%s)",
+        len(future),
+        future[-1].isoformat() if future else "n/a",
+    )

--- a/trading_bot/data/holiday_calendar.py
+++ b/trading_bot/data/holiday_calendar.py
@@ -1,0 +1,119 @@
+"""NYSE holiday calendar wrapper for the calendar-effect overlay.
+
+The repo already declares NYSE holidays in ``config.yaml`` under
+``holidays.us_<year>``. This module wraps that source plus an in-package
+multi-year fallback so the overlay can answer:
+
+* ``is_holiday(d)`` — closed-session day?
+* ``is_trading_day(d)`` — weekday and not a holiday?
+* ``next_trading_day(d)`` / ``prev_trading_day(d)``
+
+Keeping the wrapper config-aware mirrors the pattern in
+``event_calendar.py`` and avoids pulling in ``pandas_market_calendars``
+as a new dependency for one small calendar lookup.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date, timedelta
+from typing import Any
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+# NYSE full-close holidays. Update annually; config can override.
+_FALLBACK_HOLIDAYS: dict[int, list[str]] = {
+    2020: [
+        "2020-01-01", "2020-01-20", "2020-02-17", "2020-04-10",
+        "2020-05-25", "2020-07-03", "2020-09-07", "2020-11-26",
+        "2020-12-25",
+    ],
+    2021: [
+        "2021-01-01", "2021-01-18", "2021-02-15", "2021-04-02",
+        "2021-05-31", "2021-07-05", "2021-09-06", "2021-11-25",
+        "2021-12-24",
+    ],
+    2022: [
+        "2022-01-17", "2022-02-21", "2022-04-15", "2022-05-30",
+        "2022-06-20", "2022-07-04", "2022-09-05", "2022-11-24",
+        "2022-12-26",
+    ],
+    2023: [
+        "2023-01-02", "2023-01-16", "2023-02-20", "2023-04-07",
+        "2023-05-29", "2023-06-19", "2023-07-04", "2023-09-04",
+        "2023-11-23", "2023-12-25",
+    ],
+    2024: [
+        "2024-01-01", "2024-01-15", "2024-02-19", "2024-03-29",
+        "2024-05-27", "2024-06-19", "2024-07-04", "2024-09-02",
+        "2024-11-28", "2024-12-25",
+    ],
+    2025: [
+        "2025-01-01", "2025-01-09", "2025-01-20", "2025-02-17",
+        "2025-04-18", "2025-05-26", "2025-06-19", "2025-07-04",
+        "2025-09-01", "2025-11-27", "2025-12-25",
+    ],
+    2026: [
+        "2026-01-01", "2026-01-19", "2026-02-16", "2026-04-03",
+        "2026-05-25", "2026-06-19", "2026-07-03", "2026-09-07",
+        "2026-11-26", "2026-12-25",
+    ],
+    2027: [
+        "2027-01-01", "2027-01-18", "2027-02-15", "2027-03-26",
+        "2027-05-31", "2027-06-18", "2027-07-05", "2027-09-06",
+        "2027-11-25", "2027-12-24",
+    ],
+}
+
+
+class HolidayCalendar:
+    """NYSE holiday calendar with optional config-driven override."""
+
+    def __init__(self, raw_config: dict[str, Any] | None = None) -> None:
+        self._raw_config: dict[str, Any] = raw_config or {}
+        self._cache: set[date] = set()
+        self._loaded_years: set[int] = set()
+
+    def _load_year(self, year: int) -> None:
+        if year in self._loaded_years:
+            return
+        section: dict[str, Any] = self._raw_config.get("holidays", {}) or {}
+        cfg_dates: list[Any] | None = section.get(f"us_{year}")
+        if cfg_dates:
+            for s in cfg_dates:
+                try:
+                    self._cache.add(date.fromisoformat(str(s)))
+                except ValueError:
+                    logger.warning("Invalid holiday date in config: %r", s)
+        else:
+            for s in _FALLBACK_HOLIDAYS.get(year, []):
+                self._cache.add(date.fromisoformat(s))
+        self._loaded_years.add(year)
+
+    def is_holiday(self, d: date) -> bool:
+        self._load_year(d.year)
+        return d in self._cache
+
+    def is_trading_day(self, d: date) -> bool:
+        return d.weekday() < 5 and not self.is_holiday(d)
+
+    def next_trading_day(self, d: date) -> date:
+        nxt: date = d + timedelta(days=1)
+        while not self.is_trading_day(nxt):
+            nxt += timedelta(days=1)
+        return nxt
+
+    def prev_trading_day(self, d: date) -> date:
+        prv: date = d - timedelta(days=1)
+        while not self.is_trading_day(prv):
+            prv -= timedelta(days=1)
+        return prv
+
+    def days_until_next_session(self, d: date) -> int:
+        """Calendar days from *d* (inclusive end of session) to the next
+        open session. ``1`` for a normal Mon–Thu, ``3`` for a Friday into
+        a normal Monday, ≥ 4 for a long weekend.
+        """
+        nxt: date = self.next_trading_day(d)
+        return (nxt - d).days

--- a/trading_bot/docs/calendar_overlay/2026-05-03_ab_report.md
+++ b/trading_bot/docs/calendar_overlay/2026-05-03_ab_report.md
@@ -1,0 +1,98 @@
+# Calendar-effect overlay A/B — ai-broker#47
+
+**Window:** 2020-07-27 → 2026-04-16 (~5.7 years, 1,438 trading days)
+**Universe:** SPY, QQQ, XLF, XLK, XLE, XLV, XLI, XLY, XLP, XLU, XLB, XLRE, XLC
+**Mode:** `--multi-intraday` with `--no-regime-filter` (daily-bar cache only covers Dec 2025+; running regime filter would have blocked every entry pre-2025 for lack of SMA50 history)
+**Strategies enabled:** mean_reversion, overnight_drift
+
+## Acceptance bar (per the issue)
+
+Per-overlay individually:
+- Sharpe improvement ≥ +0.05 vs. baseline
+- No degradation in max drawdown
+- Trade count change within ±10%
+- (Yearly-window OOS check: not done in this aggregate sweep)
+
+Composite (all-overlays-on):
+- Sharpe improvement ≥ +0.10 vs. baseline
+
+## Baseline
+
+| Strategy | Trades | Win% | Return | Sharpe | Max DD | PF |
+|---|---:|---:|---:|---:|---:|---:|
+| mean_reversion | 478 | 55.9% | +71.33% | 4.23 | 26.96% | 1.23 |
+| overnight_drift | 4,272 | 52.2% | -0.00% | -0.27 | 31.47% | 1.00 |
+
+## Per-overlay deltas vs. baseline
+
+**Δ formatting:** positive Sharpe = better, negative MaxDD = better.
+
+### turn_of_month  ❌ FAIL
+
+Applies to: mean_reversion, overnight_drift
+
+| Strategy | ΔTrades | ΔReturn | ΔSharpe | ΔMaxDD |
+|---|---:|---:|---:|---:|
+| mean_reversion | 0 | +0.44 pp | **−0.04** | +0.04 pp |
+| overnight_drift | 0 | −1.82 pp | +0.01 | +0.86 pp |
+
+Fails Sharpe ≥ +0.05 on both sleeves; max DD slightly worse on both. **Do not enable.**
+
+### fomc_drift  ❌ FAIL
+
+Applies to: overnight_drift only
+
+| Strategy | ΔTrades | ΔReturn | ΔSharpe | ΔMaxDD |
+|---|---:|---:|---:|---:|
+| overnight_drift | −46 (−1.1%) | +0.95 pp | +0.01 | −0.02 pp |
+
+Sharpe delta well below +0.05 bar. **Do not enable.**
+
+### pre_long_weekend  ✅ PASS
+
+Block on: overnight_drift
+
+| Strategy | ΔTrades | ΔReturn | ΔSharpe | ΔMaxDD |
+|---|---:|---:|---:|---:|
+| overnight_drift | −117 (−2.7%) | **+6.30 pp** | **+0.08** | −0.13 pp |
+
+Meets all individual bars: Sharpe +0.08 (≥ +0.05), MaxDD strictly better, trade count change well within ±10%. **Recommend enabling for overnight_drift.**
+
+### opex  ❌ FAIL
+
+Applies to: mean_reversion, overnight_drift
+
+| Strategy | ΔTrades | ΔReturn | ΔSharpe | ΔMaxDD |
+|---|---:|---:|---:|---:|
+| mean_reversion | 0 | −0.87 pp | +0.02 | **−1.21 pp** |
+| overnight_drift | 0 | +0.70 pp | +0.01 | −0.95 pp |
+
+Drawdown improvements, but Sharpe deltas miss the +0.05 bar. **Do not enable.**
+
+## Composite (all four enabled)
+
+| Strategy | ΔTrades | ΔReturn | ΔSharpe | ΔMaxDD |
+|---|---:|---:|---:|---:|
+| mean_reversion | 0 | −0.43 pp | −0.02 | **−1.37 pp** |
+| overnight_drift | −163 (−3.8%) | +4.66 pp | +0.10 | +0.73 pp |
+
+mean_reversion Sharpe slightly down; overnight_drift hits the +0.10 composite bar but max DD widens. The composite is doing one thing well (overnight_drift Sharpe lift) and that gain is essentially the pre_long_weekend overlay alone — turn_of_month and opex are dragging the composite without adding edge.
+
+## Verdict
+
+Only **pre_long_weekend** clears the per-overlay acceptance bar. Everything else either degrades Sharpe or fails to meet +0.05. Per the issue's "do not iterate" rule, the recommendation is:
+
+| Overlay | Action |
+|---|---|
+| pre_long_weekend | **Enable** for overnight_drift in a separate PR |
+| turn_of_month | Mark `enabled: false` permanently |
+| fomc_drift | Mark `enabled: false` permanently |
+| opex | Mark `enabled: false` permanently |
+
+The pre_long_weekend test used `min_weekend_days: 4` (true long weekends only) — see PR notes; with the spec default `3` a plain Fri→Mon weekend also fires, which would re-test as a different overlay.
+
+## Caveats
+
+1. The yearly-window OOS check from the issue's acceptance criteria is not in this sweep — only aggregate metrics. A pre-ship walkforward on pre_long_weekend would tighten the case.
+2. The `--no-regime-filter` flag was needed because daily-bar cache is sparse pre-2026; this is consistent across all six runs so the *deltas* are valid, but absolute returns are higher than they'd be live with the regime filter active.
+3. mean_reversion is unchanged for fomc_drift and pre_long_weekend (those overlays' `applies_to` / `block_strategies` exclude it). The shared overlays (turn_of_month, opex) do touch mean_reversion and degrade Sharpe slightly.

--- a/trading_bot/multi_strategy_backtest.py
+++ b/trading_bot/multi_strategy_backtest.py
@@ -37,9 +37,12 @@ from trading_bot.constants import (
     TICKER_EXCHANGE,
     TZ_EASTERN,
 )
+from trading_bot.data.fomc_calendar import get_fomc_dates
+from trading_bot.data.holiday_calendar import HolidayCalendar
 from trading_bot.data_cache import load_cached
 from trading_bot.execution.vol_target import vol_target_multiplier
-from trading_bot.strategy.base import ExitSignal, StrategyBase
+from trading_bot.strategy import calendar_overlay
+from trading_bot.strategy.base import ExitSignal, StrategyBase, StrategyDecision
 from trading_bot.strategy.strategies import create_strategies
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -155,8 +158,15 @@ class MultiStrategyBacktester:
         "NIO": 3.0,     # Less liquid, wider spread
     }
 
-    def __init__(self, config: Config) -> None:
+    def __init__(self, config: Config, calendar_overlay_enabled: bool = True) -> None:
         self._config = config
+        # When False, the overlay is bypassed entirely (clean A/B baseline).
+        # The default keeps live and backtest in sync — the overlay reads
+        # config.calendar_overlay.enabled, which ships False, so this flag
+        # only matters when the operator has flipped overlays on.
+        self._calendar_overlay_enabled: bool = calendar_overlay_enabled
+        self._holiday_calendar: HolidayCalendar = HolidayCalendar(config._raw)
+        self._fomc_dates: list[date] = get_fomc_dates()
         self._strategies: list[StrategyBase] = create_strategies(
             config.get_strategy_configs()
         )
@@ -254,6 +264,51 @@ class MultiStrategyBacktester:
         bps = self._get_slippage_bps(ticker)
         slippage = price * (bps / 10_000.0)
         return price + slippage if side == "buy" else price - slippage
+
+    def _calendar_overlay_blocks(
+        self,
+        decision: StrategyDecision,
+        bar_dt: datetime,
+    ) -> bool:
+        """Return True when the overlay vetoes *decision* outright."""
+        if not self._calendar_overlay_enabled:
+            return False
+        try:
+            return calendar_overlay.should_block_entry(
+                decision,
+                bar_dt,
+                self._config._raw,
+                holiday_calendar=self._holiday_calendar,
+            )
+        except Exception:
+            logger.warning(
+                "Calendar overlay block-check failed for %s/%s — passing through",
+                decision.strategy_id, decision.ticker, exc_info=True,
+            )
+            return False
+
+    def _calendar_overlay_multiplier(
+        self,
+        decision: StrategyDecision,
+        bar_dt: datetime,
+    ) -> float:
+        """Return the composed sizing multiplier (1.0 when overlay disabled)."""
+        if not self._calendar_overlay_enabled:
+            return 1.0
+        try:
+            return calendar_overlay.compute_size_multiplier(
+                decision,
+                bar_dt,
+                self._config._raw,
+                holiday_calendar=self._holiday_calendar,
+                fomc_dates=self._fomc_dates,
+            )
+        except Exception:
+            logger.warning(
+                "Calendar overlay multiplier lookup failed for %s/%s — using 1.0",
+                decision.strategy_id, decision.ticker, exc_info=True,
+            )
+            return 1.0
 
     @staticmethod
     def _compute_sentiment_proxy(df_daily: pd.DataFrame) -> float | None:
@@ -537,6 +592,20 @@ class MultiStrategyBacktester:
                             sentiment_score=sentiment,
                         )
                         if decision is not None and decision.shares > 0:
+                            if self._calendar_overlay_blocks(decision, current_time):
+                                continue
+                            ovl_mult = self._calendar_overlay_multiplier(
+                                decision, current_time,
+                            )
+                            if ovl_mult <= 0.0:
+                                continue
+                            if ovl_mult != 1.0:
+                                scaled = max(int(decision.shares * ovl_mult), 0)
+                                if scaled < 1:
+                                    continue
+                                decision = decision.__class__(
+                                    **{**decision.__dict__, "shares": scaled}
+                                )
                             fill_price = self._simulate_fill(
                                 bar_close, "buy", ticker,
                             )
@@ -1017,6 +1086,13 @@ class MultiStrategyBacktester:
                         sentiment_score=sentiment,
                     )
                     if decision is not None and decision.shares > 0:
+                        if self._calendar_overlay_blocks(decision, current_time):
+                            continue
+                        ovl_mult = self._calendar_overlay_multiplier(
+                            decision, current_time,
+                        )
+                        if ovl_mult <= 0.0:
+                            continue
                         fill_price = self._simulate_fill(
                             bar_close, "buy", ticker,
                         )
@@ -1038,6 +1114,8 @@ class MultiStrategyBacktester:
                             fractional=False,
                             vol_multiplier=vt.multiplier,
                         )
+                        if ovl_mult != 1.0:
+                            shares = float(int(shares * ovl_mult))
                         if shares < 1:
                             continue
 
@@ -1348,6 +1426,11 @@ class MultiStrategyBacktester:
                     sentiment_score=sentiment,
                 )
                 if decision is not None and decision.shares > 0:
+                    if self._calendar_overlay_blocks(decision, bar_dt):
+                        continue
+                    ovl_mult = self._calendar_overlay_multiplier(decision, bar_dt)
+                    if ovl_mult <= 0.0:
+                        continue
                     fill_price = self._simulate_fill(bar_close, "buy", ticker)
 
                     # Use 5-min ATR for intraday stop/target sizing
@@ -1378,6 +1461,8 @@ class MultiStrategyBacktester:
                         fractional=True,
                         vol_multiplier=vt.multiplier,
                     )
+                    if ovl_mult != 1.0:
+                        shares = round(shares * ovl_mult, 4)
                     if shares <= 0.001:
                         continue
 
@@ -1665,6 +1750,12 @@ class MultiStrategyBacktester:
                     if decision is None or decision.shares <= 0:
                         continue
 
+                    if self._calendar_overlay_blocks(decision, bar_dt):
+                        continue
+                    ovl_mult = self._calendar_overlay_multiplier(decision, bar_dt)
+                    if ovl_mult <= 0.0:
+                        continue
+
                     fill_price = self._simulate_fill(bar_close, "buy", ticker)
                     atr_stop, atr_target, atr_trail, atr_activation = self._atr_adjusted_stops(
                         fill_price, df_slice, strat.strategy_id,
@@ -1691,6 +1782,8 @@ class MultiStrategyBacktester:
                         fractional=True,
                         vol_multiplier=vt.multiplier,
                     )
+                    if ovl_mult != 1.0:
+                        shares = round(shares * ovl_mult, 4)
                     if shares <= 0.001:
                         continue
                     cost = fill_price * shares
@@ -2024,6 +2117,12 @@ async def main() -> None:
         help="Disable market regime filter (daily mode)",
     )
     parser.add_argument(
+        "--no-calendar-overlay", action="store_true",
+        help="Bypass calendar-effect overlay (clean A/B baseline). Live + "
+             "backtest read calendar_overlay.enabled from config; this flag "
+             "forces it off in backtest regardless.",
+    )
+    parser.add_argument(
         "--spy", action="store_true",
         help="Use SPY 1-min intraday CSV data (resampled to 5-min)",
     )
@@ -2094,7 +2193,10 @@ async def main() -> None:
     async def _run_window(d1: date, d2: date) -> MultiStrategyResult:
         # Each window needs a fresh engine so per-strategy state
         # (cash, peak equity, cooldowns) doesn't leak across windows.
-        window_engine = MultiStrategyBacktester(config)
+        window_engine = MultiStrategyBacktester(
+            config,
+            calendar_overlay_enabled=not args.no_calendar_overlay,
+        )
         if args.strategies:
             selected = set(s.strip() for s in args.strategies.split(","))
             window_engine._strategies = [

--- a/trading_bot/strategy/calendar_overlay.py
+++ b/trading_bot/strategy/calendar_overlay.py
@@ -1,0 +1,309 @@
+"""Calendar-effect overlay — sizing multipliers and entry blocks.
+
+This module is an *overlay* on top of existing strategies. It does not
+generate entries of its own. After a strategy returns a
+``StrategyDecision``, ``StrategyManager`` (live) and the backtester run
+the decision through:
+
+* :func:`compute_size_multiplier` — scales ``shares`` by a composed
+  multiplier (turn-of-month × FOMC × OPEX), capped to ``[0.0, 2.0]``.
+* :func:`should_block_entry` — drops the decision entirely (e.g.
+  ``overnight_drift`` before a long weekend).
+
+Each sub-overlay has its own ``enabled`` flag and an opt-in
+``applies_to``/``block_strategies`` list — overlays designed against
+one strategy archetype must not silently affect another. A master
+``calendar_overlay.enabled`` switch disables every sub-overlay
+regardless of its own flag.
+
+Design notes
+------------
+
+Per the issue spec (#47), this code path is enabled per-overlay only
+after the A/B acceptance bar passes. The default config ships every
+sub-overlay disabled.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import replace
+from datetime import date, datetime, timedelta
+from typing import Any
+
+from trading_bot.data.holiday_calendar import HolidayCalendar
+from trading_bot.strategy.base import StrategyDecision
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+_MIN_MULTIPLIER: float = 0.0
+_MAX_MULTIPLIER: float = 2.0
+
+
+# ---------------------------------------------------------------------------
+# Predicates
+# ---------------------------------------------------------------------------
+
+
+def is_turn_of_month(
+    d: date,
+    holiday_calendar: HolidayCalendar,
+    days_before_month_end: int = 4,
+    days_after_month_start: int = 3,
+) -> bool:
+    """Return True if *d* is in the turn-of-month window.
+
+    The window is counted in **trading days**, not calendar days. The
+    last ``days_before_month_end`` trading days of the prior month and
+    the first ``days_after_month_start`` trading days of *d*'s month
+    both count as turn-of-month.
+
+    A non-trading day (weekend, holiday) is never turn-of-month.
+    """
+    if not holiday_calendar.is_trading_day(d):
+        return False
+
+    # First N trading days of d's month.
+    cur: date = date(d.year, d.month, 1)
+    seen: int = 0
+    while cur.month == d.month and seen < days_after_month_start:
+        if holiday_calendar.is_trading_day(cur):
+            seen += 1
+            if cur == d:
+                return True
+        cur += timedelta(days=1)
+
+    # Last N trading days of d's month.
+    if d.month == 12:
+        next_month: date = date(d.year + 1, 1, 1)
+    else:
+        next_month = date(d.year, d.month + 1, 1)
+    last_in_month: date = next_month - timedelta(days=1)
+    cur = last_in_month
+    seen = 0
+    while cur.month == d.month and seen < days_before_month_end:
+        if holiday_calendar.is_trading_day(cur):
+            seen += 1
+            if cur == d:
+                return True
+        cur -= timedelta(days=1)
+
+    return False
+
+
+def is_fomc_window(
+    dt: datetime,
+    fomc_dates: list[date],
+    hours_before_announcement: int = 24,
+) -> bool:
+    """Return True if *dt* is within ``hours_before_announcement`` of an
+    FOMC announcement.
+
+    Announcement is treated as 14:00 ET on the announcement day (the
+    statement release time used in the Lucca & Moench drift study).
+    *dt* must be timezone-aware; comparison uses absolute UTC instants.
+    """
+    if dt.tzinfo is None:
+        raise ValueError("is_fomc_window requires a timezone-aware datetime")
+    from zoneinfo import ZoneInfo
+
+    et: ZoneInfo = ZoneInfo("US/Eastern")
+    window: timedelta = timedelta(hours=hours_before_announcement)
+    for d in fomc_dates:
+        announcement: datetime = datetime(
+            d.year, d.month, d.day, 14, 0, 0, tzinfo=et,
+        )
+        if announcement - window <= dt < announcement:
+            return True
+    return False
+
+
+def is_pre_long_weekend(
+    d: date,
+    holiday_calendar: HolidayCalendar,
+    min_weekend_days: int = 3,
+) -> bool:
+    """Return True if *d* is the last session before a ≥ ``min_weekend_days``
+    closure (Mon holidays, Christmas, July 4, etc.).
+    """
+    if not holiday_calendar.is_trading_day(d):
+        return False
+    return holiday_calendar.days_until_next_session(d) >= min_weekend_days
+
+
+def is_opex_friday(
+    d: date,
+    weekday: int = 4,
+    week_of_month: int = 3,
+) -> bool:
+    """Return True if *d* is the configured OPEX day (default: 3rd Friday)."""
+    if d.weekday() != weekday:
+        return False
+    # Which occurrence of *weekday* within the month is *d*?
+    occurrence: int = (d.day - 1) // 7 + 1
+    return occurrence == week_of_month
+
+
+# ---------------------------------------------------------------------------
+# Composer
+# ---------------------------------------------------------------------------
+
+
+def _section(
+    config: dict[str, Any] | None,
+    key: str,
+) -> dict[str, Any]:
+    """Return the named sub-overlay block, or an empty dict."""
+    root: dict[str, Any] = (config or {}).get("calendar_overlay", {}) or {}
+    sub: dict[str, Any] = root.get(key, {}) or {}
+    return sub
+
+
+def _master_enabled(config: dict[str, Any] | None) -> bool:
+    root: dict[str, Any] = (config or {}).get("calendar_overlay", {}) or {}
+    return bool(root.get("enabled", False))
+
+
+def _applies_to(section: dict[str, Any], strategy_id: str) -> bool:
+    applies: list[str] = list(section.get("applies_to", []) or [])
+    return strategy_id in applies
+
+
+def compute_size_multiplier(
+    decision: StrategyDecision,
+    dt: datetime,
+    config: dict[str, Any] | None,
+    holiday_calendar: HolidayCalendar | None = None,
+    fomc_dates: list[date] | None = None,
+) -> float:
+    """Compose all enabled overlays into a single ``shares`` multiplier.
+
+    Overlays are multiplicative:
+    ``final = turn_of_month × fomc × opex``. The result is clamped to
+    ``[0.0, 2.0]``. Returns ``1.0`` when the master switch is off or
+    when no sub-overlay applies.
+    """
+    if not _master_enabled(config):
+        return 1.0
+    if dt.tzinfo is None:
+        raise ValueError("compute_size_multiplier requires a tz-aware datetime")
+
+    cal: HolidayCalendar = holiday_calendar or HolidayCalendar(config)
+    d: date = dt.date()
+    mult: float = 1.0
+
+    tom: dict[str, Any] = _section(config, "turn_of_month")
+    if tom.get("enabled", False) and _applies_to(tom, decision.strategy_id):
+        if is_turn_of_month(
+            d, cal,
+            days_before_month_end=int(tom.get("days_before_month_end", 4)),
+            days_after_month_start=int(tom.get("days_after_month_start", 3)),
+        ):
+            if decision.direction == "long":
+                m: float = float(tom.get("long_multiplier", 1.2))
+            else:
+                m = float(tom.get("short_multiplier", 0.8))
+            mult *= m
+            logger.info(
+                "[calendar_overlay] turn_of_month: %s_multiplier=%.2f applied to %s entry on %s",
+                decision.direction, m, decision.strategy_id, decision.ticker,
+            )
+
+    fomc: dict[str, Any] = _section(config, "fomc_drift")
+    if fomc.get("enabled", False) and _applies_to(fomc, decision.strategy_id):
+        dates: list[date] = fomc_dates if fomc_dates is not None else []
+        if dates and is_fomc_window(
+            dt, dates,
+            hours_before_announcement=int(fomc.get("hours_before_announcement", 24)),
+        ):
+            if decision.direction == "long":
+                m = float(fomc.get("long_multiplier", 1.3))
+                mult *= m
+                logger.info(
+                    "[calendar_overlay] fomc_drift: long_multiplier=%.2f applied to %s entry on %s",
+                    m, decision.strategy_id, decision.ticker,
+                )
+
+    opex: dict[str, Any] = _section(config, "opex")
+    if opex.get("enabled", False) and _applies_to(opex, decision.strategy_id):
+        if is_opex_friday(
+            d,
+            weekday=int(opex.get("weekday", 4)),
+            week_of_month=int(opex.get("week_of_month", 3)),
+        ):
+            m = float(opex.get("multiplier", 0.7))
+            mult *= m
+            logger.info(
+                "[calendar_overlay] opex: multiplier=%.2f applied to %s entry on %s",
+                m, decision.strategy_id, decision.ticker,
+            )
+
+    if mult < _MIN_MULTIPLIER:
+        mult = _MIN_MULTIPLIER
+    elif mult > _MAX_MULTIPLIER:
+        mult = _MAX_MULTIPLIER
+    return mult
+
+
+def should_block_entry(
+    decision: StrategyDecision,
+    dt: datetime,
+    config: dict[str, Any] | None,
+    holiday_calendar: HolidayCalendar | None = None,
+) -> bool:
+    """Return True if any block-style overlay vetoes *decision*."""
+    if not _master_enabled(config):
+        return False
+    if dt.tzinfo is None:
+        raise ValueError("should_block_entry requires a tz-aware datetime")
+
+    cal: HolidayCalendar = holiday_calendar or HolidayCalendar(config)
+
+    plw: dict[str, Any] = _section(config, "pre_long_weekend")
+    if plw.get("enabled", False):
+        block_list: list[str] = list(plw.get("block_strategies", []) or [])
+        if decision.strategy_id in block_list and is_pre_long_weekend(
+            dt.date(), cal,
+            min_weekend_days=int(plw.get("min_weekend_days", 3)),
+        ):
+            logger.info(
+                "[calendar_overlay] pre_long_weekend: blocking %s entry on %s",
+                decision.strategy_id, decision.ticker,
+            )
+            return True
+
+    return False
+
+
+def apply_overlay(
+    decision: StrategyDecision,
+    dt: datetime,
+    config: dict[str, Any] | None,
+    holiday_calendar: HolidayCalendar | None = None,
+    fomc_dates: list[date] | None = None,
+) -> StrategyDecision | None:
+    """One-shot helper: returns ``None`` if blocked, otherwise a new
+    decision with ``shares`` scaled by the composed multiplier.
+
+    A multiplier that pushes ``shares`` below 0 also returns ``None`` —
+    treating the decision as dropped is safer than passing zero shares
+    downstream.
+    """
+    if should_block_entry(decision, dt, config, holiday_calendar):
+        return None
+
+    mult: float = compute_size_multiplier(
+        decision, dt, config,
+        holiday_calendar=holiday_calendar,
+        fomc_dates=fomc_dates,
+    )
+    if mult <= 0.0:
+        return None
+    if mult == 1.0:
+        return decision
+
+    new_shares: float = decision.shares * mult
+    if new_shares <= 0:
+        return None
+    return replace(decision, shares=new_shares)

--- a/trading_bot/strategy/strategy_manager.py
+++ b/trading_bot/strategy/strategy_manager.py
@@ -14,7 +14,10 @@ import pandas as pd
 
 from trading_bot.constants import GICS_SECTOR, TZ_EASTERN
 from trading_bot.data.event_calendar import fomc_size_multiplier
+from trading_bot.data.fomc_calendar import get_fomc_dates
+from trading_bot.data.holiday_calendar import HolidayCalendar
 from trading_bot.db import repository as repo
+from trading_bot.strategy import calendar_overlay
 from trading_bot.execution.loss_cooldown import LossCooldownTracker
 from trading_bot.execution.order_manager import EntryDecision as OMEntryDecision
 from trading_bot.execution.virtual_portfolio import PortfolioManager, VirtualPortfolio
@@ -218,6 +221,13 @@ class StrategyManager:
                     decision = self._scale_decision_shares(decision, event_mult)
                     if decision is None:
                         continue
+
+                # Calendar-effect overlay (turn-of-month, FOMC drift, OPEX,
+                # pre-long-weekend block). No-op when calendar_overlay.enabled
+                # is false (default).
+                decision = self._apply_calendar_overlay(decision)
+                if decision is None:
+                    continue
 
                 # Per-symbol allocation cap across the global multi-strategy book.
                 decision = self._enforce_symbol_cap(decision)
@@ -577,6 +587,41 @@ class StrategyManager:
         except Exception:
             logger.warning("FOMC size multiplier lookup failed", exc_info=True)
             return 1.0
+
+    def _apply_calendar_overlay(
+        self, decision: StrategyDecision,
+    ) -> StrategyDecision | None:
+        """Run *decision* through the calendar-effect overlay.
+
+        Returns a new decision (possibly with scaled shares), or
+        ``None`` if the overlay blocks the entry. No-op when
+        ``calendar_overlay.enabled`` is false.
+        """
+        raw: dict[str, Any] = {}
+        section_fn = getattr(self._config, "raw_section", None)
+        if callable(section_fn):
+            try:
+                raw = section_fn()
+            except Exception:
+                raw = {}
+        if not raw:
+            legacy = getattr(self._config, "_raw", None)
+            if isinstance(legacy, dict):
+                raw = legacy
+        try:
+            return calendar_overlay.apply_overlay(
+                decision,
+                datetime.now(tz=ET),
+                raw,
+                holiday_calendar=HolidayCalendar(raw),
+                fomc_dates=get_fomc_dates(),
+            )
+        except Exception:
+            logger.warning(
+                "Calendar overlay failed for %s/%s — passing through",
+                decision.strategy_id, decision.ticker, exc_info=True,
+            )
+            return decision
 
     @staticmethod
     def _scale_decision_shares(

--- a/trading_bot/tests/test_calendar_overlay.py
+++ b/trading_bot/tests/test_calendar_overlay.py
@@ -1,0 +1,343 @@
+"""Tests for the calendar-effect overlay (issue ai-broker#47)."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Any
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from trading_bot.constants import HoldType
+from trading_bot.data.fomc_calendar import get_fomc_dates
+from trading_bot.data.holiday_calendar import HolidayCalendar
+from trading_bot.strategy import calendar_overlay
+from trading_bot.strategy.base import StrategyDecision
+
+ET = ZoneInfo("US/Eastern")
+
+
+def _decision(
+    strategy_id: str = "mean_reversion",
+    direction: str = "long",
+    shares: float = 100.0,
+    ticker: str = "SPY",
+) -> StrategyDecision:
+    return StrategyDecision(
+        ticker=ticker,
+        exchange="NYSE",
+        direction=direction,
+        shares=shares,
+        entry_price=400.0,
+        stop_price=395.0,
+        target_price=405.0,
+        trail_pct=None,
+        hold_type=HoldType.INTRADAY,
+        strategy_id=strategy_id,
+    )
+
+
+def _full_cfg(
+    *,
+    master: bool = True,
+    tom: bool = False,
+    fomc: bool = False,
+    plw: bool = False,
+    opex: bool = False,
+) -> dict[str, Any]:
+    return {
+        "calendar_overlay": {
+            "enabled": master,
+            "turn_of_month": {
+                "enabled": tom,
+                "days_before_month_end": 4,
+                "days_after_month_start": 3,
+                "long_multiplier": 1.2,
+                "short_multiplier": 0.8,
+                "applies_to": ["mean_reversion", "overnight_drift"],
+            },
+            "fomc_drift": {
+                "enabled": fomc,
+                "hours_before_announcement": 24,
+                "long_multiplier": 1.3,
+                "applies_to": ["overnight_drift"],
+            },
+            "pre_long_weekend": {
+                "enabled": plw,
+                "min_weekend_days": 3,
+                "block_strategies": ["overnight_drift"],
+            },
+            "opex": {
+                "enabled": opex,
+                "weekday": 4,
+                "week_of_month": 3,
+                "multiplier": 0.7,
+                "applies_to": ["mean_reversion", "overnight_drift"],
+            },
+        }
+    }
+
+
+@pytest.fixture
+def cal() -> HolidayCalendar:
+    return HolidayCalendar()
+
+
+# ---------------------------------------------------------------------------
+# Predicate tests
+# ---------------------------------------------------------------------------
+
+
+class TestTurnOfMonth:
+    def test_last_4_trading_days(self, cal: HolidayCalendar) -> None:
+        # April 2026: weekdays Apr 27 (Mon), 28, 29, 30 are last 4 trading days.
+        for d in (date(2026, 4, 27), date(2026, 4, 28), date(2026, 4, 29), date(2026, 4, 30)):
+            assert calendar_overlay.is_turn_of_month(d, cal), d
+
+    def test_first_3_trading_days(self, cal: HolidayCalendar) -> None:
+        # May 2026: weekdays May 1 (Fri), May 4 (Mon), May 5 (Tue).
+        for d in (date(2026, 5, 1), date(2026, 5, 4), date(2026, 5, 5)):
+            assert calendar_overlay.is_turn_of_month(d, cal), d
+
+    def test_middle_of_month(self, cal: HolidayCalendar) -> None:
+        assert not calendar_overlay.is_turn_of_month(date(2026, 5, 15), cal)
+
+    def test_handles_weekend(self, cal: HolidayCalendar) -> None:
+        # Saturday is never turn-of-month even at month-end.
+        assert not calendar_overlay.is_turn_of_month(date(2026, 5, 2), cal)
+        assert not calendar_overlay.is_turn_of_month(date(2026, 5, 3), cal)
+
+    def test_skips_holidays_in_count(self, cal: HolidayCalendar) -> None:
+        # Jan 2026: New Year (Jan 1, Thu) holiday. First 3 trading days are
+        # Jan 2 (Fri), Jan 5 (Mon), Jan 6 (Tue).
+        assert calendar_overlay.is_turn_of_month(date(2026, 1, 2), cal)
+        assert calendar_overlay.is_turn_of_month(date(2026, 1, 5), cal)
+        assert calendar_overlay.is_turn_of_month(date(2026, 1, 6), cal)
+        assert not calendar_overlay.is_turn_of_month(date(2026, 1, 7), cal)
+
+
+class TestFomcWindow:
+    def test_within_24h_before(self) -> None:
+        fomc = [date(2026, 3, 18)]
+        # Announcement at 14:00 ET on Mar 18. 23h earlier = Mar 17 15:00 ET.
+        dt = datetime(2026, 3, 17, 15, 0, tzinfo=ET)
+        assert calendar_overlay.is_fomc_window(dt, fomc, hours_before_announcement=24)
+
+    def test_outside_24h(self) -> None:
+        fomc = [date(2026, 3, 18)]
+        # 25h earlier = Mar 17 13:00 ET.
+        dt = datetime(2026, 3, 17, 13, 0, tzinfo=ET)
+        assert not calendar_overlay.is_fomc_window(dt, fomc, hours_before_announcement=24)
+
+    def test_after_announcement_is_false(self) -> None:
+        fomc = [date(2026, 3, 18)]
+        dt = datetime(2026, 3, 18, 15, 0, tzinfo=ET)
+        assert not calendar_overlay.is_fomc_window(dt, fomc)
+
+    def test_requires_tz_aware(self) -> None:
+        with pytest.raises(ValueError):
+            calendar_overlay.is_fomc_window(
+                datetime(2026, 3, 17, 15, 0), [date(2026, 3, 18)],
+            )
+
+
+class TestPreLongWeekend:
+    def test_friday_before_monday_holiday(self, cal: HolidayCalendar) -> None:
+        # MLK Day Mon 2026-01-19 → Fri 2026-01-16 is pre-long-weekend.
+        assert calendar_overlay.is_pre_long_weekend(date(2026, 1, 16), cal)
+
+    def test_normal_friday(self, cal: HolidayCalendar) -> None:
+        # Friday 2026-04-10 → next session Mon 2026-04-13: 3-day gap, but
+        # min_weekend_days defaults to 3 (≥ 3). 3-day weekend is the
+        # normal weekend, so we want this to NOT trigger.
+        # The check is days_until_next_session(d) >= min_weekend_days.
+        # Fri to Mon is exactly 3 days, so by default this matches a
+        # plain weekend. Use min_weekend_days=4 to require longer gap.
+        # Issue spec says "≥ 3 days (Mon holidays, Christmas, July 4)"
+        # implying 3 days = pre-long-weekend (it's the Friday before a
+        # Monday holiday-extended weekend OR the Friday before a normal
+        # weekend that already has 3 days off if Monday is a holiday).
+        # For a *plain* Fri→Mon weekend the gap is 3 days too.
+        # So with min_weekend_days=3 a normal Friday triggers. The
+        # operational fix is to set min_weekend_days=4 in config when
+        # only true long weekends should be flagged.
+        assert calendar_overlay.is_pre_long_weekend(
+            date(2026, 4, 10), cal, min_weekend_days=4,
+        ) is False
+
+    def test_christmas_eve_observed(self, cal: HolidayCalendar) -> None:
+        # 2026-12-25 is Friday holiday. Wednesday 2026-12-23 → Mon 2026-12-28
+        # spans 5 days. Thursday 2026-12-24 → Mon 2026-12-28 spans 4 days.
+        assert calendar_overlay.is_pre_long_weekend(date(2026, 12, 24), cal)
+
+    def test_holiday_itself_not_flagged(self, cal: HolidayCalendar) -> None:
+        # Holidays are not trading days, so they're never pre-long-weekend.
+        assert not calendar_overlay.is_pre_long_weekend(date(2026, 1, 19), cal)
+
+
+class TestOpexFriday:
+    @pytest.mark.parametrize(
+        "d",
+        [
+            date(2026, 1, 16),  # 3rd Fri of Jan 2026
+            date(2026, 2, 20),  # 3rd Fri of Feb 2026
+            date(2026, 3, 20),  # 3rd Fri of Mar 2026
+            date(2026, 6, 19),  # 3rd Fri of Jun 2026
+        ],
+    )
+    def test_third_friday_detected(self, d: date) -> None:
+        assert calendar_overlay.is_opex_friday(d)
+
+    @pytest.mark.parametrize(
+        "d",
+        [
+            date(2026, 1, 2),   # 1st Friday
+            date(2026, 1, 9),   # 2nd Friday
+            date(2026, 1, 23),  # 4th Friday
+            date(2026, 1, 19),  # Monday, not Friday
+        ],
+    )
+    def test_other_days_rejected(self, d: date) -> None:
+        assert not calendar_overlay.is_opex_friday(d)
+
+
+# ---------------------------------------------------------------------------
+# Composer tests
+# ---------------------------------------------------------------------------
+
+
+class TestSizeMultiplier:
+    def test_master_off_returns_one(self) -> None:
+        cfg = _full_cfg(master=False, tom=True, fomc=True)
+        dt = datetime(2026, 4, 30, 10, 0, tzinfo=ET)
+        m = calendar_overlay.compute_size_multiplier(_decision(), dt, cfg)
+        assert m == 1.0
+
+    def test_disabled_overlay_neutral(self) -> None:
+        cfg = _full_cfg()  # all sub-overlays off
+        dt = datetime(2026, 4, 30, 10, 0, tzinfo=ET)
+        m = calendar_overlay.compute_size_multiplier(_decision(), dt, cfg)
+        assert m == 1.0
+
+    def test_turn_of_month_long_multiplier(self) -> None:
+        cfg = _full_cfg(tom=True)
+        dt = datetime(2026, 4, 30, 10, 0, tzinfo=ET)
+        m = calendar_overlay.compute_size_multiplier(_decision(), dt, cfg)
+        assert m == pytest.approx(1.2)
+
+    def test_composes_multiple_overlays(self) -> None:
+        cfg = _full_cfg(tom=True, fomc=True)
+        # 2026-04-30 (Thu) = last 4 trading days of April (turn-of-month).
+        # Inject a synthetic FOMC date matching this day so the 24h
+        # window also fires at 13:30 ET (30 min before 14:00 release).
+        dt = datetime(2026, 4, 30, 13, 30, tzinfo=ET)
+        d = _decision(strategy_id="overnight_drift")
+        # turn_of_month applies to overnight_drift (1.2 long), fomc
+        # applies to overnight_drift (1.3 long). Composed = 1.56.
+        m = calendar_overlay.compute_size_multiplier(
+            d, dt, cfg, fomc_dates=[date(2026, 4, 30)],
+        )
+        assert m == pytest.approx(1.2 * 1.3)
+
+    def test_capped_at_2(self) -> None:
+        cfg = _full_cfg(tom=True, fomc=True)
+        cfg["calendar_overlay"]["turn_of_month"]["long_multiplier"] = 5.0
+        cfg["calendar_overlay"]["fomc_drift"]["long_multiplier"] = 5.0
+        dt = datetime(2026, 4, 30, 13, 30, tzinfo=ET)
+        m = calendar_overlay.compute_size_multiplier(
+            _decision(strategy_id="overnight_drift"), dt, cfg,
+            fomc_dates=[date(2026, 4, 30)],
+        )
+        assert m == 2.0
+
+    def test_floored_at_zero(self) -> None:
+        cfg = _full_cfg(tom=True)
+        cfg["calendar_overlay"]["turn_of_month"]["long_multiplier"] = -5.0
+        dt = datetime(2026, 4, 30, 10, 0, tzinfo=ET)
+        m = calendar_overlay.compute_size_multiplier(_decision(), dt, cfg)
+        assert m == 0.0
+
+    def test_per_strategy_opt_in(self) -> None:
+        cfg = _full_cfg(fomc=True)
+        # fomc_drift applies_to=["overnight_drift"] only.
+        d = _decision(strategy_id="mean_reversion", direction="long")
+        dt = datetime(2026, 5, 6, 13, 30, tzinfo=ET)
+        m = calendar_overlay.compute_size_multiplier(
+            d, dt, cfg, fomc_dates=[date(2026, 5, 6)],
+        )
+        assert m == 1.0
+
+    def test_short_uses_short_multiplier(self) -> None:
+        cfg = _full_cfg(tom=True)
+        d = _decision(direction="short")
+        dt = datetime(2026, 4, 30, 10, 0, tzinfo=ET)
+        m = calendar_overlay.compute_size_multiplier(d, dt, cfg)
+        assert m == pytest.approx(0.8)
+
+    def test_requires_tz_aware(self) -> None:
+        with pytest.raises(ValueError):
+            calendar_overlay.compute_size_multiplier(
+                _decision(), datetime(2026, 4, 30, 10, 0), _full_cfg(tom=True),
+            )
+
+
+class TestShouldBlockEntry:
+    def test_block_overrides_multiplier(self) -> None:
+        cfg = _full_cfg(plw=True, tom=True)
+        d = _decision(strategy_id="overnight_drift")
+        # Friday 2026-01-16 before MLK Mon 2026-01-19, also turn-of-month
+        # tail not relevant here. Block applies regardless of multiplier.
+        dt = datetime(2026, 1, 16, 15, 0, tzinfo=ET)
+        assert calendar_overlay.should_block_entry(d, dt, cfg)
+
+    def test_not_blocked_for_other_strategy(self) -> None:
+        cfg = _full_cfg(plw=True)
+        d = _decision(strategy_id="mean_reversion")
+        dt = datetime(2026, 1, 16, 15, 0, tzinfo=ET)
+        assert not calendar_overlay.should_block_entry(d, dt, cfg)
+
+    def test_master_off_never_blocks(self) -> None:
+        cfg = _full_cfg(master=False, plw=True)
+        d = _decision(strategy_id="overnight_drift")
+        dt = datetime(2026, 1, 16, 15, 0, tzinfo=ET)
+        assert not calendar_overlay.should_block_entry(d, dt, cfg)
+
+
+class TestApplyOverlay:
+    def test_no_op_when_disabled(self) -> None:
+        cfg = _full_cfg(master=False)
+        d = _decision()
+        dt = datetime(2026, 4, 30, 10, 0, tzinfo=ET)
+        result = calendar_overlay.apply_overlay(d, dt, cfg)
+        assert result is d  # exact pass-through
+
+    def test_block_returns_none(self) -> None:
+        cfg = _full_cfg(plw=True)
+        d = _decision(strategy_id="overnight_drift")
+        dt = datetime(2026, 1, 16, 15, 0, tzinfo=ET)
+        assert calendar_overlay.apply_overlay(d, dt, cfg) is None
+
+    def test_scales_shares(self) -> None:
+        cfg = _full_cfg(tom=True)
+        d = _decision(shares=100.0)
+        dt = datetime(2026, 4, 30, 10, 0, tzinfo=ET)
+        result = calendar_overlay.apply_overlay(d, dt, cfg)
+        assert result is not None
+        assert result.shares == pytest.approx(120.0)
+        # Original should be untouched (replace returns new instance).
+        assert d.shares == 100.0
+
+
+# ---------------------------------------------------------------------------
+# FOMC calendar coverage
+# ---------------------------------------------------------------------------
+
+
+class TestFomcCalendar:
+    def test_covers_2020_through_2027(self) -> None:
+        dates = get_fomc_dates()
+        years = {d.year for d in dates}
+        for y in range(2020, 2028):
+            count = sum(1 for d in dates if d.year == y)
+            assert count >= 8, f"year {y} has only {count} FOMC dates"
+        assert years.issuperset(set(range(2020, 2028)))


### PR DESCRIPTION
Closes #47.

## Summary

- New `calendar_overlay` module: predicates (`is_turn_of_month`, `is_fomc_window`, `is_pre_long_weekend`, `is_opex_friday`), composer (`compute_size_multiplier`, capped to `[0.0, 2.0]`), block check (`should_block_entry`), and one-shot `apply_overlay`.
- Hardcoded FOMC announcement dates 2020-2027 in `trading_bot/data/fomc_calendar.py` (annual refresh procedure documented in module docstring).
- Config-driven NYSE holiday wrapper in `trading_bot/data/holiday_calendar.py` consistent with the existing `event_calendar.py` pattern (no new dep).
- Wired into `StrategyManager` (live) and all four `evaluate_entry` call sites in `multi_strategy_backtest.py`. Block check before sizing; multiplier scales post-ATR-sized `shares`.
- `--no-calendar-overlay` CLI flag for clean A/B baselines.
- `calendar_overlay` block added to `config.yaml`. Master + all 4 sub-overlays ship `enabled: false`.

## Deviations from the issue spec

1. **No `pandas_market_calendars` dep.** The repo's existing pattern (`event_calendar.py`) is config-driven holiday lists with a hardcoded fallback, and `config.yaml` already has `holidays.us_2026`. Adding a heavy dep for `is_holiday()` was hard to justify; happy to swap in if you'd rather take the dep.
2. **`is_pre_long_weekend` semantics.** With the spec default `min_weekend_days=3`, a plain Fri→Mon weekend (3 days) also fires. To target only holiday-extended weekends, set `min_weekend_days: 4` in config. The test suite documents this.

## Test plan

- [x] 37 new unit tests in `trading_bot/tests/test_calendar_overlay.py` covering predicates, composer, block, master switch, per-strategy opt-in, multiplier capping/flooring, FOMC date coverage 2020-2027.
- [x] Full suite: **737 passed, 2 skipped** (no regressions; mean_reversion + overnight_drift backtests unchanged when overlay is disabled — that's the default).
- [ ] Per-overlay A/B reports (out of scope for this PR — overlays ship disabled, A/B + flip-to-enabled happens in a follow-up PR per the issue's "do not iterate" rule).

## Definition of done (from issue)

- [x] `calendar_overlay.py` implemented with all 4 predicates + composer
- [x] FOMC and holiday calendar modules in place
- [x] StrategyManager applies overlay
- [x] Backtester applies overlay + has `--no-calendar-overlay` flag
- [x] Config block added (master and all sub-overlays disabled)
- [x] Unit tests pass
- [x] Full suite passes; mean_reversion + overnight_drift unchanged when overlay disabled (regression check)
- [ ] Per-overlay A/B reports — follow-up
- [ ] Composite A/B report — follow-up
- [ ] Flip passing overlays to enabled — separate PR per issue