### PR TITLE
fix(recovery): defer mismatch-close on fresh entries (Alpaca lag)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -381,6 +381,18 @@ exit_intraday:
   eod_flatten_time_et: "15:55"    # ET cutoff: flatten intraday-tagged positions
 
 # -----------------------------------------------------------------------------
+# State recovery / reconciliation
+# -----------------------------------------------------------------------------
+recovery:
+  # Don't close DB-only positions whose entry_time is younger than this.
+  # Alpaca's positions endpoint can lag a fresh fill by several minutes,
+  # so a brand-new entry can briefly look DB-only and trip the mismatch
+  # branch — writing a phantom round-trip with NULL exit data. The next
+  # tick (outside the grace window) will close it for real if it never
+  # appeared.
+  fresh_entry_grace_minutes: 10
+
+# -----------------------------------------------------------------------------
 # Exit Parameters - Swing
 # -----------------------------------------------------------------------------
 exit_swing:

--- a/trading_bot/gateway/recovery.py
+++ b/trading_bot/gateway/recovery.py
@@ -29,6 +29,11 @@ ET: ZoneInfo = TZ_EASTERN
 # Default thresholds — overridable via config.
 _DEFAULT_STALE_ENTRY_MINUTES: int = 5
 _DEFAULT_EOD_FLATTEN_TIME: str = "15:55"
+# Don't close DB-only positions whose entry_time is younger than this.
+# Alpaca's positions endpoint can lag a fresh fill by several minutes,
+# so a brand-new entry can briefly look DB-only and trip the mismatch
+# branch. Override via config.recovery.fresh_entry_grace_minutes.
+_DEFAULT_FRESH_ENTRY_GRACE_MINUTES: int = 10
 
 
 @dataclass
@@ -41,6 +46,7 @@ class RecoveryResult:
 
     positions_created: list[str] = field(default_factory=list)
     positions_closed_mismatch: list[str] = field(default_factory=list)
+    positions_deferred_fresh: list[str] = field(default_factory=list)
     quantities_updated: list[str] = field(default_factory=list)
     stops_placed: list[str] = field(default_factory=list)
     stale_orders_cancelled: list[str] = field(default_factory=list)
@@ -72,6 +78,11 @@ class RecoveryResult:
             lines.append(f"Created DB records for broker-only positions: {', '.join(self.positions_created)}")
         if self.positions_closed_mismatch:
             lines.append(f"Closed DB-only positions (mismatch): {', '.join(self.positions_closed_mismatch)}")
+        if self.positions_deferred_fresh:
+            lines.append(
+                f"Deferred fresh DB-only positions (Alpaca lag): "
+                f"{', '.join(self.positions_deferred_fresh)}"
+            )
         if self.quantities_updated:
             lines.append(f"Updated quantities: {', '.join(self.quantities_updated)}")
         if self.stops_placed:
@@ -219,14 +230,44 @@ class StateRecovery:
                     self._update_db_quantity(db_row["id"], alpaca_qty)
                     result.quantities_updated.append(ticker)
 
+        recovery_cfg: dict[str, Any] = self._config.get("recovery", {}) or {}
+        grace_minutes: int = int(
+            recovery_cfg.get(
+                "fresh_entry_grace_minutes",
+                _DEFAULT_FRESH_ENTRY_GRACE_MINUTES,
+            )
+        )
+        now: datetime = self._now_fn()
+
         for ticker, db_row in db_by_ticker.items():
-            if ticker not in alpaca_by_ticker:
+            if ticker in alpaca_by_ticker:
+                continue
+            entry_age_min: float | None = _entry_age_minutes(
+                db_row.get("entry_time"), now,
+            )
+            if (
+                entry_age_min is not None
+                and entry_age_min < float(grace_minutes)
+            ):
+                # Fresh entry: Alpaca's positions endpoint can lag a fill
+                # by several minutes. Closing here would write a phantom
+                # exit for a position that very likely just opened. Defer
+                # — the next tick will either see it on Alpaca or close
+                # it once it's outside the grace window.
                 logger.warning(
-                    "DB has position %s not in Alpaca - marking CLOSED",
-                    ticker,
+                    "DB has position %s (entry %.1f min ago) not yet on "
+                    "Alpaca — within %d-min fresh-entry grace, deferring "
+                    "close",
+                    ticker, entry_age_min, grace_minutes,
                 )
-                self._close_db_position(db_row["id"], "reconciliation_mismatch")
-                result.positions_closed_mismatch.append(ticker)
+                result.positions_deferred_fresh.append(ticker)
+                continue
+            logger.warning(
+                "DB has position %s not in Alpaca - marking CLOSED",
+                ticker,
+            )
+            self._close_db_position(db_row["id"], "reconciliation_mismatch")
+            result.positions_closed_mismatch.append(ticker)
 
     async def _verify_stop_orders(
         self,
@@ -655,3 +696,19 @@ def _to_et(value: Any) -> datetime | None:
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=ZoneInfo("UTC"))
     return dt.astimezone(ET)
+
+
+def _entry_age_minutes(entry_time: Any, now: datetime) -> float | None:
+    """Minutes elapsed since ``entry_time``, or None if unparseable.
+
+    Used by the fresh-entry grace check in ``_reconcile``: a position
+    whose entry_time is recent enough may not have shown up on Alpaca's
+    positions endpoint yet, so the mismatch branch should defer rather
+    than close it.
+    """
+    et_dt = _to_et(entry_time)
+    if et_dt is None:
+        return None
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=ET)
+    return (now - et_dt).total_seconds() / 60.0

--- a/trading_bot/tests/test_state_recovery.py
+++ b/trading_bot/tests/test_state_recovery.py
@@ -157,7 +157,12 @@ class TestStateRecovery:
         conn.close()
 
         gw = self._make_gateway(positions=[])
-        recovery = _make_recovery(gw, tmp_db_path, mock_notifier)
+        # Pin the clock 1 hour in the future so PLTR's just-inserted
+        # entry_time is far outside the fresh-entry grace window.
+        recovery = _make_recovery(
+            gw, tmp_db_path, mock_notifier,
+            now=datetime.now(ET) + timedelta(hours=1),
+        )
         result = await recovery.recover()
         assert "PLTR" in result.positions_closed_mismatch
 
@@ -167,6 +172,71 @@ class TestStateRecovery:
         ).fetchone()
         conn.close()
         assert row[0] == "CLOSED"
+
+    @pytest.mark.asyncio
+    async def test_db_position_not_in_alpaca_deferred_when_entry_fresh(
+        self, tmp_db_path: str, mock_notifier
+    ) -> None:
+        """Live bug observed 2026-05-06: bot opens MSFT at 09:55 ET, the
+        next 10:00 tick's reconciler fires before Alpaca's positions
+        endpoint reflects the fill, and the row is closed as
+        reconciliation_mismatch with NULL exit data — phantom round-trip.
+
+        Fix: positions whose entry_time is within the configured grace
+        window must be deferred, not closed. The next tick (outside the
+        window) will either see the position on Alpaca or close it for
+        real if it never appeared.
+        """
+        conn = sqlite3.connect(tmp_db_path)
+        _insert_db_position(conn, "MSFT")  # entry_time = now
+        conn.close()
+
+        gw = self._make_gateway(positions=[])
+        # 5 minutes after entry — well within the 10-min default grace.
+        recovery = _make_recovery(
+            gw, tmp_db_path, mock_notifier,
+            now=datetime.now(ET) + timedelta(minutes=5),
+        )
+        result = await recovery.recover()
+
+        assert "MSFT" in result.positions_deferred_fresh, (
+            "fresh entry must be deferred, not silently closed"
+        )
+        assert "MSFT" not in result.positions_closed_mismatch
+
+        conn = sqlite3.connect(tmp_db_path)
+        row = conn.execute(
+            "SELECT status FROM positions WHERE ticker='MSFT'"
+        ).fetchone()
+        conn.close()
+        assert row[0] == "POSITION_OPEN", (
+            "deferred row must remain POSITION_OPEN — closing it would "
+            "create the same phantom round-trip the fix is preventing."
+        )
+
+    @pytest.mark.asyncio
+    async def test_db_position_grace_window_overridable_via_config(
+        self, tmp_db_path: str, mock_notifier
+    ) -> None:
+        """Setting recovery.fresh_entry_grace_minutes to 0 disables the
+        defer (covers the regression-tightening case where an operator
+        wants the original behavior back temporarily)."""
+        conn = sqlite3.connect(tmp_db_path)
+        _insert_db_position(conn, "PLTR")
+        conn.close()
+
+        gw = self._make_gateway(positions=[])
+        recovery = _make_recovery(
+            gw, tmp_db_path, mock_notifier,
+            now=datetime.now(ET) + timedelta(minutes=2),
+            config={
+                "exit_intraday": {"stop_loss_pct": 0.02},
+                "recovery": {"fresh_entry_grace_minutes": 0},
+            },
+        )
+        result = await recovery.recover()
+        assert "PLTR" in result.positions_closed_mismatch
+        assert "PLTR" not in result.positions_deferred_fresh
 
     @pytest.mark.asyncio
     async def test_quantity_mismatch_updated(


### PR DESCRIPTION
## Summary

Add a configurable grace window to \`StateRecovery._reconcile\` so a position whose entry_time is recent enough is **deferred**, not closed, when it doesn't appear on Alpaca's positions endpoint yet.

- New config: \`recovery.fresh_entry_grace_minutes\` (default \`10\`)
- New result field: \`positions_deferred_fresh\` (surfaced in \`summary()\`)
- Setting the grace to \`0\` reverts to original always-close behavior

## Why

Live bug observed 2026-05-06: bot opened MSFT at 09:55 ET, the very next 10:00 tick's reconciler queried Alpaca, didn't see MSFT in positions, and stamped the row \`reconciliation_mismatch\` with NULL exit data — a phantom round-trip for a position that very likely had just filled cleanly. Alpaca's positions endpoint can lag a fresh fill by several minutes; the 5-minute cron interval is squarely inside that window.

The grace window is short enough that a genuine orphan (DB row with no broker counterpart) gets closed within one extra tick, but long enough that a routine fill-then-immediate-reconcile doesn't trip the mismatch branch.

## Test plan

- [x] 3 new unit tests:
  - fresh entry deferred (10 min default, recover at +5 min)
  - existing close test pinned past the grace window stays green
  - \`grace_minutes = 0\` overrides back to immediate close (regression escape hatch)
- [x] Full suite passes (730 + new ones)
- [ ] Watch tomorrow's 09:30-10:00 ET ticks — confirm any fresh entry that lands in that window survives the next reconciler tick