### PR TITLE
ci(gha): prevent runner-shortage cascade from blocking ticks

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -9,7 +9,11 @@ on:
 
 concurrency:
   group: bot-run
-  cancel-in-progress: false
+  # Ticks are stateless (state is restored from cache each run), so it is
+  # safe to supersede an in-flight run with a newer one. This prevents a
+  # wedged run (e.g. hosted-runner shortage) from blocking the queue and
+  # turning subsequent dispatches into cancellations.
+  cancel-in-progress: true
 
 permissions:
   contents: write
@@ -17,7 +21,9 @@ permissions:
 jobs:
   run:
     runs-on: ubuntu-latest
-    timeout-minutes: 8
+    # Real per-tick work takes seconds; capping below the 5-min cron interval
+    # ensures one stuck run cannot block more than a single subsequent tick.
+    timeout-minutes: 4
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/heartbeat.yml
+++ b/.github/workflows/heartbeat.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 3
     env:
       GH_TOKEN: ${{ github.token }}
-      STALE_MINUTES: "20"
+      STALE_MINUTES: "12"
       BOT_WORKFLOW: "bot.yml"
     steps:
       - name: Check last successful bot run


### PR DESCRIPTION
## Summary

- `bot.yml`: `cancel-in-progress: false` → `true` so a fresh dispatch supersedes a wedged run instead of queuing behind it. Ticks are stateless (state restored from cache), so superseding is safe.
- `bot.yml`: `timeout-minutes: 8` → `4`. Real per-tick work is seconds; capping below the 5-min cron interval means one stuck run cannot block more than a single subsequent tick.
- `heartbeat.yml`: `STALE_MINUTES: 20` → `12`. The old threshold silently absorbed yesterday's 15-min gap; 12 min reliably catches a 2-tick skip.

## Why

On 2026-05-05 a GitHub hosted-runner shortage at 15:04 UTC made [run 25384457130](https://github.com/alex5imon/ai-broker/actions/runs/25384457130) hang for 15 min on runner acquisition. Two follow-up `workflow_dispatch` retries at 15:05 and 15:10 queued behind it under the `bot-run` concurrency group and were cancelled. Three consecutive 5-min ticks were dropped (15:00 → 15:15 UTC) and the heartbeat absorbed the gap silently.

## Test plan

- [ ] Next scheduled tick after merge runs to completion within the new 4-min cap
- [ ] Manual `workflow_dispatch` while a tick is in flight cancels the in-flight run rather than queuing
- [ ] Heartbeat passes on a normal day (last success ≤ 12 min)