### PR TITLE
fix(execution+ci): recover stop attach from response loss; backfill exits

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -9,7 +9,11 @@ on:
 
 concurrency:
   group: bot-run
-  cancel-in-progress: false
+  # Ticks are stateless (state is restored from cache each run), so it is
+  # safe to supersede an in-flight run with a newer one. This prevents a
+  # wedged run (e.g. hosted-runner shortage) from blocking the queue and
+  # turning subsequent dispatches into cancellations.
+  cancel-in-progress: true
 
 permissions:
   contents: write
@@ -17,7 +21,9 @@ permissions:
 jobs:
   run:
     runs-on: ubuntu-latest
-    timeout-minutes: 8
+    # Real per-tick work takes seconds; capping below the 5-min cron interval
+    # ensures one stuck run cannot block more than a single subsequent tick.
+    timeout-minutes: 4
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/daily-review.yml
+++ b/.github/workflows/daily-review.yml
@@ -70,6 +70,25 @@ jobs:
           echo "report_date=${REPORT_DATE}" >> "$GITHUB_OUTPUT"
           echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
 
+      - name: Backfill exit fills from Alpaca
+        # The live close path leaves exit_price/net_pnl NULL on
+        # reconciliation_mismatch rows so the postmortem cannot see realized
+        # P&L. Running backfill before the agent ensures it sees real fills,
+        # not phantom round-trips. The script is idempotent (skips rows
+        # already marked with the backfill: notes prefix).
+        env:
+          ALPACA_ENV: ${{ vars.ALPACA_ENV || 'paper' }}
+          ALPACA_PAPER_KEY_ID: ${{ secrets.ALPACA_PAPER_KEY_ID }}
+          ALPACA_PAPER_SECRET: ${{ secrets.ALPACA_PAPER_SECRET }}
+          ALPACA_LIVE_KEY_ID: ${{ secrets.ALPACA_LIVE_KEY_ID }}
+          ALPACA_LIVE_SECRET: ${{ secrets.ALPACA_LIVE_SECRET }}
+          BOT_LOG_DIR: logs
+        # Continue on error: a failed backfill should not block the report.
+        # Worst case the postmortem sees the same blank rows it would have
+        # seen pre-fix.
+        continue-on-error: true
+        run: python -m trading_bot.self_improve.backfill_cli
+
       - name: Run self-improvement agent
         env:
           ALPACA_ENV: ${{ vars.ALPACA_ENV || 'paper' }}

--- a/.github/workflows/heartbeat.yml
+++ b/.github/workflows/heartbeat.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 3
     env:
       GH_TOKEN: ${{ github.token }}
-      STALE_MINUTES: "20"
+      STALE_MINUTES: "12"
       BOT_WORKFLOW: "bot.yml"
     steps:
       - name: Check last successful bot run

--- a/trading_bot/execution/order_manager.py
+++ b/trading_bot/execution/order_manager.py
@@ -963,6 +963,23 @@ class OrderManager:
         )
 
         if stop_id is None:
+            # The submit may have actually reached the broker — alpaca-py
+            # response parsing can raise after Alpaca accepted the order.
+            # Before emergency-flattening (which is itself fragile and has
+            # been observed to silently fail on the same SDK paths), check
+            # whether a matching stop is already live at Alpaca and adopt it.
+            recovered_stop_id = await self._find_existing_stop(
+                active.ticker, filled_qty,
+            )
+            if recovered_stop_id is not None:
+                logger.warning(
+                    "Recovered stop attach for %s after submit-response loss: "
+                    "alpaca_id=%s (trade_id=%d). Adopting existing broker order.",
+                    active.ticker, recovered_stop_id, trade_id,
+                )
+                stop_id = recovered_stop_id
+
+        if stop_id is None:
             # Stop-attach failure leaves the position unprotected. Recovery:
             # emergency_flatten + notify, then collapse local + DB state to a
             # terminal status so the next stateless cron tick does not
@@ -1046,6 +1063,56 @@ class OrderManager:
                 active.ticker, trade_id, qty, active.stop_price,
             )
             return None
+
+    async def _find_existing_stop(
+        self, ticker: str, qty: float,
+    ) -> str | None:
+        """Look up an open SELL stop on ``ticker`` matching ``qty`` at Alpaca.
+
+        Used by ``_transition_to_open`` to recover from a submit-response
+        loss: alpaca-py occasionally raises during response parsing after
+        the order has actually been accepted by the broker, so the bot
+        thinks the stop placement failed when it succeeded. Adopting the
+        live order is preferable to emergency-flattening a real position.
+        Returns the matching order id or None.
+        """
+        try:
+            from alpaca.trading.enums import QueryOrderStatus
+            request = GetOrdersRequest(
+                status=QueryOrderStatus.OPEN,
+                symbols=[ticker],
+            )
+            orders: list[AlpacaOrder] = await asyncio.to_thread(
+                self._gw.client.get_orders, filter=request,
+            )
+        except Exception:
+            logger.warning(
+                "Could not query open orders for %s during stop recovery",
+                ticker, exc_info=True,
+            )
+            return None
+
+        for order in orders:
+            order_type_obj = getattr(order, "order_type", None) or getattr(
+                order, "type", None,
+            )
+            order_type_str: str = (
+                getattr(order_type_obj, "value", "") if order_type_obj is not None else ""
+            ).lower()
+            side_obj = getattr(order, "side", None)
+            side_str: str = (
+                getattr(side_obj, "value", "") if side_obj is not None else ""
+            ).lower()
+            try:
+                order_qty: float = float(getattr(order, "qty", 0) or 0)
+            except (TypeError, ValueError):
+                continue
+            if order_type_str != "stop" or side_str != "sell":
+                continue
+            if abs(order_qty - qty) > 1e-6:
+                continue
+            return str(order.id)
+        return None
 
     async def activate_trailing_stop(self, trade_id: int, trail_pct: float) -> bool:
         """Activate trailing stop, replacing the take-profit order."""

--- a/trading_bot/tests/test_phase3_regressions.py
+++ b/trading_bot/tests/test_phase3_regressions.py
@@ -431,3 +431,203 @@ class TestB5_UpdatePositionFieldLogsRowsAffected:
             "0-row UPDATE must log loud — that's the silent-failure mode "
             "the live bot was hiding."
         )
+
+
+# ---------------------------------------------------------------------------
+# B6 — _transition_to_open recovers from a stop-attach response loss
+# ---------------------------------------------------------------------------
+
+
+def _alpaca_open_stop(
+    *,
+    order_id: str = "stop-rec-1",
+    symbol: str = "SPY",
+    qty: float = 10.0,
+    side: str = "sell",
+    order_type: str = "stop",
+):
+    """Mock an open Alpaca order shaped like get_orders(status=OPEN) returns."""
+    o = MagicMock()
+    o.id = order_id
+    o.symbol = symbol
+    o.qty = qty
+    o.side = MagicMock()
+    o.side.value = side
+    o.order_type = MagicMock()
+    o.order_type.value = order_type
+    return o
+
+
+class TestB6_TransitionToOpenRecoversFromStopAttachResponseLoss:
+    """Live bug observed 2026-04-29 → 2026-05-05: _place_standalone_stop
+    occasionally returned None even though the stop order had actually
+    been accepted by Alpaca (alpaca-py response parsing raised after the
+    order was submitted). _transition_to_open then emergency-flattened —
+    which itself failed on the same SDK paths — leaving 7 real positions
+    stamped ENTRY_FAILED in the DB while still live at the broker.
+
+    The fix queries Alpaca for an open SELL stop matching the ticker and
+    qty before assuming submission failed; if found, the order is adopted
+    and the position transitions to STOP_AND_TARGET_ACTIVE normally.
+    """
+
+    @pytest.mark.asyncio
+    async def test_recovers_when_matching_stop_exists_at_alpaca(
+        self, config, tmp_db_path: str, mock_notifier
+    ):
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        decision = _entry()
+        # Seed an _ActiveOrder as if the entry had just filled.
+        trade_id = om._create_position_record(decision)
+        active = _ActiveOrder(
+            trade_id=trade_id,
+            ticker=decision.ticker,
+            exchange=decision.exchange,
+            alpaca_entry_order_id="entry-1",
+            status=PositionStatus.ENTRY_PENDING,
+            entry_shares=float(decision.shares),
+            filled_shares=float(decision.shares),
+            entry_price=decision.limit_price,
+            stop_price=decision.stop_price,
+            target_price=decision.target_price,
+            hold_type=decision.hold_type,
+            strategy_id=decision.strategy_id,
+        )
+        om._active_orders[trade_id] = active
+
+        # Force the submit-response loss path: _place_standalone_stop returns
+        # None even though Alpaca actually has the stop. The recovery query
+        # finds the matching open SELL stop.
+        async def _fail_stop_submit(*args, **kwargs):
+            return None
+        om._place_standalone_stop = _fail_stop_submit  # type: ignore[assignment]
+        recovered = _alpaca_open_stop(
+            order_id="recovered-stop",
+            symbol=decision.ticker,
+            qty=float(decision.shares),
+        )
+        om._gw.client.get_orders = MagicMock(return_value=[recovered])
+
+        await om._transition_to_open(trade_id, float(decision.shares))
+
+        conn = sqlite3.connect(tmp_db_path)
+        try:
+            row = conn.execute(
+                "SELECT status, alpaca_stop_order_id "
+                "FROM positions WHERE id = ?", (trade_id,),
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row is not None
+        assert row[0] == PositionStatus.STOP_AND_TARGET_ACTIVE.value, (
+            "Recovery must adopt the live broker stop and proceed to the "
+            "normal active-stop status — not stamp ENTRY_FAILED."
+        )
+        assert row[1] == "recovered-stop"
+
+    @pytest.mark.asyncio
+    async def test_falls_through_to_entry_failed_when_no_matching_stop_exists(
+        self, config, tmp_db_path: str, mock_notifier
+    ):
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        decision = _entry()
+        trade_id = om._create_position_record(decision)
+        active = _ActiveOrder(
+            trade_id=trade_id,
+            ticker=decision.ticker,
+            exchange=decision.exchange,
+            alpaca_entry_order_id="entry-1",
+            status=PositionStatus.ENTRY_PENDING,
+            entry_shares=float(decision.shares),
+            filled_shares=float(decision.shares),
+            entry_price=decision.limit_price,
+            stop_price=decision.stop_price,
+            target_price=decision.target_price,
+            hold_type=decision.hold_type,
+            strategy_id=decision.strategy_id,
+        )
+        om._active_orders[trade_id] = active
+
+        async def _fail_stop_submit(*args, **kwargs):
+            return None
+        om._place_standalone_stop = _fail_stop_submit  # type: ignore[assignment]
+        # No matching stop on the broker — recovery returns nothing.
+        om._gw.client.get_orders = MagicMock(return_value=[])
+        # Emergency flatten path needs a working market submit_order so the
+        # emergency_flatten exception swallow doesn't mask a real bug.
+        om._gw.client.submit_order = MagicMock(return_value=_alpaca_order())
+
+        await om._transition_to_open(trade_id, float(decision.shares))
+
+        conn = sqlite3.connect(tmp_db_path)
+        try:
+            row = conn.execute(
+                "SELECT status FROM positions WHERE id = ?", (trade_id,),
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row[0] == PositionStatus.ENTRY_FAILED.value, (
+            "When no broker-side stop exists, the original ENTRY_FAILED "
+            "+ emergency_flatten path must still fire — recovery is for "
+            "response loss only, not a real submission failure."
+        )
+
+    @pytest.mark.asyncio
+    async def test_recovery_ignores_non_matching_orders(
+        self, config, tmp_db_path: str, mock_notifier
+    ):
+        """A stop with a different qty or a BUY-side order must not be
+        adopted as the protective stop — that would attach a wrong-sized
+        or wrong-direction order to the position."""
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        decision = _entry(shares=10)
+        trade_id = om._create_position_record(decision)
+        active = _ActiveOrder(
+            trade_id=trade_id,
+            ticker=decision.ticker,
+            exchange=decision.exchange,
+            alpaca_entry_order_id="entry-1",
+            status=PositionStatus.ENTRY_PENDING,
+            entry_shares=10.0,
+            filled_shares=10.0,
+            entry_price=decision.limit_price,
+            stop_price=decision.stop_price,
+            target_price=decision.target_price,
+            hold_type=decision.hold_type,
+            strategy_id=decision.strategy_id,
+        )
+        om._active_orders[trade_id] = active
+
+        async def _fail_stop_submit(*args, **kwargs):
+            return None
+        om._place_standalone_stop = _fail_stop_submit  # type: ignore[assignment]
+        wrong_qty = _alpaca_open_stop(
+            order_id="wrong-qty", symbol=decision.ticker, qty=5.0,
+        )
+        wrong_side = _alpaca_open_stop(
+            order_id="wrong-side", symbol=decision.ticker, qty=10.0, side="buy",
+        )
+        wrong_type = _alpaca_open_stop(
+            order_id="wrong-type", symbol=decision.ticker, qty=10.0,
+            order_type="limit",
+        )
+        om._gw.client.get_orders = MagicMock(
+            return_value=[wrong_qty, wrong_side, wrong_type],
+        )
+        om._gw.client.submit_order = MagicMock(return_value=_alpaca_order())
+
+        await om._transition_to_open(trade_id, 10.0)
+
+        conn = sqlite3.connect(tmp_db_path)
+        try:
+            row = conn.execute(
+                "SELECT status, alpaca_stop_order_id "
+                "FROM positions WHERE id = ?", (trade_id,),
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row[0] == PositionStatus.ENTRY_FAILED.value
+        assert row[1] is None or row[1] == "", (
+            "No order matches qty+side+type — must NOT adopt any of the "
+            "non-matching open orders."
+        )


### PR DESCRIPTION
## Summary

Two related production bugs surfaced via DB reconciliation against Alpaca paper:

### Bug 1 — `ENTRY_FAILED` stamped on filled positions

7 positions in the last week (XLY, XLB, SPY×2, QQQ×2, XLC) were stamped `ENTRY_FAILED` despite their entry orders actually filling at the broker. Root cause: `_place_standalone_stop` returned `None` even though Alpaca had accepted the stop — alpaca-py response parsing raises after submission on certain TIF/qty combinations. The failure branch then called `emergency_flatten`, which silently failed on the same SDK paths, leaving the position live at the broker but invisible to the bot. The next tick's `StateRecovery` re-found it as an "unknown" `strategy_id` row, creating the duplicate-row pattern observed in the DB.

**Fix** in `trading_bot/execution/order_manager.py`: when `_place_standalone_stop` returns `None`, query Alpaca for an open SELL stop matching ticker + qty before assuming submission failed. If found, adopt the existing broker order and proceed to `STOP_AND_TARGET_ACTIVE` normally. Only emergency-flatten when no matching broker-side stop exists — preserving the original safety net for genuine submission failures.

### Bug 2 — postmortem sees 0 closed trades because exit data is never written

All 64 `reconciliation_mismatch` rows in the last 20 days had `NULL` `exit_price` and `NULL` `pnl_usd`, so the daily-review agent saw \"0 closed trades\" and produced empty reports. The reconciler already notes \"`exit_price/net_pnl` pending `alpaca_backfill`\" — the backfill tool exists, is well-tested, and is idempotent, but **it was never invoked in CI**.

**Fix** in `.github/workflows/daily-review.yml`: add a backfill step before the agent runs, with `continue-on-error: true` so a backfill failure cannot block the report.

## Test plan

- [x] 3 new cases in `test_phase3_regressions.py` (B6 class) cover the recovery path:
  - matching open stop at broker → adopted, status `STOP_AND_TARGET_ACTIVE`
  - no matching stop → original `ENTRY_FAILED` + flatten path still fires (regression guard)
  - non-matching orders (wrong qty / side / type) are not adopted (safety guard)
- [x] All 728 existing tests still pass (2 skipped, unchanged)
- [ ] Next live tick after merge: confirm a fresh entry transitions cleanly to `STOP_AND_TARGET_ACTIVE` and no new `ENTRY_FAILED`-but-filled rows appear
- [ ] Tonight's daily-review run: confirm the backfill step populates `exit_price`/`pnl_usd` and the agent's postmortem shows real trade counts

## Out of scope (follow-up)

- Phantom duplicate trade rows (59 pairs in DB) — separate fix, requires changes to the reconciler's INSERT path to UPDATE existing rows instead. One-shot cleanup of the existing 59 pairs handled separately too.
- Deep-fix the alpaca-py response parsing edge case rather than recovering after the fact. The recovery path here is robust regardless, but worth understanding upstream eventually.