### PR TITLE
fix(execution): unblock asyncio loop + tz-aware drawdown cutoff

### DIFF
--- a/trading_bot/execution/order_manager.py
+++ b/trading_bot/execution/order_manager.py
@@ -381,7 +381,9 @@ class OrderManager:
                 time_in_force=TimeInForce.DAY,
                 limit_price=round(decision.limit_price, 2),
             )
-            order: AlpacaOrder = client.submit_order(order_data=request)
+            order: AlpacaOrder = await asyncio.to_thread(
+                client.submit_order, order_data=request,
+            )
             alpaca_order_id: str = str(order.id)
 
             logger.info(
@@ -524,7 +526,9 @@ class OrderManager:
                 time_in_force=TimeInForce.GTC,
                 trail_percent=round(trail_pct * 100, 2),
             )
-            order: AlpacaOrder = client.submit_order(order_data=request)
+            order: AlpacaOrder = await asyncio.to_thread(
+                client.submit_order, order_data=request,
+            )
             order_id: str = str(order.id)
             logger.info(
                 "Trailing stop placed: %s %.6f trail=%.2f%% (alpaca_id=%s, trade_id=%d)",
@@ -955,7 +959,9 @@ class OrderManager:
                 time_in_force=TimeInForce.GTC,
                 stop_price=round(active.stop_price, 2),
             )
-            order: AlpacaOrder = self._gw.client.submit_order(order_data=request)
+            order: AlpacaOrder = await asyncio.to_thread(
+                self._gw.client.submit_order, order_data=request,
+            )
             return str(order.id)
         except Exception:
             logger.exception(

--- a/trading_bot/execution/risk_manager.py
+++ b/trading_bot/execution/risk_manager.py
@@ -352,7 +352,7 @@ class RiskManager:
             conn: sqlite3.Connection = sqlite3.connect(self._db_path)
             try:
                 cutoff: str = (
-                    date.today() - timedelta(days=rolling_days)
+                    datetime.now(tz=ET).date() - timedelta(days=rolling_days)
                 ).isoformat()
                 rows = conn.execute(
                     "SELECT account_equity_usd FROM daily_summaries "


### PR DESCRIPTION
## Summary
- Wrap three sync `client.submit_order()` calls in `asyncio.to_thread` (`place_entry`, `place_trailing_stop`, `_place_standalone_stop`) to stop blocking the event loop during entry and post-fill stop attachment. Matches the existing pattern at lines 595, 696, 817.
- Replace naive `date.today()` in `RiskManager._get_rolling_peak_equity` with `datetime.now(tz=ET).date()`. On UTC runners during the 00:00–04:00 UTC window the prior code returned tomorrow's ET date and silently dropped today's equity row from the rolling-peak query, making the drawdown gate too permissive.

Both findings from `/python-review` critical-path audit for week of 2026-05-04. The third finding (`PositionSize.shares: int` latent fractional-truncation trap) is tracked in #55 and is not blocking next-week paper trading.

## Test plan
- [x] `pytest trading_bot/tests/` — 752 passed, 2 skipped
- [x] `ruff check trading_bot/execution/order_manager.py trading_bot/execution/risk_manager.py` — clean
- [x] Targeted: `test_order_manager_lifecycle.py`, `test_order_state_machine.py`, `test_main_tick.py`, `test_risk_manager.py` — all 85 pass
- [ ] First live paper-trading tick on Monday confirms entries/stops still place correctly

Refs: #55 (CRITICAL latent — separate)