### PR TITLE
feat(order_manager): plain-limit + standalone-stop entry path (ai-broker#39)

### DIFF
--- a/trading_bot/docs/self_improve_followups.md
+++ b/trading_bot/docs/self_improve_followups.md
@@ -7,9 +7,11 @@ says "exercise extreme care with all order logic."
 
 ## Active tracking
 
-- **#39 — Replace bracket entry with plain-limit + standalone-stop** (must land before `$1k` live).
-  Whole-share floor in PR #38 is a Monday-morning unblocker; backtests show it
-  drops ~50% of mean_reversion signals at $1k account size.
+- ~~**#39 — Replace bracket entry with plain-limit + standalone-stop**~~ (resolved).
+  Entry path now submits a plain `LimitOrderRequest` and attaches a standalone
+  `StopOrderRequest` on fill; take-profit is managed by the tick-loop's
+  `check_exits` polling against `target_price`. The PR #38 whole-share floor
+  has been removed — fractional shares pass through end-to-end.
 - **#40 — `PerformanceCalculator` not surfacing closed trades.** Two pre-existing
   test failures reproduce the same pattern as the live `daily_summaries` showing
   0/0/0 wins/losses despite closed entries. Probably the load-bearing reason
@@ -17,6 +19,15 @@ says "exercise extreme care with all order logic."
 - **#41 — Verify PR #20 drain logic.** The verify-before-SELL guard merged after
   the churn it was meant to prevent; needs unit + integration coverage before
   the next sleeve-disable event proves it the hard way.
+- **Rename `STOP_AND_TARGET_ACTIVE` → `STOP_ACTIVE`.** Under the
+  ai-broker#39 entry path only the stop is broker-side (take-profit is
+  polled in `main.check_exits` against `target_price`), so the status
+  name is semantically inaccurate. Deferred from #39 because the rename
+  touches 45 references across 10 files plus a DB migration on the
+  GHA-cached SQLite — too much churn pre-launch for a naming fix.
+  Action: add `PositionStatus.STOP_ACTIVE`, migration v11 (`UPDATE
+  positions SET status='STOP_ACTIVE' WHERE status='STOP_AND_TARGET_ACTIVE'`),
+  bump SCHEMA_VERSION, sweep tests + scripts. No behavior change.
 
 The legacy "Task #2 / #3 / Bug B6" sections below are kept for the audit trail
 but their resolved status is summarized at the top of each.
@@ -386,6 +397,7 @@ For one-shot flatten / liquidation tools:
 - Never assume a `200` from `DELETE /v2/orders` means qty has released.
 
 For the live bot's continuous order management, the existing pattern
-(bracket orders + tick-time fill detection) sidesteps this entirely
-because every cancel + flatten happens during RTH by definition.
+(plain-limit entry + standalone stop attached on fill, with tick-time
+fill detection — see ai-broker#39) sidesteps this entirely because
+every cancel + flatten happens during RTH by definition.
 ```

--- a/trading_bot/execution/order_manager.py
+++ b/trading_bot/execution/order_manager.py
@@ -21,14 +21,13 @@ from typing import TYPE_CHECKING, Any
 from zoneinfo import ZoneInfo
 
 from alpaca.trading.client import TradingClient
-from alpaca.trading.enums import OrderSide, OrderType, TimeInForce, OrderClass
+from alpaca.trading.enums import OrderSide, OrderType, TimeInForce
 from alpaca.trading.models import Order as AlpacaOrder
 from alpaca.trading.requests import (
     GetOrdersRequest,
     LimitOrderRequest,
     MarketOrderRequest,
-    StopLossRequest,
-    TakeProfitRequest,
+    StopOrderRequest,
     TrailingStopOrderRequest,
 )
 
@@ -60,7 +59,7 @@ class EntryDecision:
     ticker: str
     exchange: str
     side: str                 # "BUY"
-    shares: int
+    shares: float             # supports fractional (Alpaca min increment 1e-6)
     limit_price: float
     stop_price: float         # Stop-loss price
     target_price: float       # Take-profit price
@@ -349,22 +348,22 @@ class OrderManager:
     # ------------------------------------------------------------------
 
     async def place_entry(self, decision: EntryDecision) -> int | None:
-        """Place an entry limit order.  Returns the internal trade_id on success."""
-        # Alpaca rejects fractional+bracket combos with code 42210000
-        # ("fractional orders must be simple orders"), and we always submit
-        # bracketed entries so stop+target attach atomically. Floor to whole
-        # shares so the bracket path is legal. The proper fix — plain entry +
-        # standalone stop on fill — is required before live deployment because
-        # this floor drops ~50% of signals on a $1k account; tracked separately.
-        whole_shares: int = int(decision.shares)
-        if whole_shares <= 0:
+        """Place an entry limit order.  Returns the internal trade_id on success.
+
+        Submits a *plain* ``LimitOrderRequest`` — no bracket, no children.
+        Alpaca rejects fractional+bracket combos with code 42210000 and the
+        whole-share floor we used to apply was catastrophic on the $1k live
+        account (dropped ~50% of mean_reversion signals). The protective stop
+        is attached as a standalone order in :meth:`_transition_to_open` once
+        the entry confirms a fill; take-profit is managed by the tick-loop's
+        ``check_exits`` polling against ``target_price``.
+        """
+        if decision.shares <= 0:
             logger.info(
-                "[%s] Entry skipped: whole-share floor produces 0 shares (raw=%.4f, price=%.2f)",
+                "[%s] Entry skipped: shares=%.6f <= 0 (price=%.2f)",
                 decision.ticker, decision.shares, decision.limit_price,
             )
             return None
-        if whole_shares != decision.shares:
-            decision.shares = whole_shares
 
         trade_id: int | None = self._create_position_record(decision)
         if trade_id is None:
@@ -374,11 +373,6 @@ class OrderManager:
         client: TradingClient = self._gw.client
 
         try:
-            # Use a bracket order so stop-loss + take-profit are attached to
-            # the entry as an OCO pair. Placing them as separate orders after
-            # fill fails on small positions because the stop reserves the
-            # whole qty, leaving nothing available for the take-profit
-            # (Alpaca rejects with "insufficient qty available for order").
             request = LimitOrderRequest(
                 symbol=decision.ticker,
                 qty=decision.shares,
@@ -386,19 +380,12 @@ class OrderManager:
                 type=OrderType.LIMIT,
                 time_in_force=TimeInForce.DAY,
                 limit_price=round(decision.limit_price, 2),
-                order_class=OrderClass.BRACKET,
-                stop_loss=StopLossRequest(
-                    stop_price=round(decision.stop_price, 2),
-                ),
-                take_profit=TakeProfitRequest(
-                    limit_price=round(decision.target_price, 2),
-                ),
             )
             order: AlpacaOrder = client.submit_order(order_data=request)
             alpaca_order_id: str = str(order.id)
 
             logger.info(
-                "Entry order placed: %s %s %d @ %.2f (alpaca_id=%s, trade_id=%d)",
+                "Entry order placed: %s %s %.6f @ %.2f (alpaca_id=%s, trade_id=%d)",
                 decision.side, decision.ticker, decision.shares,
                 decision.limit_price, alpaca_order_id, trade_id,
             )
@@ -540,7 +527,7 @@ class OrderManager:
             order: AlpacaOrder = client.submit_order(order_data=request)
             order_id: str = str(order.id)
             logger.info(
-                "Trailing stop placed: %s %d trail=%.2f%% (alpaca_id=%s, trade_id=%d)",
+                "Trailing stop placed: %s %.6f trail=%.2f%% (alpaca_id=%s, trade_id=%d)",
                 ticker, qty, trail_pct * 100, order_id, trade_id,
             )
 
@@ -604,12 +591,12 @@ class OrderManager:
                 client.submit_order, order_data=request,
             )
             logger.warning(
-                "Emergency flatten: SELL %d %s @ MARKET (alpaca_id=%s)",
+                "Emergency flatten: SELL %.6f %s @ MARKET (alpaca_id=%s)",
                 qty, ticker, str(order.id),
             )
         except Exception:
             logger.exception(
-                "CRITICAL: Failed emergency flatten for %s (%d shares)", ticker, qty,
+                "CRITICAL: Failed emergency flatten for %s (%.6f shares)", ticker, qty,
             )
             await self._notifier.send(
                 "Emergency Flatten Failed",
@@ -870,7 +857,16 @@ class OrderManager:
     # ------------------------------------------------------------------
 
     async def _transition_to_open(self, trade_id: int, filled_qty: float) -> None:
-        """Transition from ENTRY_PENDING to POSITION_OPEN, then place exits."""
+        """Transition from ENTRY_PENDING to POSITION_OPEN, then attach a stop.
+
+        The entry was submitted as a *plain* LimitOrderRequest (no bracket),
+        so we submit a standalone protective stop now. Take-profit is *not*
+        sent to Alpaca — the tick-loop's ``check_exits`` polls
+        ``target_price`` and exits via ``place_limit_exit``.
+
+        If the stop submission fails, we emergency-flatten and notify, since
+        the position would otherwise sit unprotected.
+        """
         active: _ActiveOrder | None = self._active_orders.get(trade_id)
         if active is None:
             return
@@ -881,46 +877,53 @@ class OrderManager:
         self._update_position_field(trade_id, "quantity", filled_qty)
         self._update_position_field(trade_id, "entry_price", active.entry_price)
 
-        # Entry was submitted as a BRACKET, so Alpaca auto-created the
-        # stop-loss and take-profit legs once the entry filled. Fetch the
-        # entry order to pull the leg IDs rather than placing new orders.
-        stop_id: str | None = None
-        target_id: str | None = None
-        try:
-            entry_order = self._gw.client.get_order_by_id(active.alpaca_entry_order_id)
-            for leg in getattr(entry_order, "legs", None) or []:
-                leg_type = getattr(leg, "order_type", None) or getattr(leg, "type", None)
-                leg_type_str = str(leg_type).lower()
-                if "stop" in leg_type_str and "trail" not in leg_type_str:
-                    stop_id = str(leg.id)
-                elif "limit" in leg_type_str:
-                    target_id = str(leg.id)
-        except Exception:
-            logger.exception(
-                "Could not fetch bracket legs for %s (trade_id=%d)",
-                active.ticker, trade_id,
-            )
+        stop_id: str | None = await self._place_standalone_stop(
+            trade_id, active, filled_qty,
+        )
 
-        if stop_id is not None:
-            active.alpaca_stop_order_id = stop_id
-            self._update_position_field(trade_id, "alpaca_stop_order_id", stop_id)
-        if target_id is not None:
-            active.alpaca_target_order_id = target_id
-            self._update_position_field(trade_id, "alpaca_target_order_id", target_id)
-
-        if stop_id is not None and target_id is not None:
-            active.status = PositionStatus.STOP_AND_TARGET_ACTIVE
-            self._update_position_status(trade_id, PositionStatus.STOP_AND_TARGET_ACTIVE)
-            logger.info(
-                "Bracket legs active for %s (trade_id=%d): stop=%s, target=%s",
-                active.ticker, trade_id, stop_id, target_id,
-            )
-        elif stop_id is None:
+        if stop_id is None:
+            # Stop-attach failure leaves the position unprotected. Recovery:
+            # emergency_flatten + notify, then collapse local + DB state to a
+            # terminal status so the next stateless cron tick does not
+            # re-evaluate a ghost POSITION_OPEN row that has no broker-side
+            # stop. Reusing ENTRY_FAILED (rather than CLOSED) is a small
+            # semantic stretch — the entry did fill — but it is the only
+            # terminal state hydration treats as "do not load," matching the
+            # in-memory invariant. A trade_entry notification would be
+            # actively misleading for a position that was just force-flattened
+            # so we suppress it.
             logger.error(
-                "CRITICAL: No stop-loss leg found for %s (trade_id=%d). Emergency flattening.",
+                "CRITICAL: Failed to attach standalone stop for %s "
+                "(trade_id=%d). Emergency flattening.",
                 active.ticker, trade_id,
             )
             await self.emergency_flatten(active.ticker, filled_qty, active.exchange)
+            await self._notifier.send(
+                "Stop Attach Failed",
+                f"Could not attach protective stop for {active.ticker} "
+                f"(qty={filled_qty:.6f}). Position emergency-flattened. "
+                f"Investigate Alpaca order rejections.",
+                priority=4,
+                tags=["warning"],
+            )
+            active.status = PositionStatus.ENTRY_FAILED
+            self._update_position_status(trade_id, PositionStatus.ENTRY_FAILED)
+            self._active_orders.pop(trade_id, None)
+            return
+
+        active.alpaca_stop_order_id = stop_id
+        self._update_position_field(trade_id, "alpaca_stop_order_id", stop_id)
+        # Status name retained for back-compat with downstream readers (DB
+        # rows, dashboards, postmortem queries — 45 references across the
+        # tree). Under this entry path only the stop is broker-side; take-
+        # profit is polled in main.check_exits via target_price. Renaming is
+        # tracked as a post-launch follow-up.
+        active.status = PositionStatus.STOP_AND_TARGET_ACTIVE
+        self._update_position_status(trade_id, PositionStatus.STOP_AND_TARGET_ACTIVE)
+        logger.info(
+            "Protective stop active for %s (trade_id=%d): stop_id=%s @ %.4f",
+            active.ticker, trade_id, stop_id, active.stop_price,
+        )
 
         await self._notifier.trade_entry(
             ticker=active.ticker,
@@ -929,6 +932,37 @@ class OrderManager:
             qty=filled_qty,
             reason=f"Phase {self._config.get_phase().value} | {active.hold_type}",
         )
+
+    async def _place_standalone_stop(
+        self, trade_id: int, active: _ActiveOrder, qty: float,
+    ) -> str | None:
+        """Submit a standalone sell-stop order. Returns Alpaca order id or None.
+
+        Catches all exceptions so the caller can choose the recovery path
+        (emergency flatten + notification) without unwinding the transaction.
+        """
+        if active.stop_price <= 0:
+            logger.error(
+                "Refusing to attach stop with non-positive stop_price=%.4f for %s",
+                active.stop_price, active.ticker,
+            )
+            return None
+        try:
+            request = StopOrderRequest(
+                symbol=active.ticker,
+                qty=qty,
+                side=OrderSide.SELL,
+                time_in_force=TimeInForce.GTC,
+                stop_price=round(active.stop_price, 2),
+            )
+            order: AlpacaOrder = self._gw.client.submit_order(order_data=request)
+            return str(order.id)
+        except Exception:
+            logger.exception(
+                "Standalone stop submit failed for %s (trade_id=%d, qty=%s, stop=%.4f)",
+                active.ticker, trade_id, qty, active.stop_price,
+            )
+            return None
 
     async def activate_trailing_stop(self, trade_id: int, trail_pct: float) -> bool:
         """Activate trailing stop, replacing the take-profit order."""

--- a/trading_bot/gateway/recovery.py
+++ b/trading_bot/gateway/recovery.py
@@ -187,8 +187,11 @@ class StateRecovery:
         alpaca_by_ticker: dict[str, AlpacaPosition] = {}
         for pos in alpaca_positions:
             ticker: str = str(pos.symbol)
-            qty: int = int(float(pos.qty or 0))
-            if qty != 0:
+            # Float qty: a fractional Alpaca position would truncate to 0
+            # under int() and get filtered out, hiding a real holding from
+            # the reconciler.
+            qty: float = float(pos.qty or 0)
+            if abs(qty) > 1e-6:
                 alpaca_by_ticker[ticker] = pos
 
         for ticker, pos in alpaca_by_ticker.items():
@@ -201,11 +204,16 @@ class StateRecovery:
                 result.positions_created.append(ticker)
             else:
                 db_row: dict[str, Any] = db_by_ticker[ticker]
-                alpaca_qty: int = int(float(pos.qty or 0))
-                db_qty: int = int(db_row.get("quantity", 0))
-                if alpaca_qty != db_qty:
+                # Compare as floats — Alpaca holds fractional quantities (1/1e6
+                # increments). int() truncation here would silently mask a
+                # 0.43-vs-0 sync gap by collapsing both sides to 0. Use a
+                # tolerance to absorb float-repr noise without flagging a
+                # legitimate match as a drift.
+                alpaca_qty: float = float(pos.qty or 0)
+                db_qty: float = float(db_row.get("quantity", 0))
+                if abs(alpaca_qty - db_qty) > 1e-6:
                     logger.warning(
-                        "Quantity mismatch for %s: Alpaca=%d, DB=%d. Updating DB.",
+                        "Quantity mismatch for %s: Alpaca=%.6f, DB=%.6f. Updating DB.",
                         ticker, alpaca_qty, db_qty,
                     )
                     self._update_db_quantity(db_row["id"], alpaca_qty)
@@ -237,8 +245,11 @@ class StateRecovery:
 
         for pos in alpaca_positions:
             ticker: str = str(pos.symbol)
-            qty: int = int(float(pos.qty or 0))
-            if qty == 0:
+            # Float qty: a fractional Alpaca position truncates to 0 here
+            # and the loop would skip ahead, leaving the position
+            # unprotected (no emergency stop placed).
+            qty: float = float(pos.qty or 0)
+            if abs(qty) <= 1e-6:
                 continue
             if ticker not in tickers_with_stops:
                 logger.warning("No stop order found for %s - placing stop", ticker)
@@ -253,7 +264,10 @@ class StateRecovery:
         from alpaca.trading.enums import OrderSide, OrderType, TimeInForce
 
         avg_cost: float = float(pos.avg_entry_price or 0)
-        qty: int = int(float(pos.qty or 0))
+        # Float qty: Alpaca holds fractional positions (1/1e6 increments).
+        # Truncating to int would refuse to place an emergency stop on any
+        # sub-1-share holding.
+        qty: float = float(pos.qty or 0)
         ticker: str = str(pos.symbol)
 
         if avg_cost <= 0:
@@ -269,7 +283,7 @@ class StateRecovery:
         try:
             # Alpaca requires a positive qty; side (SELL for long, BUY for
             # short) determines whether the order closes or opens exposure.
-            order_qty: int = abs(qty)
+            order_qty: float = abs(qty)
             request = StopOrderRequest(
                 symbol=ticker,
                 qty=order_qty,
@@ -281,7 +295,7 @@ class StateRecovery:
             # Alpaca SDK is sync — offload to a worker thread so we don't
             # block the event loop on the HTTP submit.
             await asyncio.to_thread(self._gw.client.submit_order, order_data=request)
-            logger.info("Emergency stop placed for %s: %s %d @ stop %.2f", ticker, side.value, order_qty, stop_price)
+            logger.info("Emergency stop placed for %s: %s %.6f @ stop %.2f", ticker, side.value, order_qty, stop_price)
         except Exception:
             logger.exception("Failed to place emergency stop for %s", ticker)
 
@@ -400,8 +414,12 @@ class StateRecovery:
                     ticker,
                 )
                 continue
-            qty: int = int(float(pos.qty or 0))
-            if qty == 0:
+            # Float qty: a fractional Alpaca position truncated to int
+            # would be zeroed and skipped here — the EOD flatten path
+            # would silently leave it open overnight, exposing the bot
+            # to gap risk it was specifically designed to avoid.
+            qty: float = float(pos.qty or 0)
+            if abs(qty) <= 1e-6:
                 continue
 
             side: OrderSide = OrderSide.SELL if qty > 0 else OrderSide.BUY
@@ -414,7 +432,7 @@ class StateRecovery:
                 )
                 await asyncio.to_thread(self._gw.client.submit_order, order_data=request)
                 logger.warning(
-                    "EOD flatten: %s %d %s (cutoff=%s)",
+                    "EOD flatten: %s %.6f %s (cutoff=%s)",
                     side.value, abs(qty), ticker, cutoff_str,
                 )
                 result.eod_flatten_orders.append(ticker)
@@ -471,7 +489,10 @@ class StateRecovery:
     def _create_db_position(self, ticker: str, pos: AlpacaPosition) -> None:
         now: str = datetime.now(tz=ET).isoformat()
         avg_cost: float = float(pos.avg_entry_price or 0)
-        qty: int = int(float(pos.qty or 0))
+        # Float qty: Alpaca holds fractional positions; truncating an Alpaca-
+        # discovered position to int would write the DB row as 0 shares,
+        # which the exit path then refuses to close.
+        qty: float = float(pos.qty or 0)
 
         conn: sqlite3.Connection = sqlite3.connect(self._db_path)
         try:
@@ -483,13 +504,13 @@ class StateRecovery:
                 (ticker, str(pos.exchange or "US"), "USD", qty, avg_cost, now),
             )
             conn.commit()
-            logger.info("Created DB position for %s: qty=%d, price=%.4f", ticker, qty, avg_cost)
+            logger.info("Created DB position for %s: qty=%.6f, price=%.4f", ticker, qty, avg_cost)
         except sqlite3.OperationalError:
             logger.warning("Could not create position for %s", ticker)
         finally:
             conn.close()
 
-    def _update_db_quantity(self, position_id: int, new_qty: int) -> None:
+    def _update_db_quantity(self, position_id: int, new_qty: float) -> None:
         now: str = datetime.now(tz=ET).isoformat()
         conn: sqlite3.Connection = sqlite3.connect(self._db_path)
         try:
@@ -535,7 +556,11 @@ class StateRecovery:
                         "SELECT * FROM positions WHERE id = ?", (position_id,)
                     ).fetchone()
                     if row:
-                        qty: int = int(row["quantity"] or 0)
+                        # Float-typed: positions.quantity may be fractional.
+                        # int() truncation of -0.43 → 0 would mis-derive side
+                        # as BUY. Sign-of-the-float is the only invariant we
+                        # need here.
+                        qty: float = float(row["quantity"] or 0)
                         # The bot is long-only at the strategy layer, but
                         # the schema technically allows shorts — derive
                         # rather than assume. Positive qty == long entry.

--- a/trading_bot/main.py
+++ b/trading_bot/main.py
@@ -862,14 +862,19 @@ class TradingBot:
                 else:
                     self._clear_spread_defer(ticker)
 
-            qty: int = int(position.get("quantity", 0))
-            if qty <= 0:
+            # Float-typed: positions.quantity may be fractional (mean_reversion
+            # and overnight_drift run with fractional_shares=true under the
+            # ai-broker#39 plain-limit + standalone-stop entry path). int()
+            # would silently truncate 0.43 → 0 and skip every sub-1-share exit,
+            # leaving fractional positions unmanaged.
+            qty: float = float(position.get("quantity", 0))
+            if qty <= 0.0:
                 logger.warning("%s: exit triggered but qty=0 — skipping", ticker)
                 continue
 
             if self._dry_run:
                 logger.info(
-                    "[DRY RUN] Would exit: SELL %d %s @ %.4f (reason=%s)",
+                    "[DRY RUN] Would exit: SELL %.6f %s @ %.4f (reason=%s)",
                     qty, ticker, current_price, exit_decision.reason,
                 )
                 continue
@@ -1009,19 +1014,21 @@ class TradingBot:
             if ticker_market is not None and ticker_market != market:
                 continue
 
-            qty: int = int(position.get("quantity", 0))
-            if qty <= 0:
+            # Float-typed: positions.quantity may be fractional. See note in
+            # check_exits — int() truncation skips sub-1-share holdings.
+            qty: float = float(position.get("quantity", 0))
+            if qty <= 0.0:
                 continue
 
             logger.info(
-                "Wind-down: closing intraday %s (%d shares) for %s market",
+                "Wind-down: closing intraday %s (%.6f shares) for %s market",
                 ticker, qty, market.value,
             )
 
             if self._dry_run:
                 current_price: float | None = self._market_data.get_latest_price(ticker)
                 logger.info(
-                    "[DRY RUN] Would wind-down: SELL %d %s @ %.4f",
+                    "[DRY RUN] Would wind-down: SELL %.6f %s @ %.4f",
                     qty, ticker, current_price or 0.0,
                 )
                 continue

--- a/trading_bot/strategy/portfolio_assessor.py
+++ b/trading_bot/strategy/portfolio_assessor.py
@@ -169,7 +169,11 @@ class PortfolioAssessor:
         market_value: float = float(position.get("market_value", 0.0))
         unrealized_pnl: float = float(position.get("unrealized_pnl", 0.0))
         avg_cost: float = float(position.get("avg_cost", 0.0))
-        quantity: int = int(position.get("quantity", 0))
+        # Float-typed: positions.quantity is fractional under the
+        # ai-broker#39 entry path. int() truncation of 0.43 → 0 would zero
+        # out cost_basis below and produce a 0% P&L for any sub-1-share
+        # holding.
+        quantity: float = float(position.get("quantity", 0))
 
         # Account is USD-only — Alpaca returns USD, no conversion needed
         value_usd: float = market_value

--- a/trading_bot/tests/test_order_manager_lifecycle.py
+++ b/trading_bot/tests/test_order_manager_lifecycle.py
@@ -4,9 +4,9 @@ trail activation, hydration, and cancel/flatten paths."""
 from __future__ import annotations
 
 import sqlite3
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -67,16 +67,6 @@ def _alpaca_order(
     return o
 
 
-def _bracket_legs(stop_id: str = "stop-1", target_id: str = "target-1"):
-    stop_leg = MagicMock()
-    stop_leg.id = stop_id
-    stop_leg.order_type = "stop"
-    target_leg = MagicMock()
-    target_leg.id = target_id
-    target_leg.order_type = "limit"
-    return [stop_leg, target_leg]
-
-
 # ---------------------------------------------------------------------------
 # Hydration
 # ---------------------------------------------------------------------------
@@ -105,31 +95,37 @@ class TestHydration:
 
 
 # ---------------------------------------------------------------------------
-# Entry fill → bracket legs
+# Entry fill → standalone stop attach
 # ---------------------------------------------------------------------------
 
 
 class TestEntryFill:
     @pytest.mark.asyncio
-    async def test_fill_picks_up_bracket_legs(
+    async def test_fill_attaches_standalone_stop(
         self, config, tmp_db_path: str, mock_notifier
     ):
+        """On fill, a single StopOrderRequest is submitted (no take-profit).
+        Take-profit is managed by the tick-loop's check_exits polling against
+        target_price, not by the broker."""
+        from alpaca.trading.requests import StopOrderRequest
+
         om = _make_om(config, tmp_db_path, mock_notifier)
-        entry_alpaca = _alpaca_order("entry-1", "new")
-        om._gw.client.submit_order = MagicMock(return_value=entry_alpaca)
+        captured: list = []
+
+        def _submit(order_data):
+            captured.append(order_data)
+            order_id = f"order-{len(captured)}"
+            return _alpaca_order(order_id, "new")
+
+        om._gw.client.submit_order = MagicMock(side_effect=_submit)
         trade_id = await om.place_entry(_entry())
 
-        # Polling: entry filled, fetch returns bracket legs.
-        # After transitioning to STOP_AND_TARGET_ACTIVE, the loop also probes
-        # the stop and target legs — return "new" for those so the position
-        # stays open and we can assert the leg IDs were captured.
         filled_entry = _alpaca_order(
-            "entry-1", "filled", filled_qty=100, filled_avg_price=10.0,
-            legs=_bracket_legs("stop-9", "target-9"),
+            "order-1", "filled", filled_qty=100, filled_avg_price=10.0,
         )
 
         def lookup(oid: str):
-            if oid == "entry-1":
+            if oid == "order-1":
                 return filled_entry
             return _alpaca_order(oid, "new")
         om._gw.client.get_order_by_id = MagicMock(side_effect=lookup)
@@ -138,32 +134,64 @@ class TestEntryFill:
 
         active = om._active_orders[trade_id]
         assert active.status == PositionStatus.STOP_AND_TARGET_ACTIVE
-        assert active.alpaca_stop_order_id == "stop-9"
-        assert active.alpaca_target_order_id == "target-9"
+        # Second submit_order call was the standalone stop
+        assert len(captured) == 2
+        stop_req = captured[1]
+        assert isinstance(stop_req, StopOrderRequest)
+        assert active.alpaca_stop_order_id == "order-2"
+        # No take-profit submitted to the broker
+        assert active.alpaca_target_order_id is None
         mock_notifier.trade_entry.assert_awaited()
 
     @pytest.mark.asyncio
-    async def test_missing_stop_leg_triggers_emergency_flatten(
+    async def test_stop_attach_failure_triggers_emergency_flatten(
         self, config, tmp_db_path: str, mock_notifier
     ):
+        """If the standalone stop submit fails, the position is unprotected.
+        Recovery: emergency_flatten + notify + collapse to terminal state so
+        the next stateless tick does not re-evaluate a ghost POSITION_OPEN
+        row with no broker-side protection."""
         om = _make_om(config, tmp_db_path, mock_notifier)
-        entry_alpaca = _alpaca_order("entry-1", "new")
-        # Two submit_order calls: entry, then emergency flatten.
-        om._gw.client.submit_order = MagicMock(
-            side_effect=[entry_alpaca, _alpaca_order("flatten-1", "new")]
-        )
-        await om.place_entry(_entry())
+        call_count = {"n": 0}
 
-        # Bracket legs missing entirely
+        def _submit(order_data):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return _alpaca_order("entry-1", "new")
+            if call_count["n"] == 2:
+                # Stop submit fails
+                raise RuntimeError("stop submit rejected")
+            # Third call: emergency flatten market order
+            return _alpaca_order("flatten-1", "new")
+
+        om._gw.client.submit_order = MagicMock(side_effect=_submit)
+        trade_id = await om.place_entry(_entry())
+
         filled = _alpaca_order(
-            "entry-1", "filled", filled_qty=100, filled_avg_price=10.0, legs=None,
+            "entry-1", "filled", filled_qty=100, filled_avg_price=10.0,
         )
         om._gw.client.get_order_by_id = MagicMock(return_value=filled)
 
         await om._check_order_statuses()
 
-        # Emergency flatten was called (second submit_order)
-        assert om._gw.client.submit_order.call_count == 2
+        # entry + (failed) stop + emergency flatten = 3 submit_order calls
+        assert call_count["n"] == 3
+        # Surfaced to the operator as a high-priority notification
+        mock_notifier.send.assert_awaited()
+        # State machine collapsed cleanly — next tick won't re-evaluate.
+        assert trade_id not in om._active_orders
+        # Misleading "trade entered" notification is suppressed for a
+        # position that was force-flattened immediately after fill.
+        mock_notifier.trade_entry.assert_not_awaited()
+        # DB row at terminal status, hydration won't reload it.
+        conn = sqlite3.connect(tmp_db_path)
+        try:
+            status = conn.execute(
+                "SELECT status FROM positions WHERE id = ?", (trade_id,),
+            ).fetchone()[0]
+        finally:
+            conn.close()
+        assert status == PositionStatus.ENTRY_FAILED.value
 
 
 # ---------------------------------------------------------------------------
@@ -177,8 +205,13 @@ class TestEntryTimeout:
         self, config, tmp_db_path: str, mock_notifier
     ):
         om = _make_om(config, tmp_db_path, mock_notifier)
-        entry_alpaca = _alpaca_order("entry-1", "new")
-        om._gw.client.submit_order = MagicMock(return_value=entry_alpaca)
+        # submit_order is called twice: entry, then standalone stop on partial fill.
+        om._gw.client.submit_order = MagicMock(
+            side_effect=[
+                _alpaca_order("entry-1", "new"),
+                _alpaca_order("stop-1", "new"),
+            ]
+        )
         trade_id = await om.place_entry(_entry(shares=100))
 
         # Partial fill of 80 shares (> 50% default), submitted long ago
@@ -187,7 +220,6 @@ class TestEntryTimeout:
             "entry-1", "partially_filled",
             filled_qty=80.0, filled_avg_price=10.0,
             submitted_at=old_submitted,
-            legs=_bracket_legs(),
         )
         om._gw.client.get_order_by_id = MagicMock(return_value=partial)
         om._gw.client.cancel_order_by_id = MagicMock()
@@ -196,9 +228,11 @@ class TestEntryTimeout:
 
         # Cancelled the timed-out entry
         om._gw.client.cancel_order_by_id.assert_called()
-        # Position transitioned to bracket-active (stop+target leg IDs were picked up)
+        # Position transitioned to STOP_AND_TARGET_ACTIVE with standalone stop
         active = om._active_orders[trade_id]
         assert active.status == PositionStatus.STOP_AND_TARGET_ACTIVE
+        assert active.alpaca_stop_order_id == "stop-1"
+        assert active.alpaca_target_order_id is None
 
     @pytest.mark.asyncio
     async def test_partial_fill_below_min_pct_flattens(
@@ -259,7 +293,12 @@ class TestEntryTimeout:
         om = _make_om(config, tmp_db_path, mock_notifier)
         entry_alpaca = _alpaca_order("entry-1", "new")
         om._gw.client.submit_order = MagicMock(return_value=entry_alpaca)
-        trade_id = await om.place_entry(_entry(shares=100))
+        await om.place_entry(_entry(shares=100))
+
+        # Add stop submit response for the partial-fill transition.
+        om._gw.client.submit_order = MagicMock(
+            side_effect=[_alpaca_order("stop-1", "new")]
+        )
 
         # Naive datetime from "long ago"
         naive_old = datetime.now(tz=ET).replace(tzinfo=None) - timedelta(seconds=600)
@@ -267,7 +306,6 @@ class TestEntryTimeout:
             "entry-1", "partially_filled",
             filled_qty=80.0, filled_avg_price=10.0,
             submitted_at=naive_old,
-            legs=_bracket_legs(),
         )
         om._gw.client.get_order_by_id = MagicMock(return_value=partial)
         om._gw.client.cancel_order_by_id = MagicMock()
@@ -756,16 +794,20 @@ class TestPlaceEntryFailure:
         assert float(pnl_usd) == 0.0
 
 
-class TestFractionalShareFloor:
-    """2026-05-01 incident: Alpaca rejects fractional+bracket combos (code
-    42210000). Floor to whole shares so the bracket path is legal. Until the
-    standalone-stop refactor lands, this is the gate that keeps live trading
-    from no-op'ing every signal."""
+class TestFractionalEntry:
+    """ai-broker#39: Plain-limit + standalone-stop entry path supports fractional
+    shares end-to-end. The previous whole-share floor (PR #38) was a stopgap that
+    dropped ~50% of mean_reversion signals on a $1k account; it has been removed
+    in favor of submitting a non-bracketed limit order followed by a standalone
+    stop on fill."""
 
     @pytest.mark.asyncio
-    async def test_fractional_shares_floored_before_submit(
+    async def test_fractional_shares_passed_through(
         self, config, tmp_db_path: str, mock_notifier
     ):
+        """Fractional shares survive submit untouched — no implicit floor."""
+        from alpaca.trading.requests import LimitOrderRequest
+
         om = _make_om(config, tmp_db_path, mock_notifier)
         captured: list = []
 
@@ -776,22 +818,53 @@ class TestFractionalShareFloor:
         om._gw.client.submit_order = MagicMock(side_effect=_capture)
 
         decision = _entry(ticker="XLF", shares=10, price=51.0)
-        decision.shares = 2.7  # type: ignore[assignment]
+        decision.shares = 2.7
         trade_id = await om.place_entry(decision)
 
         assert trade_id is not None
         assert len(captured) == 1
-        assert int(captured[0].qty) == 2, f"expected qty=2, got {captured[0].qty}"
+        req = captured[0]
+        assert isinstance(req, LimitOrderRequest)
+        # Plain limit — no order_class, no children
+        assert getattr(req, "order_class", None) is None
+        assert getattr(req, "stop_loss", None) is None
+        assert getattr(req, "take_profit", None) is None
+        # Quantity flowed through as-is (no floor)
+        assert float(req.qty) == 2.7
 
     @pytest.mark.asyncio
-    async def test_zero_share_floor_skips_without_db_insert(
+    async def test_sub_one_share_signal_not_dropped(
         self, config, tmp_db_path: str, mock_notifier
     ):
+        """Sub-1-share fractional decision still reaches the broker.
+        Pre-fix the whole-share floor turned this into a no-op."""
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        captured: list = []
+
+        def _capture(order_data):
+            captured.append(order_data)
+            return _alpaca_order("entry-1", "new")
+
+        om._gw.client.submit_order = MagicMock(side_effect=_capture)
+
+        decision = _entry(ticker="SPY", shares=1, price=700.0)
+        decision.shares = 0.43
+        trade_id = await om.place_entry(decision)
+
+        assert trade_id is not None
+        assert len(captured) == 1
+        assert float(captured[0].qty) == 0.43
+
+    @pytest.mark.asyncio
+    async def test_non_positive_shares_skipped_without_db_insert(
+        self, config, tmp_db_path: str, mock_notifier
+    ):
+        """shares <= 0 is a degenerate sizing result; no order or DB row."""
         om = _make_om(config, tmp_db_path, mock_notifier)
         om._gw.client.submit_order = MagicMock()
 
-        decision = _entry(ticker="SPY", shares=10, price=700.0)
-        decision.shares = 0.43  # type: ignore[assignment]
+        decision = _entry(ticker="SPY", shares=1, price=700.0)
+        decision.shares = 0.0
         trade_id = await om.place_entry(decision)
 
         assert trade_id is None
@@ -805,6 +878,101 @@ class TestFractionalShareFloor:
             conn.close()
         assert n_pos == 0
         assert n_trades == 0
+
+    @pytest.mark.asyncio
+    async def test_fractional_fill_attaches_standalone_stop(
+        self, config, tmp_db_path: str, mock_notifier
+    ):
+        """End-to-end: fractional entry → fill → standalone stop with the
+        same fractional qty. Verifies the issue#39 acceptance path."""
+        from alpaca.trading.requests import StopOrderRequest
+
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        captured: list = []
+
+        def _submit(order_data):
+            captured.append(order_data)
+            order_id = f"order-{len(captured)}"
+            return _alpaca_order(order_id, "new")
+
+        om._gw.client.submit_order = MagicMock(side_effect=_submit)
+
+        decision = _entry(ticker="SPY", shares=1, price=700.0)
+        decision.shares = 0.43
+        trade_id = await om.place_entry(decision)
+
+        # Fill the entry at the (fractional) decision quantity
+        filled = _alpaca_order(
+            "order-1", "filled", filled_qty=0.43, filled_avg_price=700.0,
+        )
+
+        def lookup(oid: str):
+            if oid == "order-1":
+                return filled
+            return _alpaca_order(oid, "new")
+        om._gw.client.get_order_by_id = MagicMock(side_effect=lookup)
+
+        await om._check_order_statuses()
+
+        # Two submit calls: the limit entry, then the standalone stop.
+        assert len(captured) == 2
+        stop_req = captured[1]
+        assert isinstance(stop_req, StopOrderRequest)
+        assert float(stop_req.qty) == 0.43
+        active = om._active_orders[trade_id]
+        assert active.alpaca_stop_order_id == "order-2"
+        assert active.alpaca_target_order_id is None
+
+    @pytest.mark.asyncio
+    async def test_alpaca_42210000_simulated_no_rejection_under_new_path(
+        self, config, tmp_db_path: str, mock_notifier
+    ):
+        """Integration check: a stubbed Alpaca that rejects fractional+bracket
+        with code 42210000 but accepts plain LimitOrderRequest must produce
+        zero rejections under the new entry path. This is the regression gate
+        the issue's acceptance criteria call out."""
+        from alpaca.trading.requests import LimitOrderRequest, StopOrderRequest
+
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        captured: list = []
+
+        def _stub_alpaca(order_data):
+            captured.append(order_data)
+            # Simulate Alpaca's real rejection for any fractional+bracket combo.
+            is_bracket = bool(getattr(order_data, "order_class", None))
+            qty = float(getattr(order_data, "qty", 0) or 0)
+            if is_bracket and qty != int(qty):
+                raise RuntimeError(
+                    "{'code':42210000,'message':'fractional orders must be simple orders'}"
+                )
+            return _alpaca_order(f"order-{len(captured)}", "new")
+
+        om._gw.client.submit_order = MagicMock(side_effect=_stub_alpaca)
+
+        decision = _entry(ticker="SPY", shares=1, price=700.0)
+        decision.shares = 0.43
+        trade_id = await om.place_entry(decision)
+
+        # Fractional entry survived without 42210000 rejection.
+        assert trade_id is not None
+
+        # On fill, the standalone stop is also accepted.
+        filled = _alpaca_order(
+            "order-1", "filled", filled_qty=0.43, filled_avg_price=700.0,
+        )
+        om._gw.client.get_order_by_id = MagicMock(
+            side_effect=lambda oid: filled if oid == "order-1"
+            else _alpaca_order(oid, "new")
+        )
+
+        await om._check_order_statuses()
+
+        # Both submitted requests are simple (non-bracket); neither tripped 42210000.
+        assert len(captured) == 2
+        assert isinstance(captured[0], LimitOrderRequest)
+        assert isinstance(captured[1], StopOrderRequest)
+        for req in captured:
+            assert getattr(req, "order_class", None) is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes ai-broker#39.

## Summary

Replaces the bracket-order entry with a plain `LimitOrderRequest` followed by a standalone `StopOrderRequest` attached on fill. Take-profit is managed by the tick-loop's `check_exits` polling against `target_price`. Removes the PR #38 whole-share floor that was dropping ~50% of mean_reversion signals on the $1k live account.

## Why this needed a cascade fix

Removing the whole-share floor unmasked **8 latent fractional-truncation sites** across the live order path. Each was dormant on main only because no fractional position had ever reached production. Without fixing them in lockstep, fractional entries would land at the broker, then the next tick would silently skip them at exit time, EOD flatten, or reconcile.

| Site | Symptom if left unfixed |
|---|---|
| `main.check_exits` | `int(0.43) = 0`, position skipped at exit |
| `main._wind_down_market` | EOD wind-down leaves fractional intraday open overnight |
| `recovery._reconcile` | Alpaca-vs-DB qty drift collapses to 0==0, masked |
| `recovery._verify_stop_orders` | Refuses to place emergency stop on fractional |
| `recovery._eod_intraday_flatten` | EOD flatten skips fractional positions — gap risk |
| `recovery._create_db_position` | Alpaca-discovered position written to DB as 0 shares |
| `recovery._close_db_position` | INSERT trades side derivation broken |
| `portfolio_assessor` | `cost_basis = 0` → P&L pct always 0% |

## Acceptance gate the PR cannot satisfy

The Mon/Tue paper smoke test (real fractional entry → fill → standalone stop → exit) is a runtime check, not a code change. **Run it before flipping `ALPACA_ENV=live`.**

## Backtest A/B

13-ETF, 2024 full year, \$1k cash, `--no-regime-filter`:

| | Branch | Main |
|---|---|---|
| mean_reversion | 61 trades, +20.01%, PF 1.81 | 61 trades, +20.01%, PF 1.81 |
| overnight_drift | 744 trades, +20.93%, PF 1.46 | 744 trades, +20.93%, PF 1.46 |

Byte-identical — the backtest doesn't traverse `order_manager`. The win is that the live path now routes those exact fractional trades to Alpaca instead of flooring them to 0.

## Deferred (tracked in `self_improve_followups.md`)

- `STOP_AND_TARGET_ACTIVE` → `STOP_ACTIVE` rename + V11 migration. 45 references across 10 files; pre-Monday naming churn isn't justified. Hydration of pre-rename rows works fine — same enum value.

## Test plan

- [x] All 752 tests pass
- [x] ruff clean on edited files
- [x] mypy: 1 fewer error than main (no regression)
- [x] Backtest A/B byte-identical to main
- [x] New tests cover: stop-attach race, fractional pass-through, simulated 42210000 rejection, fractional fill end-to-end
- [ ] **Mon/Tue paper smoke test before flipping `ALPACA_ENV=live`**