### PR TITLE
fix(self_improve): one-shot repair for orphan ENTRY_FAILED + unknown duplicates

### DIFF
--- a/trading_bot/self_improve/repair_orphans.py
+++ b/trading_bot/self_improve/repair_orphans.py
@@ -1,0 +1,359 @@
+"""One-shot repair: reconcile DB positions against Alpaca order/position state.
+
+Two classes of drift left over from the stop-attach-response-loss bug
+(see PR #64):
+
+1. ``ENTRY_FAILED`` positions whose Alpaca entry order actually filled.
+   The bot stamped them ENTRY_FAILED after a spurious stop-attach failure,
+   leaving a real position at the broker invisible to the strategy layer.
+
+2. ``strategy_id='unknown'`` rows with status ``POSITION_OPEN`` created by
+   ``StateRecovery._reconcile`` when it encountered the broker positions
+   the bot didn't know about. They exist in addition to the legitimate
+   ``ENTRY_FAILED`` rows for the same ticker / entry time.
+
+This script reads the live broker state, repairs (1), and merges/closes
+(2) so the strategy_manager's "don't double up on same ticker" guard
+fires correctly tomorrow. It is idempotent: re-running on a clean DB
+finds nothing to repair.
+
+Usage:
+    python -m trading_bot.self_improve.repair_orphans --dry-run
+    python -m trading_bot.self_improve.repair_orphans
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import sqlite3
+import sys
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+from zoneinfo import ZoneInfo
+
+from trading_bot.config import Config
+from trading_bot.constants import PositionStatus, TZ_EASTERN
+from trading_bot.env import resolve_alpaca_env
+from trading_bot.log_setup import setup_logging
+
+logger = logging.getLogger(__name__)
+
+ET: ZoneInfo = TZ_EASTERN
+
+
+@dataclass
+class RepairReport:
+    """Summary of a single repair invocation."""
+
+    entry_failed_scanned: int
+    entry_failed_repaired: int
+    unknown_duplicates_scanned: int
+    unknown_duplicates_closed: int
+    dry_run: bool
+
+
+def _load_entry_failed_with_order_id(
+    conn: sqlite3.Connection,
+) -> list[dict[str, Any]]:
+    """ENTRY_FAILED rows that have an alpaca_order_id — candidates for
+    'order actually filled' check.
+    """
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute(
+        "SELECT * FROM positions "
+        "WHERE status = ? AND alpaca_order_id IS NOT NULL "
+        "AND alpaca_order_id != '' "
+        "ORDER BY entry_time",
+        (PositionStatus.ENTRY_FAILED.value,),
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def _load_unknown_duplicates(
+    conn: sqlite3.Connection,
+) -> list[dict[str, Any]]:
+    """``strategy_id='unknown'`` rows still in non-terminal status."""
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute(
+        "SELECT * FROM positions "
+        "WHERE strategy_id = 'unknown' "
+        "AND status NOT IN ('CLOSED', 'ENTRY_FAILED') "
+        "ORDER BY entry_time",
+        (),
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
+async def _check_order_filled(client, alpaca_order_id: str):
+    """Return the Alpaca order if it exists and is filled, else None."""
+    try:
+        order = await asyncio.to_thread(
+            client.get_order_by_id, alpaca_order_id,
+        )
+    except Exception:
+        logger.warning(
+            "Could not fetch Alpaca order %s", alpaca_order_id, exc_info=True,
+        )
+        return None
+    status_str = (
+        getattr(getattr(order, "status", None), "value", "") or ""
+    ).lower()
+    if status_str != "filled":
+        return None
+    return order
+
+
+async def _find_open_stop_for_ticker(
+    client, ticker: str, qty: float,
+) -> str | None:
+    """Look up an open SELL stop for ``ticker`` matching ``qty``.
+
+    Mirrors the helper now in OrderManager._find_existing_stop, kept here
+    as a pure-function variant so the repair script doesn't need to spin
+    up the full execution stack.
+    """
+    from alpaca.trading.requests import GetOrdersRequest
+    from alpaca.trading.enums import QueryOrderStatus
+
+    try:
+        request = GetOrdersRequest(
+            status=QueryOrderStatus.OPEN, symbols=[ticker],
+        )
+        orders = await asyncio.to_thread(client.get_orders, filter=request)
+    except Exception:
+        logger.warning(
+            "Could not list open orders for %s", ticker, exc_info=True,
+        )
+        return None
+
+    for o in orders:
+        order_type_obj = (
+            getattr(o, "order_type", None) or getattr(o, "type", None)
+        )
+        order_type = (
+            getattr(order_type_obj, "value", "") or ""
+        ).lower()
+        side_obj = getattr(o, "side", None)
+        side = (getattr(side_obj, "value", "") or "").lower()
+        try:
+            order_qty = float(getattr(o, "qty", 0) or 0)
+        except (TypeError, ValueError):
+            continue
+        if order_type != "stop" or side != "sell":
+            continue
+        if abs(order_qty - qty) > 1e-6:
+            continue
+        return str(o.id)
+    return None
+
+
+async def _repair_entry_failed(
+    conn: sqlite3.Connection,
+    client,
+    *,
+    dry_run: bool,
+) -> tuple[int, int]:
+    """Flip ENTRY_FAILED → STOP_AND_TARGET_ACTIVE for rows whose Alpaca
+    order actually filled, adopting any matching open stop.
+
+    Returns (scanned, repaired).
+    """
+    candidates = _load_entry_failed_with_order_id(conn)
+    repaired = 0
+    now_iso: str = datetime.now(tz=ET).isoformat()
+
+    for pos in candidates:
+        oid: str = str(pos["alpaca_order_id"])
+        order = await _check_order_filled(client, oid)
+        if order is None:
+            logger.debug(
+                "Position %d (%s) ENTRY_FAILED is a real failure — "
+                "Alpaca order %s is not filled.",
+                pos["id"], pos["ticker"], oid[:8],
+            )
+            continue
+
+        try:
+            filled_qty: float = float(order.filled_qty or 0)
+            filled_avg: float = float(order.filled_avg_price or 0)
+        except (TypeError, ValueError):
+            logger.warning(
+                "Position %d (%s): Alpaca order %s returned malformed fill "
+                "data; skipping.", pos["id"], pos["ticker"], oid[:8],
+            )
+            continue
+
+        stop_id = await _find_open_stop_for_ticker(
+            client, str(pos["ticker"]), filled_qty,
+        )
+
+        new_status: str = (
+            PositionStatus.STOP_AND_TARGET_ACTIVE.value
+            if stop_id is not None
+            else PositionStatus.POSITION_OPEN.value
+        )
+        logger.info(
+            "%sRepairing position %d (%s): ENTRY_FAILED -> %s "
+            "(qty=%.6f @ %.4f, stop_id=%s)",
+            "[DRY-RUN] " if dry_run else "",
+            pos["id"], pos["ticker"], new_status,
+            filled_qty, filled_avg, stop_id or "none",
+        )
+
+        if dry_run:
+            repaired += 1
+            continue
+
+        with conn:
+            conn.execute(
+                "UPDATE positions SET status = ?, "
+                "entry_price = ?, quantity = ?, "
+                "alpaca_stop_order_id = COALESCE(?, alpaca_stop_order_id), "
+                "updated_at = ? "
+                "WHERE id = ?",
+                (
+                    new_status, filled_avg, filled_qty, stop_id, now_iso,
+                    pos["id"],
+                ),
+            )
+        repaired += 1
+
+    return len(candidates), repaired
+
+
+def _close_unknown_duplicates(
+    conn: sqlite3.Connection,
+    *,
+    dry_run: bool,
+) -> tuple[int, int]:
+    """Close ``strategy_id='unknown'`` positions if a sibling strategy_id
+    row for the same ticker now exists.
+
+    The repair above flipped the ENTRY_FAILED row back to a live status,
+    so the ``unknown`` duplicate is now redundant. We don't delete (audit
+    trail), we mark it CLOSED so the strategy layer ignores it.
+    """
+    candidates = _load_unknown_duplicates(conn)
+    closed = 0
+    now_iso: str = datetime.now(tz=ET).isoformat()
+
+    for unk in candidates:
+        # Look for a sibling on the same ticker that's now live (any
+        # status other than CLOSED/ENTRY_FAILED, with a real strategy_id).
+        sibling = conn.execute(
+            "SELECT id, status, strategy_id FROM positions "
+            "WHERE ticker = ? AND id != ? "
+            "AND strategy_id != 'unknown' AND strategy_id != '' "
+            "AND status NOT IN ('CLOSED', 'ENTRY_FAILED') "
+            "ORDER BY entry_time DESC LIMIT 1",
+            (unk["ticker"], unk["id"]),
+        ).fetchone()
+        if sibling is None:
+            logger.debug(
+                "Position %d (%s, unknown): no live sibling — leaving as-is "
+                "(may be a genuine broker-side-only position).",
+                unk["id"], unk["ticker"],
+            )
+            continue
+
+        logger.info(
+            "%sClosing unknown duplicate position %d (%s) — sibling %d "
+            "now live as %s",
+            "[DRY-RUN] " if dry_run else "",
+            unk["id"], unk["ticker"], sibling[0], sibling[2],
+        )
+        if dry_run:
+            closed += 1
+            continue
+
+        with conn:
+            conn.execute(
+                "UPDATE positions SET status = 'CLOSED', updated_at = ? "
+                "WHERE id = ?",
+                (now_iso, unk["id"]),
+            )
+        closed += 1
+
+    return len(candidates), closed
+
+
+async def repair(
+    conn: sqlite3.Connection,
+    client,
+    *,
+    dry_run: bool = False,
+) -> RepairReport:
+    """Run both repairs. Order matters: fix ENTRY_FAILED first so the
+    sibling lookup in step 2 finds the now-live row."""
+    ef_scanned, ef_repaired = await _repair_entry_failed(
+        conn, client, dry_run=dry_run,
+    )
+    unk_scanned, unk_closed = _close_unknown_duplicates(
+        conn, dry_run=dry_run,
+    )
+    return RepairReport(
+        entry_failed_scanned=ef_scanned,
+        entry_failed_repaired=ef_repaired,
+        unknown_duplicates_scanned=unk_scanned,
+        unknown_duplicates_closed=unk_closed,
+        dry_run=dry_run,
+    )
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="One-shot: repair orphan ENTRY_FAILED positions and "
+                    "merge unknown-strategy duplicates.",
+    )
+    parser.add_argument("--config", default="config.yaml")
+    parser.add_argument("--db", default=None,
+                        help="SQLite path (default: config's database.path)")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Log what would change; no DB writes.")
+    return parser.parse_args(argv)
+
+
+async def _async_main(args: argparse.Namespace) -> int:
+    config = Config.load(args.config)
+    db_path = args.db or config.db_path
+    if not Path(db_path).exists():
+        logger.error("DB not found at %s", db_path)
+        return 2
+
+    api_key, secret_key, is_paper = resolve_alpaca_env()
+    if not api_key or not secret_key:
+        logger.error("Alpaca credentials not found.")
+        return 2
+
+    from alpaca.trading.client import TradingClient
+    client = TradingClient(api_key, secret_key, paper=is_paper)
+    logger.info("Connected to Alpaca (%s)", "paper" if is_paper else "live")
+
+    conn = sqlite3.connect(db_path)
+    try:
+        report = await repair(conn, client, dry_run=args.dry_run)
+    finally:
+        conn.close()
+
+    logger.info(
+        "Repair complete: ef_scanned=%d ef_repaired=%d "
+        "unk_scanned=%d unk_closed=%d dry_run=%s",
+        report.entry_failed_scanned, report.entry_failed_repaired,
+        report.unknown_duplicates_scanned, report.unknown_duplicates_closed,
+        report.dry_run,
+    )
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    setup_logging("repair_orphans")
+    args = _parse_args(argv)
+    return asyncio.run(_async_main(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/trading_bot/tests/test_repair_orphans.py
+++ b/trading_bot/tests/test_repair_orphans.py
@@ -1,0 +1,300 @@
+"""Tests for the orphan-position repair script.
+
+Covers the two repair classes:
+  - ``ENTRY_FAILED`` rows whose Alpaca order actually filled.
+  - ``strategy_id='unknown'`` POSITION_OPEN rows that duplicate a real
+    strategy entry on the same ticker.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from unittest.mock import MagicMock
+
+import pytest
+
+from trading_bot.constants import PositionStatus
+from trading_bot.self_improve.repair_orphans import repair
+
+
+def _alpaca_order(*, status: str = "filled", filled_qty: float = 0.0,
+                  filled_avg_price: float = 0.0):
+    o = MagicMock()
+    o.status = MagicMock()
+    o.status.value = status
+    o.filled_qty = filled_qty
+    o.filled_avg_price = filled_avg_price
+    return o
+
+
+def _alpaca_open_stop(*, order_id: str = "stop-1", symbol: str = "SPY",
+                     qty: float = 1.0, side: str = "sell",
+                     order_type: str = "stop"):
+    o = MagicMock()
+    o.id = order_id
+    o.symbol = symbol
+    o.qty = qty
+    o.side = MagicMock(); o.side.value = side
+    o.order_type = MagicMock(); o.order_type.value = order_type
+    return o
+
+
+def _seed_position(
+    db_path: str, *, ticker: str, status: str, strategy_id: str,
+    alpaca_order_id: str | None = None, qty: float = 1.0,
+    entry_price: float = 100.0,
+) -> int:
+    conn = sqlite3.connect(db_path)
+    try:
+        cur = conn.execute(
+            "INSERT INTO positions (ticker, exchange, currency, "
+            "quantity, entry_price, entry_time, status, hold_type, "
+            "phase, strategy_id, alpaca_order_id) VALUES "
+            "(?, 'US', 'USD', ?, ?, '2026-05-05T15:45:00', ?, "
+            "'overnight', 1, ?, ?)",
+            (ticker, qty, entry_price, status, strategy_id, alpaca_order_id),
+        )
+        conn.commit()
+        return int(cur.lastrowid)
+    finally:
+        conn.close()
+
+
+@pytest.mark.asyncio
+async def test_repair_flips_entry_failed_to_active_when_order_filled_with_stop(
+    tmp_db_path: str,
+):
+    pos_id = _seed_position(
+        tmp_db_path, ticker="SPY",
+        status=PositionStatus.ENTRY_FAILED.value,
+        strategy_id="overnight_drift",
+        alpaca_order_id="entry-1",
+        qty=0.204, entry_price=720.0,  # mid-submit price; will be overwritten
+    )
+    client = MagicMock()
+    client.get_order_by_id = MagicMock(
+        return_value=_alpaca_order(
+            status="filled", filled_qty=0.204, filled_avg_price=724.72,
+        )
+    )
+    client.get_orders = MagicMock(
+        return_value=[_alpaca_open_stop(order_id="stop-recovered",
+                                       symbol="SPY", qty=0.204)]
+    )
+
+    conn = sqlite3.connect(tmp_db_path)
+    try:
+        report = await repair(conn, client, dry_run=False)
+    finally:
+        conn.close()
+
+    assert report.entry_failed_scanned == 1
+    assert report.entry_failed_repaired == 1
+
+    conn = sqlite3.connect(tmp_db_path)
+    try:
+        row = conn.execute(
+            "SELECT status, entry_price, quantity, alpaca_stop_order_id "
+            "FROM positions WHERE id = ?", (pos_id,),
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row[0] == PositionStatus.STOP_AND_TARGET_ACTIVE.value
+    # entry_price overwritten with the actual broker fill avg
+    assert abs(row[1] - 724.72) < 1e-6
+    assert abs(row[2] - 0.204) < 1e-6
+    assert row[3] == "stop-recovered"
+
+
+@pytest.mark.asyncio
+async def test_repair_flips_to_position_open_when_no_matching_stop_exists(
+    tmp_db_path: str,
+):
+    """Entry filled but no stop on broker — flip to POSITION_OPEN so the
+    next reconciler tick attaches an emergency stop. STOP_AND_TARGET_ACTIVE
+    would lie about state."""
+    pos_id = _seed_position(
+        tmp_db_path, ticker="QQQ",
+        status=PositionStatus.ENTRY_FAILED.value,
+        strategy_id="overnight_drift",
+        alpaca_order_id="entry-2", qty=0.1482, entry_price=680.0,
+    )
+    client = MagicMock()
+    client.get_order_by_id = MagicMock(
+        return_value=_alpaca_order(
+            status="filled", filled_qty=0.1482, filled_avg_price=682.07,
+        )
+    )
+    client.get_orders = MagicMock(return_value=[])
+
+    conn = sqlite3.connect(tmp_db_path)
+    try:
+        await repair(conn, client, dry_run=False)
+        row = conn.execute(
+            "SELECT status, alpaca_stop_order_id "
+            "FROM positions WHERE id = ?", (pos_id,),
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row[0] == PositionStatus.POSITION_OPEN.value
+    assert row[1] is None or row[1] == ""
+
+
+@pytest.mark.asyncio
+async def test_repair_leaves_genuine_failures_alone(tmp_db_path: str):
+    """ENTRY_FAILED with order status canceled/expired is a real failure;
+    the row must stay ENTRY_FAILED."""
+    pos_id = _seed_position(
+        tmp_db_path, ticker="XLP",
+        status=PositionStatus.ENTRY_FAILED.value,
+        strategy_id="mean_reversion",
+        alpaca_order_id="entry-canceled",
+    )
+    client = MagicMock()
+    client.get_order_by_id = MagicMock(
+        return_value=_alpaca_order(status="canceled")
+    )
+
+    conn = sqlite3.connect(tmp_db_path)
+    try:
+        report = await repair(conn, client, dry_run=False)
+        row = conn.execute(
+            "SELECT status FROM positions WHERE id = ?", (pos_id,),
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert report.entry_failed_repaired == 0, (
+        "A genuinely-canceled order must not be flipped — that would "
+        "create a phantom POSITION_OPEN with no broker counterpart."
+    )
+    assert row[0] == PositionStatus.ENTRY_FAILED.value
+
+
+@pytest.mark.asyncio
+async def test_repair_closes_unknown_duplicate_when_real_sibling_exists(
+    tmp_db_path: str,
+):
+    real_id = _seed_position(
+        tmp_db_path, ticker="SPY",
+        status=PositionStatus.STOP_AND_TARGET_ACTIVE.value,
+        strategy_id="overnight_drift",
+        alpaca_order_id="entry-real",
+    )
+    unk_id = _seed_position(
+        tmp_db_path, ticker="SPY",
+        status=PositionStatus.POSITION_OPEN.value,
+        strategy_id="unknown",
+    )
+    client = MagicMock()
+
+    conn = sqlite3.connect(tmp_db_path)
+    try:
+        report = await repair(conn, client, dry_run=False)
+        rows = conn.execute(
+            "SELECT id, status, strategy_id FROM positions "
+            "WHERE ticker = 'SPY' ORDER BY id"
+        ).fetchall()
+    finally:
+        conn.close()
+
+    assert report.unknown_duplicates_closed == 1
+    rows_by_id = {r[0]: r for r in rows}
+    assert rows_by_id[real_id][1] == PositionStatus.STOP_AND_TARGET_ACTIVE.value
+    assert rows_by_id[unk_id][1] == "CLOSED", (
+        "the duplicate must be closed once a real-strategy sibling exists, "
+        "otherwise the strategy guard sees neither (its query filters by "
+        "strategy_id) and tomorrow's entry double-submits."
+    )
+
+
+@pytest.mark.asyncio
+async def test_repair_leaves_unknown_alone_when_no_real_sibling(tmp_db_path: str):
+    """An unknown-strategy POSITION_OPEN with no sibling represents a
+    broker-side-only position the bot didn't open. Don't close it
+    blindly — that would lose audit information about the orphan."""
+    unk_id = _seed_position(
+        tmp_db_path, ticker="MSFT",
+        status=PositionStatus.POSITION_OPEN.value,
+        strategy_id="unknown",
+    )
+    client = MagicMock()
+
+    conn = sqlite3.connect(tmp_db_path)
+    try:
+        report = await repair(conn, client, dry_run=False)
+        row = conn.execute(
+            "SELECT status FROM positions WHERE id = ?", (unk_id,),
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert report.unknown_duplicates_closed == 0
+    assert row[0] == PositionStatus.POSITION_OPEN.value
+
+
+@pytest.mark.asyncio
+async def test_repair_dry_run_makes_no_writes(tmp_db_path: str):
+    pos_id = _seed_position(
+        tmp_db_path, ticker="SPY",
+        status=PositionStatus.ENTRY_FAILED.value,
+        strategy_id="overnight_drift",
+        alpaca_order_id="entry-1", qty=0.5, entry_price=700.0,
+    )
+    client = MagicMock()
+    client.get_order_by_id = MagicMock(
+        return_value=_alpaca_order(
+            status="filled", filled_qty=0.5, filled_avg_price=720.0,
+        )
+    )
+    client.get_orders = MagicMock(return_value=[])
+
+    conn = sqlite3.connect(tmp_db_path)
+    try:
+        report = await repair(conn, client, dry_run=True)
+        row = conn.execute(
+            "SELECT status, entry_price FROM positions WHERE id = ?",
+            (pos_id,),
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert report.entry_failed_repaired == 1, (
+        "dry-run still counts what it would change"
+    )
+    assert row[0] == PositionStatus.ENTRY_FAILED.value, (
+        "dry-run must not modify the row"
+    )
+    assert abs(row[1] - 700.0) < 1e-6, "entry_price untouched in dry-run"
+
+
+@pytest.mark.asyncio
+async def test_repair_is_idempotent(tmp_db_path: str):
+    """Running on a clean DB finds nothing to do; running twice in a row
+    on a fixable DB makes the same DB writes only once."""
+    _seed_position(
+        tmp_db_path, ticker="SPY",
+        status=PositionStatus.ENTRY_FAILED.value,
+        strategy_id="overnight_drift",
+        alpaca_order_id="entry-1", qty=0.2, entry_price=700.0,
+    )
+    client = MagicMock()
+    client.get_order_by_id = MagicMock(
+        return_value=_alpaca_order(
+            status="filled", filled_qty=0.2, filled_avg_price=720.0,
+        )
+    )
+    client.get_orders = MagicMock(return_value=[])
+
+    conn = sqlite3.connect(tmp_db_path)
+    try:
+        first = await repair(conn, client, dry_run=False)
+        second = await repair(conn, client, dry_run=False)
+    finally:
+        conn.close()
+
+    assert first.entry_failed_repaired == 1
+    assert second.entry_failed_repaired == 0, (
+        "after first repair the row is no longer ENTRY_FAILED, so the "
+        "second pass must find no work to do."
+    )


### PR DESCRIPTION
## Summary

One-shot repair script for the DB drift left over from the stop-attach-response-loss bug ([#64](https://github.com/alex5imon/ai-broker/pull/64) prevents new occurrences):

1. **`ENTRY_FAILED` rows whose entry order actually filled** (7 in current DB: XLY, XLB, SPY×2, QQQ×2, XLC). For each, query Alpaca; if filled, flip to `STOP_AND_TARGET_ACTIVE` (if a matching open SELL stop exists) or `POSITION_OPEN` (so the next reconciler tick attaches an emergency stop).
2. **`strategy_id='unknown'` `POSITION_OPEN` rows that duplicate a real strategy entry** (3 in current DB). If a sibling row for the same ticker now has a real `strategy_id` and live status, mark the unknown as `CLOSED`.

## Why now

Today's 2026-05-06 SPY/QQQ overnight_drift wash-trade rejections at 15:45 ET were caused by these orphans: the strategy guard in [`virtual_portfolio.get_open_positions()`](trading_bot/execution/virtual_portfolio.py:112) filters by `strategy_id`, so the real overnight_drift strategy didn't see the carryover positions and resubmitted. Alpaca rejected the new BUY against the live SELL stop.

PR #64 fixes the path that *creates* these orphans. This PR cleans up the existing ones so tomorrow's 15:45 ET tick doesn't fire the same wash-trade rejection.

## Run order

Dry-run first, then commit:

\`\`\`bash
python -m trading_bot.self_improve.repair_orphans --dry-run
python -m trading_bot.self_improve.repair_orphans
\`\`\`

The script reads from the same SQLite the live bot writes to. Run it locally against a fresh artifact pull, or wire it into a one-off GHA dispatch — either works because it is idempotent.

## Test plan

- [x] 7 unit tests cover: matching-stop adoption, no-stop fallback, genuine-failure preservation, sibling-aware unknown closure, no-sibling preservation, dry-run no-write, idempotency on repeat invocation
- [x] Full test suite passes (728 + 7 new)
- [ ] Run \`--dry-run\` against today's DB artifact, confirm it identifies 7 ENTRY_FAILED + 3 unknown rows
- [ ] Run for real, verify Alpaca state matches DB after
- [ ] Tomorrow 15:45 ET: confirm overnight_drift's SPY/QQQ entries are skipped (carryover guard fires) instead of submitted+rejected