### PR TITLE
fix(execution): use DAY TIF for fractional stop and market orders

### DIFF
--- a/trading_bot/execution/order_manager.py
+++ b/trading_bot/execution/order_manager.py
@@ -37,6 +37,7 @@ from trading_bot.constants import (
     PositionStatus,
 )
 from trading_bot.db import repository as repo
+from trading_bot.gateway.order_tif import tif_for_market, tif_for_stop
 
 if TYPE_CHECKING:
     from trading_bot.config import Config
@@ -587,7 +588,7 @@ class OrderManager:
                 symbol=ticker,
                 qty=qty,
                 side=OrderSide.SELL,
-                time_in_force=TimeInForce.GTC,
+                time_in_force=tif_for_stop(qty),
                 trail_percent=round(trail_pct * 100, 2),
             )
             order: AlpacaOrder = await asyncio.to_thread(
@@ -657,7 +658,7 @@ class OrderManager:
                 qty=qty,
                 side=OrderSide.SELL,
                 type=OrderType.MARKET,
-                time_in_force=TimeInForce.IOC,
+                time_in_force=tif_for_market(qty),
             )
             order: AlpacaOrder = await asyncio.to_thread(
                 client.submit_order, order_data=request,
@@ -1032,7 +1033,7 @@ class OrderManager:
                 symbol=active.ticker,
                 qty=qty,
                 side=OrderSide.SELL,
-                time_in_force=TimeInForce.GTC,
+                time_in_force=tif_for_stop(qty),
                 stop_price=round(active.stop_price, 2),
             )
             order: AlpacaOrder = await asyncio.to_thread(

--- a/trading_bot/gateway/order_tif.py
+++ b/trading_bot/gateway/order_tif.py
@@ -1,0 +1,38 @@
+"""Time-in-force selection helpers.
+
+Alpaca rejects fractional orders with any time-in-force other than ``DAY``
+(error code 42210000: ``fractional orders must be DAY orders``). This
+module centralises the selection so every order-submission site uses the
+same rule and a regression in any single call site can't slip through.
+"""
+
+from __future__ import annotations
+
+from alpaca.trading.enums import TimeInForce
+
+
+def is_fractional(qty: float) -> bool:
+    """Return True if ``qty`` has a non-zero fractional component."""
+    qty_f: float = float(qty)
+    return qty_f != int(qty_f)
+
+
+def tif_for_stop(qty: float) -> TimeInForce:
+    """TIF for stop / trailing-stop orders.
+
+    Whole-share stops use ``GTC`` so they survive across the day. Fractional
+    must be ``DAY`` per Alpaca. The stateless tick + recovery loop will
+    re-attach a missing stop on the next trading day's first tick.
+    """
+    return TimeInForce.DAY if is_fractional(qty) else TimeInForce.GTC
+
+
+def tif_for_market(qty: float) -> TimeInForce:
+    """TIF for emergency-flatten / market exit orders.
+
+    Whole-share markets use ``IOC`` (fill immediately or kill). Fractional
+    must be ``DAY``: during market hours a market order with DAY TIF still
+    fills immediately if there is liquidity, so the semantic gap only
+    matters off-hours — and emergency_flatten is gated to trading hours.
+    """
+    return TimeInForce.DAY if is_fractional(qty) else TimeInForce.IOC

--- a/trading_bot/gateway/recovery.py
+++ b/trading_bot/gateway/recovery.py
@@ -261,7 +261,9 @@ class StateRecovery:
     ) -> None:
         """Place a stop-loss order for a position that has no stop."""
         from alpaca.trading.requests import StopOrderRequest
-        from alpaca.trading.enums import OrderSide, OrderType, TimeInForce
+        from alpaca.trading.enums import OrderSide, OrderType
+
+        from trading_bot.gateway.order_tif import tif_for_stop
 
         avg_cost: float = float(pos.avg_entry_price or 0)
         # Float qty: Alpaca holds fractional positions (1/1e6 increments).
@@ -289,7 +291,7 @@ class StateRecovery:
                 qty=order_qty,
                 side=side,
                 type=OrderType.STOP,
-                time_in_force=TimeInForce.GTC,
+                time_in_force=tif_for_stop(order_qty),
                 stop_price=stop_price,
             )
             # Alpaca SDK is sync — offload to a worker thread so we don't

--- a/trading_bot/tests/test_order_manager_lifecycle.py
+++ b/trading_bot/tests/test_order_manager_lifecycle.py
@@ -146,6 +146,61 @@ class TestEntryFill:
         mock_notifier.trade_entry.assert_awaited()
 
     @pytest.mark.asyncio
+    async def test_fractional_fill_uses_day_tif_for_stop(
+        self, config, tmp_db_path: str, mock_notifier
+    ):
+        """Regression: 2026-05-04 incident.
+
+        Alpaca rejects stop orders on fractional positions with TIF != DAY
+        (error 42210000). Without this guard, every fractional entry hit
+        the failure path → emergency_flatten → orphan drain on next tick,
+        wiping today's strategy attribution.
+        """
+        from alpaca.trading.enums import TimeInForce
+        from alpaca.trading.requests import StopOrderRequest
+        from trading_bot.execution.order_manager import EntryDecision
+
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        captured: list = []
+
+        def _submit(order_data):
+            captured.append(order_data)
+            return _alpaca_order(f"order-{len(captured)}", "new")
+
+        om._gw.client.submit_order = MagicMock(side_effect=_submit)
+
+        # Fractional qty mirrors today's XLY entry: 4.2067 shares.
+        decision = EntryDecision(
+            ticker="XLY", exchange="US", side="BUY",
+            shares=4.2067, limit_price=117.67,
+            stop_price=115.90, target_price=120.0,
+            hold_type="intraday", sector="Consumer Discretionary",
+            phase=3, sentiment_score=0.0, signals="test",
+            currency="USD", strategy_id="mean_reversion",
+            trail_pct=None, trail_activation_price=None,
+        )
+        trade_id = await om.place_entry(decision)
+
+        filled = _alpaca_order(
+            "order-1", "filled", filled_qty=4.2067, filled_avg_price=117.67,
+        )
+        om._gw.client.get_order_by_id = MagicMock(
+            side_effect=lambda oid: filled if oid == "order-1" else _alpaca_order(oid, "new"),
+        )
+
+        await om._check_order_statuses()
+
+        # Stop order was submitted with DAY TIF, not GTC.
+        stop_req = captured[1]
+        assert isinstance(stop_req, StopOrderRequest)
+        assert stop_req.time_in_force == TimeInForce.DAY, (
+            "fractional stop must use DAY TIF (Alpaca rejects GTC for "
+            "fractional with error 42210000)"
+        )
+        active = om._active_orders[trade_id]
+        assert active.status == PositionStatus.STOP_AND_TARGET_ACTIVE
+
+    @pytest.mark.asyncio
     async def test_stop_attach_failure_triggers_emergency_flatten(
         self, config, tmp_db_path: str, mock_notifier
     ):

--- a/trading_bot/tests/test_order_tif.py
+++ b/trading_bot/tests/test_order_tif.py
@@ -1,0 +1,71 @@
+"""Unit tests for the time-in-force selection helpers.
+
+Regression coverage for production incident 2026-05-04: every entry signal
+hit Alpaca error 42210000 ("fractional orders must be DAY orders") because
+stop / emergency-flatten orders were submitted with GTC / IOC TIF.
+"""
+
+from __future__ import annotations
+
+import pytest
+from alpaca.trading.enums import TimeInForce
+
+from trading_bot.gateway.order_tif import (
+    is_fractional,
+    tif_for_market,
+    tif_for_stop,
+)
+
+
+class TestIsFractional:
+    @pytest.mark.parametrize(
+        "qty,expected",
+        [
+            (4.2067, True),
+            (0.4412, True),
+            (0.001, True),
+            (1.5, True),
+            (1.0, False),
+            (5.0, False),
+            (100, False),
+            (0, False),
+        ],
+    )
+    def test_detects_fractional(self, qty: float, expected: bool) -> None:
+        assert is_fractional(qty) is expected
+
+
+class TestTifForStop:
+    @pytest.mark.parametrize(
+        "qty",
+        [4.2067, 0.4412, 6.5395, 0.001, 1.5],
+    )
+    def test_fractional_qty_returns_day(self, qty: float) -> None:
+        # Alpaca rejects GTC stops on fractional qty (error 42210000).
+        assert tif_for_stop(qty) == TimeInForce.DAY
+
+    @pytest.mark.parametrize(
+        "qty",
+        [1, 1.0, 5, 100, 1000.0],
+    )
+    def test_whole_qty_returns_gtc(self, qty: float) -> None:
+        # Whole-share stops use GTC so they survive across the day.
+        assert tif_for_stop(qty) == TimeInForce.GTC
+
+
+class TestTifForMarket:
+    @pytest.mark.parametrize(
+        "qty",
+        [4.2067, 0.4412, 6.5395, 0.001, 1.5],
+    )
+    def test_fractional_qty_returns_day(self, qty: float) -> None:
+        # Alpaca rejects IOC market orders on fractional qty (error 42210000).
+        assert tif_for_market(qty) == TimeInForce.DAY
+
+    @pytest.mark.parametrize(
+        "qty",
+        [1, 1.0, 5, 100, 1000.0],
+    )
+    def test_whole_qty_returns_ioc(self, qty: float) -> None:
+        # Whole-share emergency flattens use IOC: fill immediately or kill.
+        assert tif_for_market(qty) == TimeInForce.IOC


### PR DESCRIPTION
## Summary

- Production bug found via 2026-05-04 trade postmortem — every fractional entry today was killed by an Alpaca 422 within ~10 min of entry.
- Root cause: stop and emergency-market orders submitted with `TimeInForce.GTC` / `IOC`. Alpaca rejects any non-DAY TIF on fractional qty (error code `42210000`).
- Fix: centralise TIF selection in `trading_bot/gateway/order_tif.py` and route all four submission sites through it.

## Today's cascade (per cluster)

| Tick (UTC) | What happened |
|---|---|
| 16:20 | `mean_reversion` fires → BUY limit XLY (4.2067) + XLB (6.5395) filled. DB position records created. |
| 16:25 | Bot detects fills → `_place_standalone_stop` (GTC) → **422**. Fallback `emergency_flatten` (IOC) → **also 422**. Recovery's `_place_emergency_stop` (GTC) → **also 422**. DB position state lost. |
| 16:30 | Recovery sees positions on Alpaca that aren't in DB → creates record with `strategy=unknown`. `strategy_manager` drains as orphan via market SELL: `Draining orphan position: ticker=XLB strategy=unknown`. |

Same cascade for SPY (0.4412) + QQQ (0.3217) at 19:45 → 19:55. 4/4 round-trips closed via `orphan_sleeve_drain:unknown`. Strategy P&L attribution destroyed; `daily_summaries.net_pnl_usd = 0` despite Alpaca showing −$1.05.

## Provenance

- Introduced in [#53](https://github.com/alex5imon/ai-broker/pull/53) (plain-limit + standalone-stop entry path) — the previous bracket-order path didn't hit Alpaca's fractional-TIF rule.
- Surfaced today by [#59](https://github.com/alex5imon/ai-broker/pull/59) (order-safety hardening) — the new emergency_flatten + orphan_drain cascade converted the silent failed-stop into a force-flatten.

## Patched call sites

| File | Function | Was | Now |
|---|---|---|---|
| `trading_bot/execution/order_manager.py` | `_place_standalone_stop` | `GTC` | `tif_for_stop(qty)` |
| `trading_bot/execution/order_manager.py` | `place_trailing_stop` | `GTC` | `tif_for_stop(qty)` |
| `trading_bot/execution/order_manager.py` | `emergency_flatten` | `IOC` | `tif_for_market(qty)` |
| `trading_bot/gateway/recovery.py` | `_place_emergency_stop` | `GTC` | `tif_for_stop(order_qty)` |

`tif_for_stop` returns `DAY` for fractional, `GTC` for whole. `tif_for_market` returns `DAY` for fractional, `IOC` for whole. The stateless tick + recovery loop will re-attach a missing stop on the next trading day's first tick if a DAY stop survives only the session.

## Why pre-open-check missed it

The dry-run tick in `pre-open-check.yml` doesn't fill orders, so `_place_standalone_stop` is never exercised. The ✅ from yesterday's run is a known blind spot. Worth a paper-account fractional smoke test post-merge.

## Test plan

- [x] `pytest trading_bot/tests/test_order_tif.py` — 23 helper unit tests covering fractional/whole boundaries.
- [x] `pytest trading_bot/tests/test_order_manager_lifecycle.py` — added `test_fractional_fill_uses_day_tif_for_stop` regression test.
- [x] Full suite: `781 passed, 2 skipped` (2 skipped pre-existing; `test_sizing_properties.py` requires `hypothesis`, not installed in local venv).
- [ ] After merge: monitor first weekday tick post-deploy, confirm `_place_standalone_stop` lands without 422.
- [ ] After merge: one-off reconciliation of `strategy_portfolios` virtual cash (`mean_reversion` shows $673 of $1500 marked "in positions" that don't exist).

## Follow-ups (not in this PR)

- `daily_summaries.net_pnl_usd = 0` for 2026-05-04 — synthetic exit rows have NULL `exit_price`. After fix, normal-exit path will populate this. Backfill of today's row is optional.
- Strategy virtual-portfolio cash drift on `mean_reversion`, `breakout`, `trend_following`, `overnight_drift`. One-off reset to match Alpaca reality.
- Add fractional-aware paper smoke test to `pre-open-check`.