### PR TITLE
fix(self_improve): backfill UPDATEs reconciliation rows + recompute daily_summaries

### DIFF
--- a/.github/workflows/daily-review.yml
+++ b/.github/workflows/daily-review.yml
@@ -89,6 +89,16 @@ jobs:
         continue-on-error: true
         run: python -m trading_bot.self_improve.backfill_cli
 
+      - name: Recompute daily_summaries from backfilled trades
+        # The live wind-down writes daily_summaries ~16:10 ET, before this
+        # backfill runs at 21:30 UTC. Without a recompute, daily_summaries
+        # rows stay frozen with wins=0/losses=0/net_pnl=0 even after the
+        # trades are backfilled. Idempotent (INSERT OR REPLACE).
+        env:
+          BOT_LOG_DIR: logs
+        continue-on-error: true
+        run: python -m trading_bot.self_improve.recompute_daily_summaries --days 14
+
       - name: Run self-improvement agent
         env:
           ALPACA_ENV: ${{ vars.ALPACA_ENV || 'paper' }}

--- a/trading_bot/self_improve/alpaca_backfill.py
+++ b/trading_bot/self_improve/alpaca_backfill.py
@@ -231,10 +231,64 @@ def insert_backfilled_trade(
     position: ClosedPositionRow,
     exit_fill: ExitFill,
 ) -> None:
-    """Write a complete trades row, idempotent via the notes marker."""
+    """Write or repair a backfilled trades row.
+
+    Two paths, in order:
+
+    1. If a reconciliation_mismatch row already exists for this position
+       (same ticker, same entry_time, NULL exit_price), UPDATE that row in
+       place — fills the missing exit_price/pnl/exit_reason and stamps the
+       backfill notes marker so the candidate query skips it next time.
+       This is the common path: ``StateRecovery._close_db_position``
+       writes the row with NULL exit data, and the backfill repairs it.
+
+    2. Otherwise INSERT a fresh row. Covers older positions that predate
+       the recovery-write path, or any case where the reconciler row is
+       missing for some reason. Idempotent via the same notes marker.
+
+    Avoiding the duplicate INSERT lets ``daily_summaries`` see the real
+    pnl_usd and stops the trades table from growing a phantom row per
+    position per night.
+    """
     gross_pnl = (exit_fill.filled_avg_price - position.entry_price) * position.quantity
     exit_reason = _infer_exit_reason(exit_fill.order_id, position)
     note = f"{BACKFILL_MARKER_PREFIX}{position.position_id}"
+    entry_time_str = position.entry_time.strftime("%Y-%m-%d %H:%M:%S")
+    exit_time_str = exit_fill.filled_at.strftime("%Y-%m-%d %H:%M:%S")
+
+    # Match the reconciliation_mismatch row by (ticker, entry_time prefix,
+    # exit_reason='reconciliation_mismatch', null exit_price). Entry-time
+    # comparison uses a substring match because the live writer stamps a
+    # tz-aware ISO string while we built ours via strftime — exact equality
+    # would never match. The seconds-precision substring is precise enough
+    # to disambiguate (a strategy doesn't open two positions on the same
+    # ticker in the same second).
+    existing = conn.execute(
+        """
+        SELECT id FROM trades
+         WHERE ticker = ?
+           AND substr(entry_time, 1, 19) = ?
+           AND exit_reason = 'reconciliation_mismatch'
+           AND exit_price IS NULL
+         ORDER BY id DESC LIMIT 1
+        """,
+        (position.ticker, entry_time_str),
+    ).fetchone()
+
+    if existing is not None:
+        conn.execute(
+            """
+            UPDATE trades
+               SET exit_time = ?, exit_price = ?, exit_reason = ?,
+                   gross_pnl = ?, net_pnl = ?, pnl_usd = ?, notes = ?
+             WHERE id = ?
+            """,
+            (
+                exit_time_str, exit_fill.filled_avg_price, exit_reason,
+                gross_pnl, gross_pnl, gross_pnl, note, int(existing[0]),
+            ),
+        )
+        return
 
     conn.execute(
         """
@@ -253,9 +307,9 @@ def insert_backfilled_trade(
         """,
         (
             position.ticker, position.exchange, position.currency,
-            position.entry_time.strftime("%Y-%m-%d %H:%M:%S"),
+            entry_time_str,
             position.entry_price, position.quantity,
-            exit_fill.filled_at.strftime("%Y-%m-%d %H:%M:%S"),
+            exit_time_str,
             exit_fill.filled_avg_price, exit_reason,
             gross_pnl, gross_pnl, gross_pnl,
             position.hold_type, position.phase, position.strategy_id, note,

--- a/trading_bot/self_improve/recompute_daily_summaries.py
+++ b/trading_bot/self_improve/recompute_daily_summaries.py
@@ -1,0 +1,211 @@
+"""Recompute daily_summaries rows from the trades table.
+
+The live wind-down writer (``main.py::_save_daily_summary``) runs ~16:10 ET,
+before the 21:30 UTC daily-review backfill populates the actual exit_price
+and pnl_usd on closed trades. As a result every recent daily_summaries
+row reads as ``wins=0 losses=0 net_pnl_usd=0`` even on days with dozens
+of closed trades.
+
+This script reads the trades table, recomputes the metrics, and uses
+``repo.save_daily_summary`` (INSERT OR REPLACE) to overwrite the row.
+Run after the backfill so it sees the populated trade rows.
+
+Usage:
+    python -m trading_bot.self_improve.recompute_daily_summaries --days 7
+    python -m trading_bot.self_improve.recompute_daily_summaries --date 2026-05-05
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sqlite3
+import sys
+from datetime import date, datetime, timedelta
+from pathlib import Path
+from typing import Iterable
+
+from trading_bot.config import Config
+from trading_bot.constants import TZ_EASTERN
+from trading_bot.db import repository as repo
+from trading_bot.log_setup import setup_logging
+from trading_bot.reporting.performance import PerformanceCalculator
+
+logger = logging.getLogger(__name__)
+
+
+def _dates_with_trades(
+    conn: sqlite3.Connection, days_back: int,
+) -> list[str]:
+    """Return YYYY-MM-DD strings for the last ``days_back`` calendar days
+    that have at least one trades row with a non-null exit_time."""
+    cutoff: date = (
+        datetime.now(tz=TZ_EASTERN).date() - timedelta(days=days_back)
+    )
+    rows = conn.execute(
+        "SELECT DISTINCT date(exit_time) AS d FROM trades "
+        "WHERE exit_time IS NOT NULL AND date(exit_time) >= ? "
+        "ORDER BY d",
+        (cutoff.isoformat(),),
+    ).fetchall()
+    return [str(r[0]) for r in rows if r[0]]
+
+
+def _resolve_db_path(conn: sqlite3.Connection) -> str:
+    """Return the file path backing ``conn`` so PerformanceCalculator can
+    open its own read connection against the same DB. Empty for
+    ``:memory:`` connections, which would make the metrics path read an
+    unrelated empty file — the caller must pass ``db_path`` explicitly
+    in that case.
+    """
+    row = conn.execute("PRAGMA database_list").fetchone()
+    # PRAGMA database_list returns (seq, name, file). The 'main' entry's
+    # file is empty for in-memory or temp DBs.
+    return str(row[2]) if row and row[2] else ""
+
+
+def _equity_for_date(
+    conn: sqlite3.Connection, target_date: str,
+) -> float | None:
+    """Use the existing daily_summaries row's account_equity_usd if any,
+    so the recompute doesn't reset the equity column to a stale value.
+    daily_summaries.account_equity_usd is NOT NULL — without a value we
+    skip the recompute rather than write a 0.0 lie.
+    """
+    row = conn.execute(
+        "SELECT account_equity_usd FROM daily_summaries WHERE date = ?",
+        (target_date,),
+    ).fetchone()
+    if row is None:
+        return None
+    try:
+        return float(row[0])
+    except (TypeError, ValueError):
+        return None
+
+
+def recompute_for_dates(
+    conn: sqlite3.Connection,
+    dates: Iterable[str],
+    *,
+    phase: int,
+    dry_run: bool,
+    db_path: str | None = None,
+) -> int:
+    """Recompute ``daily_summaries`` rows for ``dates``. Returns the
+    number of rows written (or that would be written, in dry-run).
+
+    ``db_path`` is required when ``conn`` is in-memory or otherwise opaque
+    to ``PerformanceCalculator`` (which opens its own read connection).
+    Pass the actual file path so the metrics calculator can read the
+    same trades the connection sees. For test connections backed by a
+    temp file, the path can be derived via ``conn.execute('PRAGMA
+    database_list')`` — see the CLI ``main`` for the canonical wiring.
+    """
+    perf = PerformanceCalculator(db_path or _resolve_db_path(conn))
+    written = 0
+    for d in dates:
+        equity = _equity_for_date(conn, d)
+        if equity is None:
+            logger.warning(
+                "Skipping %s: no existing daily_summaries row to read "
+                "account_equity from. Run the live bot's wind-down once "
+                "to seed it, then re-run this script.", d,
+            )
+            continue
+        try:
+            metrics = perf.calculate_daily_metrics(d)
+        except Exception:
+            logger.exception("Daily metrics calculation failed for %s", d)
+            continue
+
+        summary = {
+            "date": d,
+            "total_trades": metrics.get("total_trades", 0),
+            "wins": metrics.get("wins", 0),
+            "losses": metrics.get("losses", 0),
+            "gross_pnl_usd": metrics.get("gross_pnl_usd", 0.0),
+            "commissions_usd": metrics.get("commissions_usd", 0.0),
+            "net_pnl_usd": metrics.get("net_pnl_usd", 0.0),
+            "account_equity_usd": equity,
+            "max_drawdown_pct": metrics.get("max_drawdown_pct"),
+            "win_rate": metrics.get("win_rate"),
+            "avg_win_usd": metrics.get("avg_win"),
+            "avg_loss_usd": metrics.get("avg_loss"),
+            "profit_factor": metrics.get("profit_factor"),
+            "phase": phase,
+            "us_trades": metrics.get("us_trades", 0),
+            "notes": "recomputed:post_backfill",
+        }
+        logger.info(
+            "%sRecompute %s: trades=%d wins=%d losses=%d net=$%.2f",
+            "[DRY-RUN] " if dry_run else "",
+            d, summary["total_trades"], summary["wins"],
+            summary["losses"], summary["net_pnl_usd"],
+        )
+        if dry_run:
+            written += 1
+            continue
+        repo.save_daily_summary(conn, summary)
+        written += 1
+
+    if not dry_run:
+        conn.commit()
+    return written
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Recompute daily_summaries rows from the trades table.",
+    )
+    parser.add_argument("--config", default="config.yaml")
+    parser.add_argument("--db", default=None,
+                        help="SQLite path (default: config's database.path)")
+    parser.add_argument(
+        "--days", type=int, default=7,
+        help="Recompute summaries for the last N days that have closed "
+             "trades (default 7).",
+    )
+    parser.add_argument(
+        "--date", default=None,
+        help="Recompute a single YYYY-MM-DD date (overrides --days).",
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    setup_logging("recompute_daily_summaries")
+    args = _parse_args(argv)
+    config = Config.load(args.config)
+    db_path = args.db or config.db_path
+    if not Path(db_path).exists():
+        logger.error("DB not found at %s", db_path)
+        return 2
+
+    conn = sqlite3.connect(db_path)
+    try:
+        if args.date:
+            dates = [args.date]
+        else:
+            dates = _dates_with_trades(conn, args.days)
+            if not dates:
+                logger.info("No closed-trade dates in the last %d days.",
+                            args.days)
+                return 0
+        written = recompute_for_dates(
+            conn, dates,
+            phase=config.get_phase().value,
+            dry_run=args.dry_run,
+            db_path=db_path,
+        )
+    finally:
+        conn.close()
+
+    logger.info("Recomputed %d daily_summary row(s) (dry_run=%s)",
+                written, args.dry_run)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/trading_bot/tests/test_recompute_daily_summaries.py
+++ b/trading_bot/tests/test_recompute_daily_summaries.py
@@ -1,0 +1,168 @@
+"""Tests for trading_bot.self_improve.recompute_daily_summaries.
+
+The recompute step closes the gap between the live wind-down
+(daily_summary written at 16:10 ET with NULL pnl_usd in trades) and the
+21:30 UTC backfill (which populates pnl_usd). Without it, daily_summaries
+stays at wins=0/losses=0/net=0 even on busy trading days.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from contextlib import contextmanager
+
+import pytest
+
+from trading_bot.self_improve.recompute_daily_summaries import (
+    _dates_with_trades,
+    recompute_for_dates,
+)
+
+
+@contextmanager
+def _conn(db_path: str):
+    c = sqlite3.connect(db_path)
+    try:
+        yield c
+    finally:
+        c.close()
+
+
+def _seed_summary(
+    conn: sqlite3.Connection, *, date: str, equity: float = 100000.0,
+):
+    """Seed a stale-zeros daily_summaries row mimicking the live writer."""
+    conn.execute(
+        """INSERT INTO daily_summaries (
+            date, total_trades, wins, losses,
+            gross_pnl_usd, commissions_usd, net_pnl_usd,
+            account_equity_usd, phase, us_trades
+        ) VALUES (?, 0, 0, 0, 0.0, 0.0, 0.0, ?, 3, 0)""",
+        (date, equity),
+    )
+
+
+def _seed_trade(
+    conn: sqlite3.Connection, *,
+    ticker: str, exit_date: str, gross: float, pnl: float,
+):
+    conn.execute(
+        """INSERT INTO trades (
+            ticker, exchange, currency, side,
+            entry_time, entry_price, quantity,
+            exit_time, exit_price, exit_reason,
+            gross_pnl, net_pnl, pnl_usd,
+            hold_type, phase, strategy_id
+        ) VALUES (?, 'US', 'USD', 'BUY',
+                  ?, 100.0, 10,
+                  ?, ?, 'stop_loss',
+                  ?, ?, ?,
+                  'swing', 3, 'overnight_drift')""",
+        (
+            ticker,
+            f"{exit_date}T09:00:00",
+            f"{exit_date}T15:00:00",
+            100.0 + (pnl / 10),  # plausible exit price
+            gross, gross, pnl,
+        ),
+    )
+
+
+@pytest.mark.unit
+def test_recompute_overwrites_stale_zeros_with_real_metrics(tmp_db_path):
+    """Pre-condition: daily_summaries written by wind-down with NULL
+    pnl_usd in trades → all zeros. After backfill populates pnl_usd, the
+    recompute fills in the real wins/losses/net."""
+    with _conn(tmp_db_path) as conn:
+        _seed_summary(conn, date="2026-04-30")
+        _seed_trade(conn, ticker="SPY", exit_date="2026-04-30",
+                    gross=12.0, pnl=12.0)
+        _seed_trade(conn, ticker="QQQ", exit_date="2026-04-30",
+                    gross=-5.0, pnl=-5.0)
+        _seed_trade(conn, ticker="XLK", exit_date="2026-04-30",
+                    gross=8.0, pnl=8.0)
+        conn.commit()
+
+        written = recompute_for_dates(
+            conn, ["2026-04-30"], phase=3, dry_run=False,
+        )
+        assert written == 1
+
+        row = conn.execute(
+            "SELECT total_trades, wins, losses, net_pnl_usd, notes "
+            "FROM daily_summaries WHERE date = '2026-04-30'"
+        ).fetchone()
+    assert row[0] == 3
+    assert row[1] == 2  # wins
+    assert row[2] == 1  # losses
+    assert row[3] == pytest.approx(15.0)  # 12 - 5 + 8
+    assert "recomputed:post_backfill" in (row[4] or "")
+
+
+@pytest.mark.unit
+def test_recompute_skips_dates_with_no_existing_summary(tmp_db_path):
+    """Without an existing daily_summaries row we have no
+    account_equity_usd to write — the column is NOT NULL. Skip rather
+    than make up a value."""
+    with _conn(tmp_db_path) as conn:
+        _seed_trade(conn, ticker="SPY", exit_date="2026-04-29",
+                    gross=10.0, pnl=10.0)
+        conn.commit()
+
+        written = recompute_for_dates(
+            conn, ["2026-04-29"], phase=3, dry_run=False,
+        )
+        assert written == 0
+
+        row = conn.execute(
+            "SELECT COUNT(*) FROM daily_summaries WHERE date='2026-04-29'"
+        ).fetchone()
+    assert row[0] == 0
+
+
+@pytest.mark.unit
+def test_recompute_dry_run_makes_no_writes(tmp_db_path):
+    with _conn(tmp_db_path) as conn:
+        _seed_summary(conn, date="2026-05-01")
+        _seed_trade(conn, ticker="SPY", exit_date="2026-05-01",
+                    gross=20.0, pnl=20.0)
+        conn.commit()
+
+        written = recompute_for_dates(
+            conn, ["2026-05-01"], phase=3, dry_run=True,
+        )
+        assert written == 1
+
+        row = conn.execute(
+            "SELECT wins, net_pnl_usd FROM daily_summaries "
+            "WHERE date='2026-05-01'"
+        ).fetchone()
+    assert row[0] == 0
+    assert row[1] == pytest.approx(0.0)
+
+
+@pytest.mark.unit
+def test_dates_with_trades_returns_only_dates_with_closed_trades(tmp_db_path):
+    """An open trade (exit_time NULL) must not count — recompute would
+    pick up an in-progress day and write zeros over a future correct
+    summary."""
+    with _conn(tmp_db_path) as conn:
+        _seed_trade(conn, ticker="SPY", exit_date="2026-04-30",
+                    gross=10.0, pnl=10.0)
+        conn.execute(
+            """INSERT INTO trades (
+                ticker, exchange, currency, side,
+                entry_time, entry_price, quantity,
+                hold_type, phase, strategy_id
+            ) VALUES ('QQQ', 'US', 'USD', 'BUY',
+                      '2026-05-06T15:00:00', 200.0, 5,
+                      'swing', 3, 'overnight_drift')""",
+        )
+        conn.commit()
+
+        # Use a wide enough days_back to reach back from "now" to test data.
+        # Test fixtures use 2026-04-30 / 2026-05-06; days_back=10000 covers
+        # any wall-clock date.
+        dates = _dates_with_trades(conn, days_back=10000)
+    assert "2026-04-30" in dates
+    assert "2026-05-06" not in dates

--- a/trading_bot/tests/test_self_improve_alpaca_backfill.py
+++ b/trading_bot/tests/test_self_improve_alpaca_backfill.py
@@ -176,6 +176,142 @@ def test_insert_writes_complete_row(tmp_db):
     assert row[5] == f"{BACKFILL_MARKER_PREFIX}1"
 
 
+@pytest.mark.unit
+def test_backfill_updates_existing_reconciliation_mismatch_row(tmp_db):
+    """Live bug: StateRecovery._close_db_position writes a trades row
+    with NULL exit_price and exit_reason='reconciliation_mismatch'.
+    Pre-fix backfill INSERTed a separate row, leaving daily_summaries
+    blind to the actual P&L (it can't tell which of the two duplicates
+    is the truth) and bloating the table by one row per close per night.
+
+    The repair must UPDATE the existing reconciliation_mismatch row,
+    not insert.
+    """
+    p = _make_position(stop_id="alp-stop")
+    # Seed the reconciliation_mismatch row that StateRecovery writes.
+    tmp_db.execute(
+        """
+        INSERT INTO trades (
+            ticker, exchange, currency, side,
+            entry_time, entry_price, quantity,
+            exit_time, exit_reason,
+            hold_type, phase, strategy_id, notes
+        ) VALUES ('SPY', 'NYSE', 'USD', 'BUY',
+                  '2026-04-01 15:45:00', 100.0, 10,
+                  '2026-04-02 09:00:00', 'reconciliation_mismatch',
+                  'swing', 1, 'overnight_drift', 'placeholder')
+        """,
+    )
+    tmp_db.commit()
+
+    fill = ExitFill(
+        order_id="alp-stop",
+        filled_at=datetime(2026, 4, 2, 9, 31, tzinfo=timezone.utc),
+        filled_avg_price=98.0,
+        filled_qty=10.0,
+    )
+    insert_backfilled_trade(tmp_db, p, fill)
+    tmp_db.commit()
+
+    rows = tmp_db.execute(
+        "SELECT id, exit_reason, exit_price, pnl_usd, notes FROM trades "
+        "WHERE ticker='SPY' ORDER BY id"
+    ).fetchall()
+    assert len(rows) == 1, (
+        "backfill must UPDATE the existing reconciliation_mismatch row, "
+        "not insert a duplicate."
+    )
+    row = rows[0]
+    assert row[1] == "stop_loss", "exit_reason rewritten with the real one"
+    assert row[2] == pytest.approx(98.0)
+    assert row[3] == pytest.approx((98.0 - 100.0) * 10)
+    assert row[4] == f"{BACKFILL_MARKER_PREFIX}1", (
+        "notes carries the backfill marker so load_candidates skips next time"
+    )
+
+
+@pytest.mark.unit
+def test_backfill_inserts_when_no_reconciliation_row_present(tmp_db):
+    """Older closed positions that predate the recovery-write path don't
+    have a reconciliation_mismatch row to update — INSERT remains the
+    correct fallback."""
+    p = _make_position(stop_id="alp-stop")
+    fill = ExitFill(
+        order_id="alp-stop",
+        filled_at=datetime(2026, 4, 2, 9, 31, tzinfo=timezone.utc),
+        filled_avg_price=98.0,
+        filled_qty=10.0,
+    )
+    insert_backfilled_trade(tmp_db, p, fill)
+    tmp_db.commit()
+
+    rows = tmp_db.execute(
+        "SELECT exit_price, notes FROM trades WHERE ticker='SPY'"
+    ).fetchall()
+    assert len(rows) == 1
+    assert rows[0][0] == pytest.approx(98.0)
+    assert rows[0][1] == f"{BACKFILL_MARKER_PREFIX}1"
+
+
+@pytest.mark.unit
+def test_backfill_only_updates_matching_entry_time(tmp_db):
+    """Two closes on the same ticker on different days must not collide:
+    the UPDATE keys on entry_time and only modifies the matching row."""
+    p1 = _make_position(
+        position_id=1, stop_id="alp-stop-1",
+    )
+    # Different position, different entry_time
+    other_position = ClosedPositionRow(
+        position_id=2, ticker="SPY", exchange="NYSE", currency="USD",
+        strategy_id="overnight_drift", quantity=10, entry_price=110.0,
+        entry_time=datetime(2026, 5, 5, 15, 45, tzinfo=timezone.utc),
+        hold_type="swing", phase=1,
+        alpaca_order_id="alp-entry-2", alpaca_stop_order_id="alp-stop-2",
+        alpaca_target_order_id=None, alpaca_trail_order_id=None,
+    )
+
+    # Seed two reconciliation_mismatch rows, one per day.
+    for entry_time, ep in [
+        ("2026-04-01 15:45:00", 100.0),
+        ("2026-05-05 15:45:00", 110.0),
+    ]:
+        tmp_db.execute(
+            """
+            INSERT INTO trades (
+                ticker, exchange, currency, side,
+                entry_time, entry_price, quantity,
+                exit_time, exit_reason,
+                hold_type, phase, strategy_id
+            ) VALUES ('SPY', 'NYSE', 'USD', 'BUY',
+                      ?, ?, 10,
+                      '2026-05-06 09:00:00', 'reconciliation_mismatch',
+                      'swing', 1, 'overnight_drift')
+            """,
+            (entry_time, ep),
+        )
+    tmp_db.commit()
+
+    insert_backfilled_trade(tmp_db, p1, ExitFill(
+        order_id="alp-stop-1",
+        filled_at=datetime(2026, 4, 2, 9, 31, tzinfo=timezone.utc),
+        filled_avg_price=98.0, filled_qty=10.0,
+    ))
+    tmp_db.commit()
+
+    rows = tmp_db.execute(
+        "SELECT entry_time, exit_price, pnl_usd FROM trades "
+        "WHERE ticker='SPY' ORDER BY entry_time"
+    ).fetchall()
+    assert len(rows) == 2
+    # The April row got its exit price filled in.
+    assert rows[0][1] == pytest.approx(98.0)
+    # The May row stays untouched.
+    assert rows[1][1] is None, (
+        "the day-2 reconciliation_mismatch row must not be modified by "
+        "the day-1 backfill — entry_time disambiguates them."
+    )
+
+
 # ---------------------------------------------------------------------------
 # backfill (orchestrator with stubbed fill finder)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two coupled changes that together restore the broken \`daily_summaries\` telemetry surfaced in [#64](https://github.com/alex5imon/ai-broker/pull/64).

### Change 1 — \`alpaca_backfill\` UPDATEs in place

When a \`reconciliation_mismatch\` row already exists for a closed position (the placeholder \`StateRecovery._close_db_position\` writes with NULL exit data), the backfill now **UPDATEs** that row instead of inserting a duplicate. Match key: ticker + entry_time + \`exit_reason='reconciliation_mismatch'\` + null exit_price. Falls through to INSERT when no such row exists (preserves backwards compat for older positions).

Two consequences:
- The \`trades\` table no longer grows one phantom row per close per night (current DB: 64 such rows already accumulated over the last 20 days).
- \`daily_summaries\` can compute wins/losses from a single canonical row per closed position, instead of having to disambiguate the duplicate.

### Change 2 — Recompute \`daily_summaries\` after backfill

New CLI module \`trading_bot.self_improve.recompute_daily_summaries\`:
- Reads the trades table, recomputes per-day metrics via \`PerformanceCalculator\`, writes via \`repo.save_daily_summary\` (INSERT OR REPLACE).
- Skips dates with no existing \`daily_summaries\` row (\`account_equity_usd\` is NOT NULL — we cannot fabricate it without the live wind-down's broker query).
- Wired into \`daily-review.yml\` after the backfill step, with \`--days 14\`.

### Why

The live wind-down writes \`daily_summaries\` at ~16:10 ET with NULL \`pnl_usd\` in trades, so \`wins/losses/net_pnl\` all read \`0\` on every recent day — even \`2026-04-30\` with 60 trades. The 21:30 UTC daily-review backfill populates \`pnl_usd\` but never re-runs the summary writer. After this PR, the order is:

1. (existing) Live wind-down writes daily_summaries with stale 0s and seeds the equity column.
2. (new) Backfill UPDATEs reconciliation rows with real exit_price + pnl_usd.
3. (new) Recompute reads the now-real trades and overwrites daily_summaries with correct wins/losses/net.

## Test plan

- [x] 4 new backfill tests:
  - UPDATE existing reconciliation_mismatch row (the new path)
  - INSERT fallback when no reconciliation row exists (backwards compat)
  - Entry-time disambiguation: two closes on the same ticker on different days don't collide
  - The original \`test_insert_writes_complete_row\` (still passes)
- [x] 4 new recompute tests:
  - Overwrites stale zeros with real metrics from the trades table
  - Skips when no existing daily_summaries row to read equity from
  - Dry-run makes no writes
  - \`_dates_with_trades\` excludes open positions (exit_time IS NULL)
- [x] Full suite: 735 passing
- [ ] After merge, watch tomorrow's daily-review run: confirm \`daily_summaries\` for the past 14 days reflect real wins/losses, and the trades table doesn't grow a duplicate row for each closed position