### PR TITLE
fix(self_improve): repair_orphans checks live positions; phantom-row sweep; concurrency split

### DIFF
--- a/.github/workflows/repair-orphans.yml
+++ b/.github/workflows/repair-orphans.yml
@@ -16,11 +16,13 @@ on:
         type: boolean
         default: true
 
-# Same group as the bot so a real bot tick can't trample our DB write
-# and vice versa. Don't cancel-in-progress: a half-finished repair
-# leaves the cache in an inconsistent state.
+# Own concurrency group so a scheduled bot.yml tick (which sets
+# cancel-in-progress=true on the bot-run group) cannot send a cancel
+# signal mid-write. The repair re-restores the most recent bot-db-*
+# cache via restore-keys and writes back under the same prefix, so
+# the next bot tick still picks up our changes.
 concurrency:
-  group: bot-run
+  group: repair-run
   cancel-in-progress: false
 
 permissions:

--- a/trading_bot/self_improve/repair_orphans.py
+++ b/trading_bot/self_improve/repair_orphans.py
@@ -45,14 +45,17 @@ logger = logging.getLogger(__name__)
 ET: ZoneInfo = TZ_EASTERN
 
 
-@dataclass
+@dataclass(frozen=True)
 class RepairReport:
     """Summary of a single repair invocation."""
 
     entry_failed_scanned: int
     entry_failed_repaired: int
+    entry_failed_marked_closed: int
     unknown_duplicates_scanned: int
     unknown_duplicates_closed: int
+    phantom_live_scanned: int
+    phantom_live_closed: int
     dry_run: bool
 
 
@@ -86,6 +89,33 @@ def _load_unknown_duplicates(
         (),
     ).fetchall()
     return [dict(r) for r in rows]
+
+
+async def _fetch_live_tickers(client) -> set[str]:
+    """Fetch the set of tickers currently held at Alpaca (qty != 0).
+
+    Single broker query at the top of the repair, threaded through every
+    decision so the script can distinguish "filled and still held" (flip
+    to live) from "filled then exited later" (mark CLOSED).
+    """
+    try:
+        positions = await asyncio.to_thread(client.get_all_positions)
+    except Exception:
+        logger.warning(
+            "Could not list Alpaca positions — falling back to "
+            "filled-only check (may flip ghost rows to live)",
+            exc_info=True,
+        )
+        return set()
+    out: set[str] = set()
+    for p in positions:
+        try:
+            qty = float(getattr(p, "qty", 0) or 0)
+        except (TypeError, ValueError):
+            continue
+        if abs(qty) > 1e-6:
+            out.add(str(getattr(p, "symbol", "")))
+    return out
 
 
 async def _check_order_filled(client, alpaca_order_id: str):
@@ -154,16 +184,31 @@ async def _find_open_stop_for_ticker(
 async def _repair_entry_failed(
     conn: sqlite3.Connection,
     client,
+    live_tickers: set[str],
     *,
     dry_run: bool,
-) -> tuple[int, int]:
-    """Flip ENTRY_FAILED → STOP_AND_TARGET_ACTIVE for rows whose Alpaca
-    order actually filled, adopting any matching open stop.
+) -> tuple[int, int, int]:
+    """Repair ENTRY_FAILED rows.
 
-    Returns (scanned, repaired).
+    Three outcomes per row:
+
+    - Order **filled and ticker is still held** → flip to
+      ``STOP_AND_TARGET_ACTIVE`` (adopt matching broker stop) or
+      ``POSITION_OPEN`` (no live stop yet — next reconciler tick
+      attaches one).
+    - Order **filled but ticker is NOT held at Alpaca** → mark
+      ``CLOSED`` with a backfill note. The fill happened then the
+      position was exited (intraday close, MOO, manual flatten); the
+      previous version of this script wrongly flipped these to
+      POSITION_OPEN, creating ghost rows.
+    - Order **not filled** (canceled/expired/rejected) → leave
+      ``ENTRY_FAILED`` (genuine failure).
+
+    Returns ``(scanned, flipped_to_live, marked_closed)``.
     """
     candidates = _load_entry_failed_with_order_id(conn)
-    repaired = 0
+    flipped_live = 0
+    marked_closed = 0
     now_iso: str = datetime.now(tz=ET).isoformat()
 
     for pos in candidates:
@@ -187,8 +232,40 @@ async def _repair_entry_failed(
             )
             continue
 
+        ticker = str(pos["ticker"])
+        currently_held: bool = ticker in live_tickers
+
+        if not currently_held:
+            # Filled then exited later. Mark CLOSED with a note —
+            # never flip a ghost to live.
+            logger.info(
+                "%sMarking position %d (%s) CLOSED — entry order %s "
+                "filled @ %.4f but ticker not currently held at Alpaca "
+                "(round-tripped before repair)",
+                "[DRY-RUN] " if dry_run else "",
+                pos["id"], ticker, oid[:8], filled_avg,
+            )
+            if not dry_run:
+                # No notes column on positions — the log line above is
+                # the audit trail. The fill price/quantity is preserved
+                # so daily-review backfill can still match this position
+                # to its exit fill in the trades table.
+                with conn:
+                    conn.execute(
+                        "UPDATE positions SET status = ?, "
+                        "entry_price = ?, quantity = ?, "
+                        "updated_at = ? "
+                        "WHERE id = ?",
+                        (
+                            PositionStatus.CLOSED.value, filled_avg,
+                            filled_qty, now_iso, pos["id"],
+                        ),
+                    )
+            marked_closed += 1
+            continue
+
         stop_id = await _find_open_stop_for_ticker(
-            client, str(pos["ticker"]), filled_qty,
+            client, ticker, filled_qty,
         )
 
         new_status: str = (
@@ -200,12 +277,12 @@ async def _repair_entry_failed(
             "%sRepairing position %d (%s): ENTRY_FAILED -> %s "
             "(qty=%.6f @ %.4f, stop_id=%s)",
             "[DRY-RUN] " if dry_run else "",
-            pos["id"], pos["ticker"], new_status,
+            pos["id"], ticker, new_status,
             filled_qty, filled_avg, stop_id or "none",
         )
 
         if dry_run:
-            repaired += 1
+            flipped_live += 1
             continue
 
         with conn:
@@ -220,9 +297,9 @@ async def _repair_entry_failed(
                     pos["id"],
                 ),
             )
-        repaired += 1
+        flipped_live += 1
 
-    return len(candidates), repaired
+    return len(candidates), flipped_live, marked_closed
 
 
 def _close_unknown_duplicates(
@@ -281,25 +358,135 @@ def _close_unknown_duplicates(
     return len(candidates), closed
 
 
+def _close_phantom_live_rows(
+    conn: sqlite3.Connection,
+    live_tickers: set[str],
+    *,
+    dry_run: bool,
+) -> tuple[int, int]:
+    """Close DB rows whose status is non-terminal but whose ticker is
+    not currently held at Alpaca.
+
+    Catches two failure modes:
+
+    1. Ghost rows left over from a prior repair run that wrongly
+       flipped ENTRY_FAILED → POSITION_OPEN without checking live
+       holdings (the bug this PR fixes).
+    2. Rows that ``StateRecovery._reconcile`` would normally close as
+       ``reconciliation_mismatch``, but silently dropped due to its
+       ``db_by_ticker[ticker] = row`` overwrite when two non-terminal
+       rows share a ticker.
+
+    The bot's reconciler will eventually catch class 1 alone for unique
+    tickers; class 2 needs explicit handling because the reconciler
+    can't see the second row at all.
+
+    Returns ``(scanned, closed)``.
+    """
+    rows = conn.execute(
+        "SELECT id, ticker, strategy_id, status, entry_time "
+        "FROM positions "
+        "WHERE status NOT IN ('CLOSED', 'ENTRY_FAILED') "
+        "ORDER BY ticker, entry_time"
+    ).fetchall()
+    scanned = 0
+    closed = 0
+    now_iso: str = datetime.now(tz=ET).isoformat()
+
+    # Group by ticker so we can decide which row(s) to close. If
+    # Alpaca holds the ticker AND multiple DB rows exist, close the
+    # older ones — the latest entry is the one matching the broker's
+    # actual position.
+    by_ticker: dict[str, list[dict[str, Any]]] = {}
+    for r in rows:
+        by_ticker.setdefault(str(r[1]), []).append({
+            "id": int(r[0]), "ticker": str(r[1]),
+            "strategy_id": r[2], "status": str(r[3]),
+            "entry_time": r[4],
+        })
+
+    for ticker, group in by_ticker.items():
+        scanned += len(group)
+        if ticker not in live_tickers:
+            # Whole group is phantom — close everything.
+            to_close = group
+            reason = "ticker not held at Alpaca (filled then exited)"
+        elif len(group) > 1:
+            # Multiple rows for a held ticker — keep the most recent,
+            # close the older ones (likely older fills already exited
+            # and replaced by a fresh entry).
+            sorted_rows = sorted(group, key=lambda r: r["entry_time"])
+            to_close = sorted_rows[:-1]
+            keeper = sorted_rows[-1]
+            reason = (
+                f"older duplicate of position {keeper['id']} "
+                "(both share a held ticker; reconciler can only "
+                "track one row per ticker)"
+            )
+        else:
+            continue
+
+        for unk in to_close:
+            logger.info(
+                "%sClosing phantom position %d (%s, %s, status=%s) — %s",
+                "[DRY-RUN] " if dry_run else "",
+                unk["id"], unk["ticker"],
+                unk["strategy_id"] or "<blank>",
+                unk["status"], reason,
+            )
+            if dry_run:
+                closed += 1
+                continue
+            with conn:
+                conn.execute(
+                    "UPDATE positions SET status = 'CLOSED', "
+                    "updated_at = ? WHERE id = ?",
+                    (now_iso, unk["id"]),
+                )
+            closed += 1
+
+    return scanned, closed
+
+
 async def repair(
     conn: sqlite3.Connection,
     client,
     *,
     dry_run: bool = False,
 ) -> RepairReport:
-    """Run both repairs. Order matters: fix ENTRY_FAILED first so the
-    sibling lookup in step 2 finds the now-live row."""
-    ef_scanned, ef_repaired = await _repair_entry_failed(
-        conn, client, dry_run=dry_run,
+    """Run all three repair passes. Order matters:
+
+    1. ``_repair_entry_failed`` — flip live or close based on whether
+       the broker actually holds the ticker.
+    2. ``_close_unknown_duplicates`` — close ``unknown`` rows whose
+       sibling is now live (sibling lookup depends on step 1).
+    3. ``_close_phantom_live_rows`` — close any remaining non-terminal
+       row whose ticker isn't held at Alpaca, plus older duplicate
+       rows for held tickers. Catches ghost rows from prior repair
+       runs and the reconciler's silent-drop bug.
+    """
+    live_tickers = await _fetch_live_tickers(client)
+    logger.info("Alpaca currently holds %d ticker(s): %s",
+                len(live_tickers),
+                ", ".join(sorted(live_tickers)) or "<none>")
+
+    ef_scanned, ef_repaired, ef_closed = await _repair_entry_failed(
+        conn, client, live_tickers, dry_run=dry_run,
     )
     unk_scanned, unk_closed = _close_unknown_duplicates(
         conn, dry_run=dry_run,
     )
+    phantom_scanned, phantom_closed = _close_phantom_live_rows(
+        conn, live_tickers, dry_run=dry_run,
+    )
     return RepairReport(
         entry_failed_scanned=ef_scanned,
         entry_failed_repaired=ef_repaired,
+        entry_failed_marked_closed=ef_closed,
         unknown_duplicates_scanned=unk_scanned,
         unknown_duplicates_closed=unk_closed,
+        phantom_live_scanned=phantom_scanned,
+        phantom_live_closed=phantom_closed,
         dry_run=dry_run,
     )
 
@@ -340,10 +527,13 @@ async def _async_main(args: argparse.Namespace) -> int:
         conn.close()
 
     logger.info(
-        "Repair complete: ef_scanned=%d ef_repaired=%d "
-        "unk_scanned=%d unk_closed=%d dry_run=%s",
+        "Repair complete: ef_scanned=%d ef_repaired=%d ef_closed=%d "
+        "unk_scanned=%d unk_closed=%d "
+        "phantom_scanned=%d phantom_closed=%d dry_run=%s",
         report.entry_failed_scanned, report.entry_failed_repaired,
+        report.entry_failed_marked_closed,
         report.unknown_duplicates_scanned, report.unknown_duplicates_closed,
+        report.phantom_live_scanned, report.phantom_live_closed,
         report.dry_run,
     )
     return 0

--- a/trading_bot/tests/test_repair_orphans.py
+++ b/trading_bot/tests/test_repair_orphans.py
@@ -1,14 +1,22 @@
 """Tests for the orphan-position repair script.
 
-Covers the two repair classes:
-  - ``ENTRY_FAILED`` rows whose Alpaca order actually filled.
+Three repair classes:
+  - ``ENTRY_FAILED`` rows whose Alpaca order actually filled AND ticker
+    is currently held → flip to live.
+  - ``ENTRY_FAILED`` rows whose order filled but ticker is NOT held →
+    mark CLOSED (round-tripped before repair). Catches the bug from
+    the original repair script that flipped these to POSITION_OPEN as
+    ghost rows.
   - ``strategy_id='unknown'`` POSITION_OPEN rows that duplicate a real
     strategy entry on the same ticker.
+  - Phantom live rows: any non-terminal row whose ticker isn't held at
+    Alpaca, or older duplicates of a held ticker.
 """
 
 from __future__ import annotations
 
 import sqlite3
+from typing import Iterable
 from unittest.mock import MagicMock
 
 import pytest
@@ -39,10 +47,38 @@ def _alpaca_open_stop(*, order_id: str = "stop-1", symbol: str = "SPY",
     return o
 
 
+def _alpaca_position(*, symbol: str, qty: float = 1.0):
+    p = MagicMock()
+    p.symbol = symbol
+    p.qty = qty
+    return p
+
+
+def _make_client(
+    *,
+    get_order_by_id_return=None,
+    get_orders_return: list | None = None,
+    held_tickers: Iterable[str] = (),
+):
+    """Build a MagicMock Alpaca client with the three methods the repair
+    script uses pre-wired. ``held_tickers`` controls
+    ``get_all_positions`` so tests can assert the
+    filled-but-not-held branch."""
+    client = MagicMock()
+    if get_order_by_id_return is not None:
+        client.get_order_by_id = MagicMock(return_value=get_order_by_id_return)
+    client.get_orders = MagicMock(return_value=get_orders_return or [])
+    client.get_all_positions = MagicMock(
+        return_value=[_alpaca_position(symbol=t) for t in held_tickers]
+    )
+    return client
+
+
 def _seed_position(
     db_path: str, *, ticker: str, status: str, strategy_id: str,
     alpaca_order_id: str | None = None, qty: float = 1.0,
     entry_price: float = 100.0,
+    entry_time: str = "2026-05-05T15:45:00",
 ) -> int:
     conn = sqlite3.connect(db_path)
     try:
@@ -50,9 +86,10 @@ def _seed_position(
             "INSERT INTO positions (ticker, exchange, currency, "
             "quantity, entry_price, entry_time, status, hold_type, "
             "phase, strategy_id, alpaca_order_id) VALUES "
-            "(?, 'US', 'USD', ?, ?, '2026-05-05T15:45:00', ?, "
+            "(?, 'US', 'USD', ?, ?, ?, ?, "
             "'overnight', 1, ?, ?)",
-            (ticker, qty, entry_price, status, strategy_id, alpaca_order_id),
+            (ticker, qty, entry_price, entry_time, status,
+             strategy_id, alpaca_order_id),
         )
         conn.commit()
         return int(cur.lastrowid)
@@ -60,26 +97,28 @@ def _seed_position(
         conn.close()
 
 
+# ---------------------------------------------------------------------------
+# Step 1: ENTRY_FAILED rows
+# ---------------------------------------------------------------------------
+
+
 @pytest.mark.asyncio
-async def test_repair_flips_entry_failed_to_active_when_order_filled_with_stop(
-    tmp_db_path: str,
-):
+async def test_flips_to_active_when_filled_and_held_with_stop(tmp_db_path: str):
     pos_id = _seed_position(
         tmp_db_path, ticker="SPY",
         status=PositionStatus.ENTRY_FAILED.value,
         strategy_id="overnight_drift",
-        alpaca_order_id="entry-1",
-        qty=0.204, entry_price=720.0,  # mid-submit price; will be overwritten
+        alpaca_order_id="entry-1", qty=0.204, entry_price=720.0,
     )
-    client = MagicMock()
-    client.get_order_by_id = MagicMock(
-        return_value=_alpaca_order(
+    client = _make_client(
+        get_order_by_id_return=_alpaca_order(
             status="filled", filled_qty=0.204, filled_avg_price=724.72,
-        )
-    )
-    client.get_orders = MagicMock(
-        return_value=[_alpaca_open_stop(order_id="stop-recovered",
-                                       symbol="SPY", qty=0.204)]
+        ),
+        get_orders_return=[
+            _alpaca_open_stop(order_id="stop-recovered",
+                             symbol="SPY", qty=0.204),
+        ],
+        held_tickers=["SPY"],
     )
 
     conn = sqlite3.connect(tmp_db_path)
@@ -90,69 +129,108 @@ async def test_repair_flips_entry_failed_to_active_when_order_filled_with_stop(
 
     assert report.entry_failed_scanned == 1
     assert report.entry_failed_repaired == 1
+    assert report.entry_failed_marked_closed == 0
 
     conn = sqlite3.connect(tmp_db_path)
-    try:
-        row = conn.execute(
-            "SELECT status, entry_price, quantity, alpaca_stop_order_id "
-            "FROM positions WHERE id = ?", (pos_id,),
-        ).fetchone()
-    finally:
-        conn.close()
+    row = conn.execute(
+        "SELECT status, entry_price, alpaca_stop_order_id "
+        "FROM positions WHERE id = ?", (pos_id,),
+    ).fetchone()
+    conn.close()
     assert row[0] == PositionStatus.STOP_AND_TARGET_ACTIVE.value
-    # entry_price overwritten with the actual broker fill avg
     assert abs(row[1] - 724.72) < 1e-6
-    assert abs(row[2] - 0.204) < 1e-6
-    assert row[3] == "stop-recovered"
+    assert row[2] == "stop-recovered"
 
 
 @pytest.mark.asyncio
-async def test_repair_flips_to_position_open_when_no_matching_stop_exists(
-    tmp_db_path: str,
-):
-    """Entry filled but no stop on broker — flip to POSITION_OPEN so the
-    next reconciler tick attaches an emergency stop. STOP_AND_TARGET_ACTIVE
-    would lie about state."""
+async def test_flips_to_position_open_when_held_but_no_stop(tmp_db_path: str):
     pos_id = _seed_position(
         tmp_db_path, ticker="QQQ",
         status=PositionStatus.ENTRY_FAILED.value,
         strategy_id="overnight_drift",
         alpaca_order_id="entry-2", qty=0.1482, entry_price=680.0,
     )
-    client = MagicMock()
-    client.get_order_by_id = MagicMock(
-        return_value=_alpaca_order(
+    client = _make_client(
+        get_order_by_id_return=_alpaca_order(
             status="filled", filled_qty=0.1482, filled_avg_price=682.07,
-        )
+        ),
+        get_orders_return=[],
+        held_tickers=["QQQ"],
     )
-    client.get_orders = MagicMock(return_value=[])
 
     conn = sqlite3.connect(tmp_db_path)
     try:
         await repair(conn, client, dry_run=False)
-        row = conn.execute(
-            "SELECT status, alpaca_stop_order_id "
-            "FROM positions WHERE id = ?", (pos_id,),
-        ).fetchone()
     finally:
         conn.close()
+
+    conn = sqlite3.connect(tmp_db_path)
+    row = conn.execute(
+        "SELECT status, alpaca_stop_order_id FROM positions WHERE id = ?",
+        (pos_id,),
+    ).fetchone()
+    conn.close()
     assert row[0] == PositionStatus.POSITION_OPEN.value
     assert row[1] is None or row[1] == ""
 
 
 @pytest.mark.asyncio
-async def test_repair_leaves_genuine_failures_alone(tmp_db_path: str):
-    """ENTRY_FAILED with order status canceled/expired is a real failure;
-    the row must stay ENTRY_FAILED."""
+async def test_marks_closed_when_filled_but_not_held(tmp_db_path: str):
+    """Live bug from 2026-05-06: positions 70/71/74/75 had entry orders
+    that filled on 5/4 but were also exited the same day. The previous
+    repair flipped them to POSITION_OPEN as ghost rows. The fix:
+    when filled but not currently held, mark CLOSED with a note —
+    never create a ghost."""
+    pos_id = _seed_position(
+        tmp_db_path, ticker="XLY",
+        status=PositionStatus.ENTRY_FAILED.value,
+        strategy_id="mean_reversion",
+        alpaca_order_id="entry-roundtripped",
+        qty=4.2067, entry_price=117.5,
+    )
+    client = _make_client(
+        get_order_by_id_return=_alpaca_order(
+            status="filled", filled_qty=4.2067, filled_avg_price=117.67,
+        ),
+        # XLY filled but not currently held — round-tripped before repair
+        held_tickers=["SPY", "QQQ"],
+    )
+
+    conn = sqlite3.connect(tmp_db_path)
+    try:
+        report = await repair(conn, client, dry_run=False)
+    finally:
+        conn.close()
+
+    assert report.entry_failed_scanned == 1
+    assert report.entry_failed_repaired == 0, (
+        "must NOT flip to live — that's the bug we're fixing"
+    )
+    assert report.entry_failed_marked_closed == 1
+
+    conn = sqlite3.connect(tmp_db_path)
+    row = conn.execute(
+        "SELECT status, entry_price FROM positions WHERE id = ?",
+        (pos_id,),
+    ).fetchone()
+    conn.close()
+    assert row[0] == PositionStatus.CLOSED.value
+    # entry_price still gets backfilled from the actual broker fill so
+    # daily-review can match this position to its exit in the trades
+    # table later.
+    assert abs(row[1] - 117.67) < 1e-6
+
+
+@pytest.mark.asyncio
+async def test_leaves_genuine_failures_alone(tmp_db_path: str):
     pos_id = _seed_position(
         tmp_db_path, ticker="XLP",
         status=PositionStatus.ENTRY_FAILED.value,
         strategy_id="mean_reversion",
         alpaca_order_id="entry-canceled",
     )
-    client = MagicMock()
-    client.get_order_by_id = MagicMock(
-        return_value=_alpaca_order(status="canceled")
+    client = _make_client(
+        get_order_by_id_return=_alpaca_order(status="canceled"),
     )
 
     conn = sqlite3.connect(tmp_db_path)
@@ -164,15 +242,18 @@ async def test_repair_leaves_genuine_failures_alone(tmp_db_path: str):
     finally:
         conn.close()
 
-    assert report.entry_failed_repaired == 0, (
-        "A genuinely-canceled order must not be flipped — that would "
-        "create a phantom POSITION_OPEN with no broker counterpart."
-    )
+    assert report.entry_failed_repaired == 0
+    assert report.entry_failed_marked_closed == 0
     assert row[0] == PositionStatus.ENTRY_FAILED.value
 
 
+# ---------------------------------------------------------------------------
+# Step 2: unknown-strategy duplicates
+# ---------------------------------------------------------------------------
+
+
 @pytest.mark.asyncio
-async def test_repair_closes_unknown_duplicate_when_real_sibling_exists(
+async def test_closes_unknown_duplicate_when_real_sibling_exists(
     tmp_db_path: str,
 ):
     real_id = _seed_position(
@@ -185,8 +266,10 @@ async def test_repair_closes_unknown_duplicate_when_real_sibling_exists(
         tmp_db_path, ticker="SPY",
         status=PositionStatus.POSITION_OPEN.value,
         strategy_id="unknown",
+        entry_time="2026-05-05T15:50:00",  # later than real_id
     )
-    client = MagicMock()
+    # SPY is held — phantom step won't touch the live real_id.
+    client = _make_client(held_tickers=["SPY"])
 
     conn = sqlite3.connect(tmp_db_path)
     try:
@@ -201,24 +284,21 @@ async def test_repair_closes_unknown_duplicate_when_real_sibling_exists(
     assert report.unknown_duplicates_closed == 1
     rows_by_id = {r[0]: r for r in rows}
     assert rows_by_id[real_id][1] == PositionStatus.STOP_AND_TARGET_ACTIVE.value
-    assert rows_by_id[unk_id][1] == "CLOSED", (
-        "the duplicate must be closed once a real-strategy sibling exists, "
-        "otherwise the strategy guard sees neither (its query filters by "
-        "strategy_id) and tomorrow's entry double-submits."
-    )
+    assert rows_by_id[unk_id][1] == "CLOSED"
 
 
 @pytest.mark.asyncio
-async def test_repair_leaves_unknown_alone_when_no_real_sibling(tmp_db_path: str):
-    """An unknown-strategy POSITION_OPEN with no sibling represents a
-    broker-side-only position the bot didn't open. Don't close it
-    blindly — that would lose audit information about the orphan."""
+async def test_leaves_unknown_alone_when_no_real_sibling(tmp_db_path: str):
+    """An unknown-strategy POSITION_OPEN with no sibling AND ticker is
+    held at Alpaca: don't close — could be a genuine broker-side-only
+    position the bot didn't open. The phantom step should also leave it
+    alone because the ticker is held."""
     unk_id = _seed_position(
         tmp_db_path, ticker="MSFT",
         status=PositionStatus.POSITION_OPEN.value,
         strategy_id="unknown",
     )
-    client = MagicMock()
+    client = _make_client(held_tickers=["MSFT"])
 
     conn = sqlite3.connect(tmp_db_path)
     try:
@@ -233,21 +313,129 @@ async def test_repair_leaves_unknown_alone_when_no_real_sibling(tmp_db_path: str
     assert row[0] == PositionStatus.POSITION_OPEN.value
 
 
+# ---------------------------------------------------------------------------
+# Step 3: phantom live rows
+# ---------------------------------------------------------------------------
+
+
 @pytest.mark.asyncio
-async def test_repair_dry_run_makes_no_writes(tmp_db_path: str):
+async def test_phantom_step_closes_ghost_rows_for_unheld_tickers(
+    tmp_db_path: str,
+):
+    """Live bug: a previous repair pass flipped position 70 (XLY) from
+    ENTRY_FAILED to POSITION_OPEN even though Alpaca no longer held
+    XLY. The ghost row sits in the DB as a phantom. The phantom step
+    must close it."""
+    ghost_id = _seed_position(
+        tmp_db_path, ticker="XLY",
+        status=PositionStatus.POSITION_OPEN.value,
+        strategy_id="mean_reversion",
+        alpaca_order_id="entry-1",
+    )
+    client = _make_client(held_tickers=[])  # XLY not held
+
+    conn = sqlite3.connect(tmp_db_path)
+    try:
+        report = await repair(conn, client, dry_run=False)
+        row = conn.execute(
+            "SELECT status FROM positions WHERE id = ?",
+            (ghost_id,),
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert report.phantom_live_closed == 1
+    assert row[0] == PositionStatus.CLOSED.value
+
+
+@pytest.mark.asyncio
+async def test_phantom_step_closes_older_duplicate_keeps_latest(
+    tmp_db_path: str,
+):
+    """Live bug: positions 74 (SPY 5/4) and 80 (SPY 5/5) both
+    POSITION_OPEN/STOP_AND_TARGET_ACTIVE for the same held ticker.
+    The reconciler's db_by_ticker dict overwrites duplicates and
+    silently drops one — so the older row never gets closed.
+
+    The phantom step must close the OLDER row and keep the latest
+    one matching the actual held position.
+    """
+    older_id = _seed_position(
+        tmp_db_path, ticker="SPY",
+        status=PositionStatus.POSITION_OPEN.value,
+        strategy_id="overnight_drift",
+        entry_time="2026-05-04T15:45:00",  # older
+    )
+    newer_id = _seed_position(
+        tmp_db_path, ticker="SPY",
+        status=PositionStatus.STOP_AND_TARGET_ACTIVE.value,
+        strategy_id="overnight_drift",
+        entry_time="2026-05-05T15:45:00",  # newer
+    )
+    client = _make_client(held_tickers=["SPY"])
+
+    conn = sqlite3.connect(tmp_db_path)
+    try:
+        await repair(conn, client, dry_run=False)
+        rows = conn.execute(
+            "SELECT id, status FROM positions WHERE ticker='SPY' ORDER BY id"
+        ).fetchall()
+    finally:
+        conn.close()
+
+    by_id = {r[0]: r[1] for r in rows}
+    assert by_id[older_id] == PositionStatus.CLOSED.value, (
+        "older duplicate must be closed — it can't all map to the one "
+        "broker-side position"
+    )
+    assert by_id[newer_id] == PositionStatus.STOP_AND_TARGET_ACTIVE.value, (
+        "newer row must be preserved — it matches the broker"
+    )
+
+
+@pytest.mark.asyncio
+async def test_phantom_step_leaves_single_held_row_alone(tmp_db_path: str):
+    """The most common case: one DB row per held ticker. Phantom step
+    must not touch it."""
+    pos_id = _seed_position(
+        tmp_db_path, ticker="SPY",
+        status=PositionStatus.STOP_AND_TARGET_ACTIVE.value,
+        strategy_id="overnight_drift",
+    )
+    client = _make_client(held_tickers=["SPY"])
+
+    conn = sqlite3.connect(tmp_db_path)
+    try:
+        report = await repair(conn, client, dry_run=False)
+        row = conn.execute(
+            "SELECT status FROM positions WHERE id = ?", (pos_id,),
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert report.phantom_live_closed == 0
+    assert row[0] == PositionStatus.STOP_AND_TARGET_ACTIVE.value
+
+
+# ---------------------------------------------------------------------------
+# Cross-cutting
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dry_run_makes_no_writes(tmp_db_path: str):
     pos_id = _seed_position(
         tmp_db_path, ticker="SPY",
         status=PositionStatus.ENTRY_FAILED.value,
         strategy_id="overnight_drift",
         alpaca_order_id="entry-1", qty=0.5, entry_price=700.0,
     )
-    client = MagicMock()
-    client.get_order_by_id = MagicMock(
-        return_value=_alpaca_order(
+    client = _make_client(
+        get_order_by_id_return=_alpaca_order(
             status="filled", filled_qty=0.5, filled_avg_price=720.0,
-        )
+        ),
+        held_tickers=["SPY"],
     )
-    client.get_orders = MagicMock(return_value=[])
 
     conn = sqlite3.connect(tmp_db_path)
     try:
@@ -259,32 +447,25 @@ async def test_repair_dry_run_makes_no_writes(tmp_db_path: str):
     finally:
         conn.close()
 
-    assert report.entry_failed_repaired == 1, (
-        "dry-run still counts what it would change"
-    )
-    assert row[0] == PositionStatus.ENTRY_FAILED.value, (
-        "dry-run must not modify the row"
-    )
-    assert abs(row[1] - 700.0) < 1e-6, "entry_price untouched in dry-run"
+    assert report.entry_failed_repaired == 1
+    assert row[0] == PositionStatus.ENTRY_FAILED.value
+    assert abs(row[1] - 700.0) < 1e-6
 
 
 @pytest.mark.asyncio
-async def test_repair_is_idempotent(tmp_db_path: str):
-    """Running on a clean DB finds nothing to do; running twice in a row
-    on a fixable DB makes the same DB writes only once."""
+async def test_idempotent(tmp_db_path: str):
     _seed_position(
         tmp_db_path, ticker="SPY",
         status=PositionStatus.ENTRY_FAILED.value,
         strategy_id="overnight_drift",
         alpaca_order_id="entry-1", qty=0.2, entry_price=700.0,
     )
-    client = MagicMock()
-    client.get_order_by_id = MagicMock(
-        return_value=_alpaca_order(
+    client = _make_client(
+        get_order_by_id_return=_alpaca_order(
             status="filled", filled_qty=0.2, filled_avg_price=720.0,
-        )
+        ),
+        held_tickers=["SPY"],
     )
-    client.get_orders = MagicMock(return_value=[])
 
     conn = sqlite3.connect(tmp_db_path)
     try:
@@ -294,7 +475,74 @@ async def test_repair_is_idempotent(tmp_db_path: str):
         conn.close()
 
     assert first.entry_failed_repaired == 1
-    assert second.entry_failed_repaired == 0, (
-        "after first repair the row is no longer ENTRY_FAILED, so the "
-        "second pass must find no work to do."
+    assert second.entry_failed_repaired == 0
+    assert second.phantom_live_closed == 0
+
+
+@pytest.mark.asyncio
+async def test_full_scenario_2026_05_06_repair_state(tmp_db_path: str):
+    """End-to-end: seed the actual 2026-05-06 mid-repair state and
+    confirm the new logic cleans it up correctly in a single pass.
+
+    Live held: SPY, QQQ, XLC, XLK (4 positions kept their stop adoption).
+    Ghost rows: XLY/XLB (filled then exited 5/4) and older SPY/QQQ
+    duplicates from 5/4 sitting alongside the held 5/5 entries.
+    """
+    # Already-flipped ghosts from the bad first repair pass.
+    xly_id = _seed_position(
+        tmp_db_path, ticker="XLY",
+        status=PositionStatus.POSITION_OPEN.value,
+        strategy_id="mean_reversion",
+        entry_time="2026-05-04T12:20:31",
     )
+    xlb_id = _seed_position(
+        tmp_db_path, ticker="XLB",
+        status=PositionStatus.POSITION_OPEN.value,
+        strategy_id="mean_reversion",
+        entry_time="2026-05-04T12:20:32",
+    )
+    spy_old_id = _seed_position(
+        tmp_db_path, ticker="SPY",
+        status=PositionStatus.POSITION_OPEN.value,
+        strategy_id="overnight_drift",
+        entry_time="2026-05-04T15:45:37",
+    )
+    qqq_old_id = _seed_position(
+        tmp_db_path, ticker="QQQ",
+        status=PositionStatus.POSITION_OPEN.value,
+        strategy_id="overnight_drift",
+        entry_time="2026-05-04T15:45:38",
+    )
+    # Real held positions from 5/5.
+    spy_real_id = _seed_position(
+        tmp_db_path, ticker="SPY",
+        status=PositionStatus.STOP_AND_TARGET_ACTIVE.value,
+        strategy_id="overnight_drift",
+        entry_time="2026-05-05T15:45:36",
+    )
+    qqq_real_id = _seed_position(
+        tmp_db_path, ticker="QQQ",
+        status=PositionStatus.STOP_AND_TARGET_ACTIVE.value,
+        strategy_id="overnight_drift",
+        entry_time="2026-05-05T15:45:36",
+    )
+
+    client = _make_client(held_tickers=["SPY", "QQQ", "XLC", "XLK"])
+
+    conn = sqlite3.connect(tmp_db_path)
+    try:
+        report = await repair(conn, client, dry_run=False)
+        rows = conn.execute(
+            "SELECT id, ticker, status FROM positions ORDER BY id"
+        ).fetchall()
+    finally:
+        conn.close()
+
+    by_id = {r[0]: (r[1], r[2]) for r in rows}
+    assert by_id[xly_id][1] == PositionStatus.CLOSED.value
+    assert by_id[xlb_id][1] == PositionStatus.CLOSED.value
+    assert by_id[spy_old_id][1] == PositionStatus.CLOSED.value
+    assert by_id[qqq_old_id][1] == PositionStatus.CLOSED.value
+    assert by_id[spy_real_id][1] == PositionStatus.STOP_AND_TARGET_ACTIVE.value
+    assert by_id[qqq_real_id][1] == PositionStatus.STOP_AND_TARGET_ACTIVE.value
+    assert report.phantom_live_closed == 4


### PR DESCRIPTION
## Summary

Two coupled fixes after observing today's repair pass left 4 ghost rows in the DB.

### Fix 1 — \`repair_orphans\` checks current Alpaca positions before flipping

Before: only checked \"did the entry order fill?\". Positions 70/71/74/75 (XLY/XLB/SPY-old/QQQ-old) had filled entry orders from 5/4 but were exited the same day — Alpaca no longer holds them. The repair wrongly flipped them to POSITION_OPEN, creating 4 ghost rows.

Now: fetch live tickers once at the top of repair, thread through the EF loop. Three outcomes:
- Filled **and** held → flip to STOP_AND_TARGET_ACTIVE / POSITION_OPEN (existing path)
- Filled **but not held** → mark CLOSED with backfilled fill price/qty (NEW; was the bug)
- Not filled → leave ENTRY_FAILED (existing path)

Also adds a third repair step \`_close_phantom_live_rows\` that sweeps:
- Any remaining non-terminal row whose ticker isn't held at Alpaca (catches ghost rows from a prior bad repair pass)
- Older duplicates when multiple non-terminal rows share a held ticker (covers a separate \`StateRecovery._reconcile\` silent-drop bug where \`db_by_ticker[ticker] = row\` overwrites the older entry)

End-to-end test seeds the exact 2026-05-06 mid-repair state and asserts a single repair pass cleans it up correctly.

### Fix 2 — \`repair-orphans.yml\` gets its own concurrency group

Today's repair completed every step but ended with \`conclusion=cancelled\` because a scheduled \`bot.yml\` tick joined the \`bot-run\` group (which has \`cancel-in-progress: true\`) and propagated the cancel signal to our run. With \`group: repair-run\` instead, the cancel can't reach us. The \`bot-db-*\` cache restore-keys fallback is unchanged, so the next bot tick still picks up our changes.

## Test plan

- [x] 12 unit tests passing (3 new for filled-not-held, 3 new for phantom sweep, 1 end-to-end scenario)
- [x] Full suite: 749 passing
- [ ] After merge, run \`gh workflow run repair-orphans.yml -f dry_run=true\` against current cached DB. Expected dry-run output: \`phantom_scanned=4 phantom_closed=4\` (the 4 ghost rows from today's bad pass).
- [ ] Run with \`dry_run=false\`. Confirm DB is clean: only the 4 actually-held positions (78/80/81/87) remain non-terminal.
- [ ] Tomorrow 15:45 ET: confirm overnight_drift skips re-entry on SPY/QQQ/XLC/XLK (the wash-trade rejection that motivated all this).