### PR TITLE
docs(calendar_overlay): walkforward postmortem — pre_long_weekend shelved (ai-broker#47)

### DIFF
--- a/scripts/run_pre_long_weekend_walkforward.py
+++ b/scripts/run_pre_long_weekend_walkforward.py
@@ -1,0 +1,195 @@
+"""Walkforward A/B for pre_long_weekend overlay (issue ai-broker#47).
+
+Per-window OOS check called for in the issue's acceptance criteria:
+
+* OOS Return improvement positive across ≥ 4 of 6 yearly windows
+* No single-window catastrophic loss (no window worse than baseline by > 200 bps)
+
+Runs two walkforward backtests over the issue's window:
+
+  baseline: --no-calendar-overlay
+  prelw_on: calendar_overlay.enabled + pre_long_weekend.enabled,
+            min_weekend_days=4 (true long weekends only)
+
+Both runs use ``--no-regime-filter`` for the same reason as the
+aggregate A/B — daily-bar cache is sparse pre-2026.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+
+PROJECT_ROOT: Path = Path(__file__).resolve().parents[1]
+REPORTS_DIR: Path = PROJECT_ROOT / "backtest_results" / "calendar_overlay_walkforward"
+
+UNIVERSE: str = "SPY,QQQ,XLF,XLK,XLE,XLV,XLI,XLY,XLP,XLU,XLB,XLRE,XLC"
+DATE_FROM: str = "2020-07-27"
+DATE_TO: str = "2026-04-16"
+
+# 6 yearly OOS windows over the ~5.7 year span.
+WINDOW_DAYS: int = 365
+STEP_DAYS: int = 365
+
+
+@dataclass(frozen=True)
+class RunSpec:
+    name: str
+    overlay_enabled: bool
+    no_overlay_flag: bool
+
+
+def _build_config(name: str, overlay_enabled: bool) -> Path:
+    src: Path = PROJECT_ROOT / "config.yaml"
+    with src.open() as f:
+        cfg = yaml.safe_load(f)
+    cfg = copy.deepcopy(cfg)
+    cfg["calendar_overlay"] = {
+        "enabled": overlay_enabled,
+        "turn_of_month": {
+            "enabled": False,
+            "days_before_month_end": 4,
+            "days_after_month_start": 3,
+            "long_multiplier": 1.2,
+            "short_multiplier": 0.8,
+            "applies_to": ["mean_reversion", "overnight_drift"],
+        },
+        "fomc_drift": {
+            "enabled": False,
+            "hours_before_announcement": 24,
+            "long_multiplier": 1.3,
+            "applies_to": ["overnight_drift"],
+        },
+        "pre_long_weekend": {
+            "enabled": overlay_enabled,
+            "min_weekend_days": 4,
+            "block_strategies": ["overnight_drift"],
+        },
+        "opex": {
+            "enabled": False,
+            "weekday": 4,
+            "week_of_month": 3,
+            "multiplier": 0.7,
+            "applies_to": ["mean_reversion", "overnight_drift"],
+        },
+    }
+    REPORTS_DIR.mkdir(parents=True, exist_ok=True)
+    out: Path = REPORTS_DIR / f"config_{name}.yaml"
+    with out.open("w") as f:
+        yaml.safe_dump(cfg, f, sort_keys=False)
+    return out
+
+
+def _run_one(spec: RunSpec) -> dict:
+    cfg_path: Path = _build_config(spec.name, spec.overlay_enabled)
+    log_path: Path = REPORTS_DIR / f"{spec.name}.log"
+    cmd: list[str] = [
+        sys.executable, "-m", "trading_bot.multi_strategy_backtest",
+        "--from", DATE_FROM, "--to", DATE_TO,
+        "--multi-intraday",
+        "--tickers", UNIVERSE,
+        "--config", str(cfg_path),
+        "--no-regime-filter",
+        "--walkforward",
+        "--wf-window", str(WINDOW_DAYS),
+        "--wf-step", str(STEP_DAYS),
+    ]
+    if spec.no_overlay_flag:
+        cmd.append("--no-calendar-overlay")
+
+    print(f"\n=== {spec.name} ===\n  cmd: {' '.join(cmd)}", flush=True)
+    with log_path.open("w") as logf:
+        proc = subprocess.run(
+            cmd, cwd=PROJECT_ROOT, stdout=logf, stderr=subprocess.STDOUT,
+            text=True,
+        )
+    print(f"  exit={proc.returncode}  log={log_path}", flush=True)
+
+    output: str = log_path.read_text()
+    json_match = re.search(r"Walkforward (?:JSON saved to|results saved to:)\s*(\S+\.json)", output)
+    json_path: Path | None = Path(json_match.group(1)) if json_match else None
+
+    return {
+        "name": spec.name,
+        "exit_code": proc.returncode,
+        "log": str(log_path),
+        "json": str(json_path) if json_path else None,
+    }
+
+
+def _load_per_window(json_path: str) -> dict[str, list[dict]]:
+    with Path(json_path).open() as f:
+        data = json.load(f)
+    return data.get("per_window", {})
+
+
+def _evaluate(baseline_json: str, prelw_json: str) -> dict:
+    base_pw = _load_per_window(baseline_json)
+    prelw_pw = _load_per_window(prelw_json)
+    sleeve = "overnight_drift"  # the only sleeve pre_long_weekend touches
+
+    base_windows = base_pw.get(sleeve, [])
+    prelw_windows = prelw_pw.get(sleeve, [])
+    pairs: list[dict] = []
+    for b, p in zip(base_windows, prelw_windows):
+        delta_ret = round(p["return_pct"] - b["return_pct"], 4)
+        pairs.append({
+            "window_idx": b["window_idx"],
+            "from": b["from_date"],
+            "to": b["to_date"],
+            "baseline_return_pct": b["return_pct"],
+            "prelw_return_pct": p["return_pct"],
+            "delta_pp": delta_ret,
+            "trades_baseline": b["trades"],
+            "trades_prelw": p["trades"],
+        })
+
+    positive_windows = sum(1 for x in pairs if x["delta_pp"] > 0)
+    catastrophic = [x for x in pairs if x["delta_pp"] < -2.0]
+    return {
+        "sleeve": sleeve,
+        "total_windows": len(pairs),
+        "positive_windows": positive_windows,
+        "catastrophic_windows": catastrophic,
+        "passes_4_of_6": positive_windows >= 4 and len(pairs) >= 4,
+        "passes_no_catastrophic": not catastrophic,
+        "windows": pairs,
+    }
+
+
+def main() -> None:
+    REPORTS_DIR.mkdir(parents=True, exist_ok=True)
+
+    runs = [
+        RunSpec("baseline", overlay_enabled=False, no_overlay_flag=True),
+        RunSpec("prelw_on", overlay_enabled=True, no_overlay_flag=False),
+    ]
+    summaries = [_run_one(s) for s in runs]
+
+    summary_path = REPORTS_DIR / "summary.json"
+    if all(s["json"] for s in summaries):
+        analysis = _evaluate(summaries[0]["json"], summaries[1]["json"])
+        out = {"runs": summaries, "analysis": analysis}
+    else:
+        out = {"runs": summaries, "analysis": "missing json — see logs"}
+    with summary_path.open("w") as f:
+        json.dump(out, f, indent=2)
+    print(f"\n=== summary written to {summary_path} ===")
+    if isinstance(out["analysis"], dict):
+        a = out["analysis"]
+        print(f"  total_windows={a['total_windows']}")
+        print(f"  positive_windows={a['positive_windows']}")
+        print(f"  passes_4_of_6={a['passes_4_of_6']}")
+        print(f"  passes_no_catastrophic={a['passes_no_catastrophic']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/trading_bot/docs/calendar_overlay/2026-05-03_walkforward_postmortem.md
+++ b/trading_bot/docs/calendar_overlay/2026-05-03_walkforward_postmortem.md
@@ -1,0 +1,92 @@
+# Calendar overlay walkforward postmortem — all four overlays shelved
+
+**Date:** 2026-05-03
+**Issue:** [ai-broker#47](https://github.com/alex5imon/ai-broker/issues/47)
+**Predecessor PR:** #50 (overlay infra + aggregate A/B)
+**This PR:** postmortem; no config changes
+
+## TL;DR
+
+After the aggregate A/B (PR #50) shelved 3 of 4 overlays, `pre_long_weekend`
+remained the only candidate to enable. The issue's acceptance criteria
+also require a per-window OOS check ("≥ 4 of 6 yearly windows
+positive"). Walkforward A/B run today shows `pre_long_weekend` **fails
+that bar** (3 of 6 windows positive). Per the "do not iterate" rule,
+all four overlays are now permanently shelved. Code in
+`trading_bot/strategy/calendar_overlay.py` stays opt-in only,
+consistent with the breakout shelved-try precedent (PR #43).
+
+## Walkforward setup
+
+* Window: 2020-07-27 → 2026-04-16 (~5.7 years)
+* Universe: SPY, QQQ, XLF, XLK, XLE, XLV, XLI, XLY, XLP, XLU, XLB, XLRE, XLC
+* Mode: `--multi-intraday --no-regime-filter` (daily cache sparse pre-2026)
+* Walkforward: 6 non-overlapping yearly windows (`--wf-window 365 --wf-step 365`)
+* Sleeve under test: `overnight_drift` (the only sleeve `pre_long_weekend` blocks)
+* Variant config: `pre_long_weekend.enabled: true`, `min_weekend_days: 4` (true long weekends only)
+
+## Per-window OOS results
+
+| Window | Period | Baseline Return | + pre_long_weekend | Δ pp | Trades base / +overlay |
+|---:|---|---:|---:|---:|---:|
+| 0 | 2020-07-27 → 2021-07-26 | +6.63% | +5.98% | **−0.65** | 750 / 729 |
+| 1 | 2021-07-27 → 2022-07-26 | −15.11% | −12.43% | **+2.69** | 753 / 729 |
+| 2 | 2022-07-27 → 2023-07-26 | −12.45% | −12.75% | **−0.30** | 747 / 723 |
+| 3 | 2023-07-27 → 2024-07-25 | +14.29% | +16.06% | **+1.76** | 747 / 726 |
+| 4 | 2024-07-26 → 2025-07-25 | +3.46% | +3.40% | **−0.06** | 735 / 720 |
+| 5 | 2025-07-26 → 2026-04-16 | +4.44% | +7.05% | **+2.61** | 540 / 528 |
+
+Summary:
+- **Positive windows: 3 / 6** — fails the ≥ 4 of 6 bar
+- No catastrophic loss (worst window: −0.65 pp, well within the −2 pp tolerance)
+- Aggregate Δ across 6 windows: **+6.05 pp** (consistent with the +6.30 pp aggregate A/B in PR #50)
+
+## Why the walkforward disagreed with the aggregate A/B
+
+The aggregate Sharpe lift (+0.08, PR #50) was real but concentrated in
+two windows (W1 the 2022 bear market: +2.69 pp; W5 the 2025-2026
+window: +2.61 pp). Three windows showed mild negative deltas.
+
+The issue's acceptance bar was specifically designed to catch this
+pattern — an overlay that wins big in 2 of 6 years but loses or breaks
+even in the others is overfit to those years' calendar structure, not
+a durable edge. Holding to the 4-of-6 bar is the discipline that
+keeps shelved-try infrastructure useful long-term (this is the same
+logic that shelved the breakout retune PR #43 and the trend retune PR
+#49).
+
+## Decision
+
+| Overlay | Per-issue verdict | Final status |
+|---|---|---|
+| turn_of_month | failed aggregate Sharpe bar (PR #50) | Permanently shelved |
+| fomc_drift | failed aggregate Sharpe bar (PR #50) | Permanently shelved |
+| opex | failed aggregate Sharpe bar (PR #50) | Permanently shelved |
+| pre_long_weekend | passed aggregate, **failed** walkforward 4-of-6 | Permanently shelved |
+
+`config.yaml` already ships every sub-overlay `enabled: false`. No
+config changes needed for this PR.
+
+## What to do if revisiting
+
+If the universe, regime, or strategy mix changes meaningfully (new
+sleeve, regime filter overhaul, walkforward methodology change), re-run
+the same A/B + walkforward harness:
+
+```bash
+# Aggregate A/B (~2 hours, six 20-min runs)
+python scripts/run_calendar_overlay_ab.py
+
+# Per-window walkforward A/B (~1 hour, two 25-min runs)
+python scripts/run_pre_long_weekend_walkforward.py
+```
+
+Both scripts are idempotent and write to
+`backtest_results/calendar_overlay_ab/` and
+`backtest_results/calendar_overlay_walkforward/` respectively.
+
+## Files
+
+- Walkforward summary: `backtest_results/calendar_overlay_walkforward/summary.json`
+- Driver script: `scripts/run_pre_long_weekend_walkforward.py`
+- Aggregate A/B writeup: `trading_bot/docs/calendar_overlay/2026-05-03_ab_report.md`


### PR DESCRIPTION
Closes #47.

## Summary

Follow-up to #50. The aggregate A/B in #50 left `pre_long_weekend` as the only candidate to enable. The issue's acceptance criteria also require **per-window OOS** validation ("≥ 4 of 6 yearly windows positive"). Walkforward A/B run today shows `pre_long_weekend` **fails that bar** — 3 of 6 yearly windows positive, with the aggregate gain concentrated in 2 windows (W1 2022 bear: +2.69 pp; W5 2025–2026: +2.61 pp).

| Window | Period | Δ pp |
|---:|---|---:|
| 0 | 2020-07 → 2021-07 | −0.65 |
| 1 | 2021-07 → 2022-07 | **+2.69** |
| 2 | 2022-07 → 2023-07 | −0.30 |
| 3 | 2023-07 → 2024-07 | **+1.76** |
| 4 | 2024-07 → 2025-07 | −0.06 |
| 5 | 2025-07 → 2026-04 | **+2.61** |

Per the issue's "do not iterate" rule, `pre_long_weekend` is now permanently shelved alongside the other three. **All four overlays remain `enabled: false` in `config.yaml`** — no live behavior change.

## What's in this PR

- `trading_bot/docs/calendar_overlay/2026-05-03_walkforward_postmortem.md` — full writeup
- `scripts/run_pre_long_weekend_walkforward.py` — driver script for reproducibility

No code or config changes. Issue #47 can close.

## Test plan

- [x] Walkforward A/B run completes cleanly (both runs exit 0)
- [x] Per-window OOS deltas computed
- [x] No code changes → existing test suite unaffected