### PR TITLE
fix(safety): order-safety hardening pre-2026-05-04 open

### DIFF
--- a/trading_bot/execution/order_manager.py
+++ b/trading_bot/execution/order_manager.py
@@ -93,6 +93,14 @@ class _ActiveOrder:
     alpaca_stop_order_id: str | None = None
     alpaca_target_order_id: str | None = None
     alpaca_trail_order_id: str | None = None
+    # Strategy-driven exit (place_exit / place_limit_exit). Populated
+    # when the position transitions to CLOSING; polled by
+    # _check_order_statuses to advance CLOSING -> CLOSED with the real
+    # exit_reason instead of leaving the row for state-recovery to
+    # tag as 'reconciliation_mismatch' next tick. In-memory only —
+    # process restarts fall back to the recovery path.
+    alpaca_exit_order_id: str | None = None
+    exit_reason: str | None = None
     status: PositionStatus = PositionStatus.ENTRY_PENDING
     entry_shares: float = 0.0  # float to support fractional shares
     filled_shares: float = 0.0
@@ -248,8 +256,8 @@ class OrderManager:
                 and active.alpaca_entry_order_id
             ):
                 try:
-                    order: AlpacaOrder = client.get_order_by_id(
-                        active.alpaca_entry_order_id
+                    order: AlpacaOrder = await asyncio.to_thread(
+                        client.get_order_by_id, active.alpaca_entry_order_id,
                     )
                     if order.status.value == "filled":
                         active.filled_shares = float(order.filled_qty or 0)
@@ -319,7 +327,9 @@ class OrderManager:
                     if order_id is None:
                         continue
                     try:
-                        order = client.get_order_by_id(order_id)
+                        order = await asyncio.to_thread(
+                            client.get_order_by_id, order_id,
+                        )
                         if order.status.value == "filled":
                             exit_price: float = float(order.filled_avg_price or 0)
                             logger.info(
@@ -342,6 +352,60 @@ class OrderManager:
                             "Error checking exit order for %s", active.ticker,
                             exc_info=True,
                         )
+
+            # Strategy-driven exit (place_exit / place_limit_exit). Without
+            # this branch the row stays CLOSING until the next tick's
+            # StateRecovery reconciles it as 'reconciliation_mismatch',
+            # losing the real exit_reason. The recovery path is still the
+            # ultimate fallback for crashed ticks / process restarts (the
+            # exit_order_id is in-memory only).
+            if (
+                active.status == PositionStatus.CLOSING
+                and active.alpaca_exit_order_id is not None
+            ):
+                exit_oid: str = active.alpaca_exit_order_id
+                try:
+                    exit_order = await asyncio.to_thread(
+                        client.get_order_by_id, exit_oid,
+                    )
+                    if exit_order.status.value == "filled":
+                        exit_px: float = float(exit_order.filled_avg_price or 0)
+                        reason_str: str = active.exit_reason or "strategy_exit"
+                        logger.info(
+                            "Strategy exit FILLED: %s reason=%s @ %.4f (trade_id=%d)",
+                            active.ticker, reason_str, exit_px, trade_id,
+                        )
+                        await self._close_position(
+                            trade_id, active, exit_px, reason_str,
+                        )
+                        pnl_strategy: float = (
+                            (exit_px - active.entry_price) * active.filled_shares
+                        )
+                        await self._notifier.position_closed(
+                            ticker=active.ticker, pnl=pnl_strategy,
+                            hold_time="", exit_reason=reason_str,
+                        )
+                    elif exit_order.status.value in ("canceled", "expired", "rejected"):
+                        # Limit exit didn't fill (e.g. price gapped through
+                        # the limit). Roll back to STOP_AND_TARGET_ACTIVE so
+                        # the next tick re-evaluates the exit condition; the
+                        # protective stop is re-attached by recovery if it
+                        # was cancelled.
+                        logger.warning(
+                            "Strategy exit %s for %s — rolling back to STOP_AND_TARGET_ACTIVE",
+                            exit_order.status.value, active.ticker,
+                        )
+                        active.alpaca_exit_order_id = None
+                        active.exit_reason = None
+                        active.status = PositionStatus.STOP_AND_TARGET_ACTIVE
+                        self._update_position_status(
+                            trade_id, PositionStatus.STOP_AND_TARGET_ACTIVE,
+                        )
+                except Exception:
+                    logger.warning(
+                        "Error polling strategy exit for %s", active.ticker,
+                        exc_info=True,
+                    )
 
     # ------------------------------------------------------------------
     # Entry orders
@@ -555,7 +619,7 @@ class OrderManager:
     async def cancel_order(self, order_id: str) -> None:
         """Cancel an order by Alpaca order ID."""
         try:
-            self._gw.client.cancel_order_by_id(order_id)
+            await asyncio.to_thread(self._gw.client.cancel_order_by_id, order_id)
             logger.info("Cancelled order %s", order_id)
         except Exception:
             # Benign: order may already be filled/cancelled by the time we try.
@@ -569,10 +633,14 @@ class OrderManager:
                 status=QueryOrderStatus.OPEN,
                 symbols=[ticker],
             )
-            orders: list[AlpacaOrder] = self._gw.client.get_orders(filter=request)
+            orders: list[AlpacaOrder] = await asyncio.to_thread(
+                self._gw.client.get_orders, filter=request,
+            )
             for order in orders:
                 try:
-                    self._gw.client.cancel_order_by_id(str(order.id))
+                    await asyncio.to_thread(
+                        self._gw.client.cancel_order_by_id, str(order.id),
+                    )
                 except Exception:
                     logger.warning("Error cancelling order for %s", ticker, exc_info=True)
             if orders:
@@ -709,6 +777,8 @@ class OrderManager:
                 self._alpaca_to_trade[order_id] = matching_trade_id
                 if matching_active is not None:
                     matching_active.status = PositionStatus.CLOSING
+                    matching_active.alpaca_exit_order_id = order_id
+                    matching_active.exit_reason = reason
                 self._update_position_status(
                     matching_trade_id, PositionStatus.CLOSING,
                 )
@@ -830,6 +900,8 @@ class OrderManager:
                 self._alpaca_to_trade[order_id] = matching_trade_id
                 if matching_active is not None:
                     matching_active.status = PositionStatus.CLOSING
+                    matching_active.alpaca_exit_order_id = order_id
+                    matching_active.exit_reason = reason
                 self._update_position_status(
                     matching_trade_id, PositionStatus.CLOSING,
                 )
@@ -844,6 +916,8 @@ class OrderManager:
             # the local state pointing at a phantom CLOSING.
             if matching_active is not None and prior_status is not None:
                 matching_active.status = prior_status
+                matching_active.alpaca_exit_order_id = None
+                matching_active.exit_reason = None
             if order_id is not None:
                 self._alpaca_to_trade.pop(order_id, None)
             return None
@@ -851,7 +925,9 @@ class OrderManager:
     async def flatten_all(self) -> None:
         """Flatten all positions with market orders (kill switch)."""
         try:
-            self._gw.client.close_all_positions(cancel_orders=True)
+            await asyncio.to_thread(
+                self._gw.client.close_all_positions, cancel_orders=True,
+            )
             logger.warning("Flatten all: closed all positions via Alpaca API")
         except Exception:
             logger.exception("Flatten all: error closing positions")

--- a/trading_bot/execution/risk_manager.py
+++ b/trading_bot/execution/risk_manager.py
@@ -7,6 +7,7 @@ the current phase via Config.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import sqlite3
 import time
@@ -656,7 +657,9 @@ class RiskManager:
 
         # Close all positions and cancel all orders via Alpaca API
         try:
-            gateway.client.close_all_positions(cancel_orders=True)
+            await asyncio.to_thread(
+                gateway.client.close_all_positions, cancel_orders=True,
+            )
             logger.info("Kill switch: closed all positions and cancelled all orders")
         except Exception:
             logger.exception("Kill switch: error flattening positions")

--- a/trading_bot/main.py
+++ b/trading_bot/main.py
@@ -879,19 +879,22 @@ class TradingBot:
                 )
                 continue
 
-            # Cancel existing orders for this ticker first
-            await self._order_manager.cancel_all_for_ticker(ticker)
-
             if exit_decision.use_market_order or force_market_exit:
+                # Market exit: cancel ALL ticker orders first so Alpaca
+                # releases held_for_orders qty before the IOC sell.
+                await self._order_manager.cancel_all_for_ticker(ticker)
                 await self._order_manager.emergency_flatten(ticker, qty, exchange)
                 self._clear_spread_defer(ticker)
             else:
-                # Limit sell at mid-price.  Routed through OrderManager so
-                # the position transitions to CLOSING and the exit order_id
-                # is persisted BEFORE the next tick — without that step, a
-                # slow Alpaca fill leaves the row at POSITION_OPEN and the
-                # next tick re-evaluates the exit condition, risking a
-                # double-submit.
+                # Limit sell at mid-price. place_limit_exit cancels just
+                # the bracket legs it tracks (stop/target/trail) before
+                # submitting; if the submit raises, it rolls back local
+                # state. We deliberately do NOT call cancel_all_for_ticker
+                # here — that would also cancel the protective stop with
+                # no atomic re-attach, leaving the position naked for one
+                # tick if the limit submit fails. On submission failure
+                # we fall back to emergency_flatten, which itself does
+                # cancel_all_for_ticker before the IOC sell.
                 bid_ask = self._market_data.get_bid_ask(ticker)
                 limit_price: float
                 if bid_ask is not None:
@@ -909,6 +912,7 @@ class TradingBot:
                     logger.warning(
                         "Limit exit failed for %s — falling back to market", ticker,
                     )
+                    await self._order_manager.cancel_all_for_ticker(ticker)
                     await self._order_manager.emergency_flatten(ticker, qty, exchange)
                 self._clear_spread_defer(ticker)
 

--- a/trading_bot/notifications/notifier.py
+++ b/trading_bot/notifications/notifier.py
@@ -123,6 +123,31 @@ class Notifier:
 
         self._do_send(title, message, priority, resolved_tags)
 
+    def send_sync(
+        self,
+        title: str,
+        message: str,
+        priority: int = 3,
+        tags: list[str] | None = None,
+    ) -> None:
+        """Synchronous send for callers running outside an event loop.
+
+        ``send`` itself is sync under the hood (``requests.post``); this
+        is a coroutine-free entry point for ``RiskManager`` paths that
+        run from sync code (e.g. ``can_trade()``). Scheduling via
+        ``asyncio.ensure_future`` from those paths could be silently
+        dropped if the tick exits before the task runs.
+        """
+        resolved_tags: list[str] = tags if tags is not None else []
+        if not self._can_send_now():
+            logger.warning(
+                "Rate limit (%d/min) hit — dropping notification: %s",
+                self._rate_limit,
+                title,
+            )
+            return
+        self._do_send(title, message, priority, resolved_tags)
+
     # ------------------------------------------------------------------
     # Convenience methods for specific events
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Addresses four findings from a critical-path Python review run on 2026-05-03. All four are real defects in `main` today; none has materially damaged the paper account but each closes a sharp edge before the 2026-05-04 09:30 ET open.

The remaining review items (no live-account impact) are tracked in **#58**.

## What changed

### C-1 — `Notifier.send_sync` was missing
[risk_manager.py:407](https://github.com/alex5imon/ai-broker/blob/main/trading_bot/execution/risk_manager.py#L407) (drawdown breaker) and [:467](https://github.com/alex5imon/ai-broker/blob/main/trading_bot/execution/risk_manager.py#L467) (rejection breaker) called `Notifier.send_sync`, but `Notifier` only exposed `async def send`. On trigger the breaker would log `AttributeError` instead of paging. Added a real `send_sync` mirroring `send` (rate-limit + `_do_send`); the notifier is already synchronous under the hood (`requests.post`), so this is a 25-line shim, not a redesign.

### C-2 — `CLOSING` positions were never polled
`place_exit` / `place_limit_exit` transitioned the row to `CLOSING` and pinned the exit `order_id` in `_alpaca_to_trade`, but `_check_order_statuses` only iterated `STOP_AND_TARGET_ACTIVE` / `TRAILING_ACTIVE`. The exit fill was detected one tick later by `StateRecovery._reconcile`, which writes the trade row with `exit_reason='reconciliation_mismatch'` instead of the real reason.

Added `alpaca_exit_order_id` + `exit_reason` fields on `_ActiveOrder`, set them in both `place_*_exit` paths, and added a `CLOSING` branch in `_check_order_statuses` that polls the exit order and either:
- closes the position with the correct reason (filled), or
- rolls back to `STOP_AND_TARGET_ACTIVE` so the next tick re-evaluates the exit (canceled / expired / rejected).

In-memory only — no schema change. Recovery remains the ultimate fallback for crashed ticks.

### C-3 + M-1 — sync REST calls inside `async def`
PR #56 wrapped `submit_order` in `asyncio.to_thread` but four siblings were left blocking the loop. Wrapped:
- `cancel_order_by_id` (in `cancel_order`)
- `get_orders` + `cancel_order_by_id` (in `cancel_all_for_ticker`)
- `get_order_by_id` (in `_check_order_statuses`, both polling sites)
- `close_all_positions` (in `flatten_all` and the kill-switch path in `risk_manager`)

Pure plumbing; same idiom as PR #56.

### H-5 — limit-exit branch left a brief unprotected window
`main.check_exits` called `cancel_all_for_ticker` BEFORE delegating to `place_limit_exit`, which already cancels just the bracket legs it tracks. If `place_limit_exit` raised on submit, the protective stop was cancelled and only re-attached by next-tick recovery (~5-min unprotected window).

Now `cancel_all_for_ticker` runs only on:
- the market-exit branch (where `emergency_flatten` needs the held_for_orders qty released)
- the limit-exit failure fallback (before the IOC market sell)

`place_limit_exit` owns its own atomic bracket-leg cancellation on the success path.

## Test plan

- [x] Full unit suite: 752 passed, 2 skipped, 0 failures
- [x] Backtest A/B (SPY/QQQ/XLF/XLK 2026-02-20 → 2026-04-29, no-regime): byte-identical to main
  - mean_reversion: 13 trades, +1.12%, PF 1.15
  - overnight_drift: 117 trades, −1.95%, PF 0.86
- [x] Targeted suites passed individually: `test_order_manager_lifecycle`, `test_order_state_machine`, `test_risk_manager`, `test_main_tick`, `test_exit_logic`
- [ ] First live tick post-merge: monitor logs for any `AttributeError` or `held_for_orders` rejection that wasn't there before

## Why these weren't caught earlier

- `send_sync` calls in `risk_manager` are pre-existing and weren't touched in PRs #28, #38, #52, #53, or #56 — diff-anchored reviews missed them
- `CLOSING` polling gap arrived with PR #28's exit state machine; `StateRecovery` masked it in practice
- `check_drawdown_breaker` is defined but never called from outside `risk_manager.py` (its `send_sync` site is dormant), and `_recent_rejections` is per-process — the rejection breaker fires only on a triple-rejection within a single tick. So both crash bombs almost never trigger
- PR #56 wrapped `submit_order` but didn't audit other sync REST calls in the same file

## Diff stats

```
trading_bot/execution/order_manager.py | 90 +++++++++++++++++++++++++++++++---
trading_bot/execution/risk_manager.py  |  5 +-
trading_bot/main.py                    | 22 +++++----
trading_bot/notifications/notifier.py  | 25 ++++++++++
4 files changed, 125 insertions(+), 17 deletions(-)
```

## Deferred items

Tracked in #58 — `PositionSizer` dead code (C-4), short-side P&L sign (C-5, latent), `Notifier` async/sync wrap (H-1), `_hydrate_active_orders` full-scan (H-2), `contextlib.closing` sweep (H-3/H-4), mypy redef (H-6), magic numbers (M-2), `_check_correlation` no-op (M-3/M-4).