### PR TITLE
fix(strategy_manager): bound drain SELL by Alpaca qty, not DB qty

### DIFF
--- a/trading_bot/strategy/strategy_manager.py
+++ b/trading_bot/strategy/strategy_manager.py
@@ -7,7 +7,7 @@ import logging
 import sqlite3
 from dataclasses import replace
 from datetime import datetime
-from typing import Any, NamedTuple
+from typing import Any, Literal, NamedTuple
 from zoneinfo import ZoneInfo
 
 import pandas as pd
@@ -65,6 +65,9 @@ def _is_alpaca_position_not_found(exc: Any) -> bool:
     return False
 
 
+VerdictType = Literal["OK", "NOT_HELD", "OPPOSITE_SIDE", "UNKNOWN"]
+
+
 class AlpacaPositionCheck(NamedTuple):
     """Outcome of probing Alpaca for a position before a drain SELL.
 
@@ -85,7 +88,7 @@ class AlpacaPositionCheck(NamedTuple):
     default and the caller doesn't read it.
     """
 
-    verdict: str
+    verdict: VerdictType
     alpaca_qty: float
 
 
@@ -466,14 +469,12 @@ class StrategyManager:
             if qty <= 0:
                 continue
 
-            # INVARIANT: re-fetch Alpaca qty before EACH SELL. The DB
-            # is the bot's intent; the broker is truth. DB qty drifts
-            # via manual flatten, broker-side stop fills not yet
-            # written back, state-recovery races, and partial fills
-            # mid-tick. Submitting a SELL for the DB qty when Alpaca
-            # holds less closes the long *and* opens a short for the
-            # difference — the 2026-04-30 incident class. Drain SELL
-            # qty must be bounded by Alpaca's position size.
+            # Re-fetch Alpaca qty before each SELL — see the
+            # AlpacaPositionCheck docstring for the full invariant.
+            # The DB is the bot's intent; the broker is truth.
+            # Submitting a SELL for the DB qty when Alpaca holds less
+            # closes the long *and* opens a short for the difference
+            # — the 2026-04-30 incident class.
             position_id: int | None = pos.get("id")
             check = self._check_alpaca_position(ticker, db_qty=qty)
             if check.verdict == "NOT_HELD":
@@ -516,10 +517,14 @@ class StrategyManager:
             # someone else's position to handle.
             qty_to_sell: float = min(qty, abs(check.alpaca_qty))
             if qty_to_sell <= 0:
-                # Defensive: NOT_HELD already covers alpaca_qty=0; this
-                # only fires if check.alpaca_qty came back as something
-                # exotic (NaN-ish, negative same-sign rounding). Log
-                # and skip rather than submit a zero-qty order.
+                # Structural guard: given verdict=="OK", alpaca_qty is
+                # nonzero and same-sign as db_qty (db_qty>0 enforced
+                # above), so abs(alpaca_qty) > 0 and this branch is
+                # unreachable today. NaN propagates through min() but
+                # is filtered upstream as OPPOSITE_SIDE since
+                # ``NaN > 0`` is False. Kept as a final safety net
+                # against future logic changes — never submit a
+                # zero-qty order.
                 logger.warning(
                     "Drain skip: %s strategy=%s — computed qty_to_sell=%.4f "
                     "(db=%+.4f, alpaca=%+.4f); refusing to submit",

--- a/trading_bot/strategy/strategy_manager.py
+++ b/trading_bot/strategy/strategy_manager.py
@@ -7,7 +7,7 @@ import logging
 import sqlite3
 from dataclasses import replace
 from datetime import datetime
-from typing import Any
+from typing import Any, NamedTuple
 from zoneinfo import ZoneInfo
 
 import pandas as pd
@@ -63,6 +63,30 @@ def _is_alpaca_position_not_found(exc: Any) -> bool:
     if str(_ALPACA_POSITION_NOT_FOUND_CODE) in text:
         return True
     return False
+
+
+class AlpacaPositionCheck(NamedTuple):
+    """Outcome of probing Alpaca for a position before a drain SELL.
+
+    The drain loop must verify Alpaca state before submitting any
+    exit — DB qty can drift from broker truth (manual flatten,
+    broker-side stop fill not yet recorded, state-recovery race,
+    partial fills mid-tick). Submitting a SELL for the DB qty when
+    Alpaca holds less opens a short for the difference.
+
+    INVARIANT: drain SELL qty MUST be ``min(db_qty, abs(alpaca_qty))``
+    when ``verdict == "OK"``. Re-fetch Alpaca on every iteration of
+    the drain loop — the DB is the bot's intent, not the broker's
+    truth.
+
+    ``alpaca_qty`` is signed (positive = long, negative = short, 0 =
+    not held). Only meaningful when ``verdict == "OK"`` — for
+    NOT_HELD / OPPOSITE_SIDE / UNKNOWN it's set to 0.0 as a safe
+    default and the caller doesn't read it.
+    """
+
+    verdict: str
+    alpaca_qty: float
 
 
 class StrategyManager:
@@ -442,16 +466,17 @@ class StrategyManager:
             if qty <= 0:
                 continue
 
-            # Verify the position is actually held on Alpaca before
-            # submitting a SELL. The DB qty can drift from broker truth
-            # (manual flatten, broker-side stop fill not yet recorded,
-            # state-recovery race). Submitting blind opens a NEW position
-            # in the OPPOSITE direction — exactly the
-            # 2026-04-30 incident where a SELL drained against an
-            # already-flat sleeve and built an unbounded short.
+            # INVARIANT: re-fetch Alpaca qty before EACH SELL. The DB
+            # is the bot's intent; the broker is truth. DB qty drifts
+            # via manual flatten, broker-side stop fills not yet
+            # written back, state-recovery races, and partial fills
+            # mid-tick. Submitting a SELL for the DB qty when Alpaca
+            # holds less closes the long *and* opens a short for the
+            # difference — the 2026-04-30 incident class. Drain SELL
+            # qty must be bounded by Alpaca's position size.
             position_id: int | None = pos.get("id")
             check = self._check_alpaca_position(ticker, db_qty=qty)
-            if check == "NOT_HELD":
+            if check.verdict == "NOT_HELD":
                 logger.warning(
                     "Drain skip: %s strategy=%s DB qty=%+.4f but Alpaca "
                     "holds 0 — DB drift; marking position CLOSED instead "
@@ -461,15 +486,16 @@ class StrategyManager:
                 if position_id is not None:
                     self._mark_position_closed(position_id)
                 continue
-            if check == "OPPOSITE_SIDE":
+            if check.verdict == "OPPOSITE_SIDE":
                 logger.critical(
                     "Drain REFUSING %s strategy=%s: DB qty=%+.4f but Alpaca "
-                    "holds the opposite side. Will not submit a drain order "
-                    "that would deepen the position. Manual reconcile needed.",
-                    ticker, sid or "<none>", qty,
+                    "holds %+.4f (opposite side). Will not submit a drain "
+                    "order that would deepen the position. Manual reconcile "
+                    "needed.",
+                    ticker, sid or "<none>", qty, check.alpaca_qty,
                 )
                 continue
-            if check == "UNKNOWN":
+            if check.verdict == "UNKNOWN":
                 # Transient Alpaca lookup failure (5xx, network, rate
                 # limit, malformed response). Do NOT mark the DB row
                 # CLOSED — that permanently drops a possibly-real
@@ -481,11 +507,37 @@ class StrategyManager:
                     ticker, sid or "<none>",
                 )
                 continue
-            # check == "OK" — Alpaca confirms a same-side position.
+            # check.verdict == "OK" — Alpaca confirms a same-side position.
+            # Bound the SELL by what Alpaca actually holds. If DB says
+            # +10 and Alpaca holds +5 (e.g. external partial flatten),
+            # SELL 5 — never overshoot into a short. We never SELL
+            # *more* than the DB recorded either, because the DB is
+            # what the bot considers "ours to drain"; the rest is
+            # someone else's position to handle.
+            qty_to_sell: float = min(qty, abs(check.alpaca_qty))
+            if qty_to_sell <= 0:
+                # Defensive: NOT_HELD already covers alpaca_qty=0; this
+                # only fires if check.alpaca_qty came back as something
+                # exotic (NaN-ish, negative same-sign rounding). Log
+                # and skip rather than submit a zero-qty order.
+                logger.warning(
+                    "Drain skip: %s strategy=%s — computed qty_to_sell=%.4f "
+                    "(db=%+.4f, alpaca=%+.4f); refusing to submit",
+                    ticker, sid or "<none>",
+                    qty_to_sell, qty, check.alpaca_qty,
+                )
+                continue
+
+            if qty_to_sell < qty:
+                logger.warning(
+                    "Drain partial: %s strategy=%s DB qty=%+.4f but Alpaca "
+                    "holds %+.4f — SELL bounded by broker truth (%.4f)",
+                    ticker, sid or "<none>", qty, check.alpaca_qty, qty_to_sell,
+                )
 
             logger.warning(
                 "Draining orphan position: ticker=%s strategy=%s qty=%.4f",
-                ticker, sid or "<none>", qty,
+                ticker, sid or "<none>", qty_to_sell,
             )
 
             if self._dry_run:
@@ -494,7 +546,7 @@ class StrategyManager:
             try:
                 exit_order_id: str | None = await self._order_manager.place_exit(
                     ticker=ticker,
-                    qty=qty,
+                    qty=qty_to_sell,
                     reason=f"orphan_sleeve_drain:{sid or 'unknown'}",
                     is_emergency=False,
                 )
@@ -511,20 +563,18 @@ class StrategyManager:
 
         return closed
 
-    def _check_alpaca_position(self, ticker: str, *, db_qty: float) -> str:
+    def _check_alpaca_position(
+        self, ticker: str, *, db_qty: float,
+    ) -> AlpacaPositionCheck:
         """Probe Alpaca for the current position on ``ticker``.
 
-        Returns one of:
-          - ``"NOT_HELD"`` — Alpaca confirmed no position (HTTP 404 or
-            Alpaca error code 40410000). Caller should mark DB CLOSED.
-          - ``"OPPOSITE_SIDE"`` — Alpaca holds a position on the opposite
-            sign of ``db_qty``. A drain SELL on an already-short position
-            would deepen the short. Caller should REFUSE.
-          - ``"OK"`` — Alpaca holds a same-sign position. Drain may proceed.
-          - ``"UNKNOWN"`` — Lookup failed for a non-deterministic reason
-            (5xx, network, rate-limit, parse failure). Caller MUST NOT
-            mark CLOSED — a transient broker outage would silently drop
-            real positions out of the monitoring loop.
+        Returns an :class:`AlpacaPositionCheck` — see its docstring for
+        the per-verdict invariants. ``alpaca_qty`` is meaningful only
+        when ``verdict == "OK"`` and lets the caller bound the drain
+        SELL by what the broker actually holds (the partial-drain case
+        — DB says +10, Alpaca holds +5 — was the latent half of the
+        2026-04-30 incident; without the cap, a SELL 10 would close
+        the long *and* open a short for the missing 5).
         """
         from alpaca.common.exceptions import APIError
 
@@ -539,7 +589,7 @@ class StrategyManager:
             # mark the DB row CLOSED. Anything else (5xx, 429, schema
             # drift) is transient and should NOT mutate state.
             if _is_alpaca_position_not_found(exc):
-                return "NOT_HELD"
+                return AlpacaPositionCheck("NOT_HELD", 0.0)
             logger.warning(
                 "Alpaca position lookup for %s returned APIError "
                 "(status=%s, code=%s) — treating as UNKNOWN",
@@ -547,19 +597,19 @@ class StrategyManager:
                 getattr(exc, "status_code", None),
                 _safe_apierror_code(exc),
             )
-            return "UNKNOWN"
+            return AlpacaPositionCheck("UNKNOWN", 0.0)
         except Exception:
             logger.warning(
                 "Alpaca position lookup for %s failed unexpectedly — "
                 "treating as UNKNOWN", ticker, exc_info=True,
             )
-            return "UNKNOWN"
+            return AlpacaPositionCheck("UNKNOWN", 0.0)
 
         if alpaca_qty == 0:
-            return "NOT_HELD"
+            return AlpacaPositionCheck("NOT_HELD", 0.0)
         if (db_qty > 0) != (alpaca_qty > 0):
-            return "OPPOSITE_SIDE"
-        return "OK"
+            return AlpacaPositionCheck("OPPOSITE_SIDE", alpaca_qty)
+        return AlpacaPositionCheck("OK", alpaca_qty)
 
     def _mark_position_closed(self, position_id: int) -> None:
         """Update positions.status = 'CLOSED' for a single row."""

--- a/trading_bot/tests/test_strategy_manager.py
+++ b/trading_bot/tests/test_strategy_manager.py
@@ -1261,6 +1261,131 @@ class TestDrainDisabledSleeves:
         assert called_tickers == {"SPY", "XLRE"}
 
     @pytest.mark.asyncio
+    async def test_drain_refuses_on_nan_alpaca_qty(
+        self,
+        base_market_data,
+        base_risk_manager,
+        base_earnings,
+        base_sentiment,
+        base_order_manager,
+        base_portfolio_manager,
+        base_config,
+        tmp_db_path,
+    ):
+        """If Alpaca returns NaN for ``qty`` (schema drift, parser
+        oddity), the drain must refuse to submit any SELL.
+
+        ``NaN > 0`` is False, so the side-mismatch check inside
+        ``_check_alpaca_position`` returns OPPOSITE_SIDE — the drain
+        logs CRITICAL and skips. Pin this behavior so a future loosening
+        of the side-mismatch check can't silently route NaN through
+        ``min(qty, abs(NaN))`` (which is NaN) into ``place_exit``.
+        """
+        import sqlite3
+
+        conn = sqlite3.connect(tmp_db_path)
+        conn.execute(
+            """
+            INSERT INTO positions (
+                ticker, exchange, currency, quantity, entry_price,
+                entry_time, status, hold_type, phase, strategy_id
+            ) VALUES ('SPY', 'US', 'USD', 10.0, 100.0,
+                      '2026-04-27T15:40:00-04:00',
+                      'STOP_AND_TARGET_ACTIVE', 'swing', 1, 'breakout')
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        nan_pos = MagicMock()
+        nan_pos.qty = "nan"
+        base_order_manager._gw.client.get_open_position.return_value = nan_pos
+
+        sm = StrategyManager(
+            strategies=[_StubStrategy(decision=_make_decision())],
+            portfolio_manager=base_portfolio_manager,
+            market_data=base_market_data,
+            order_manager=base_order_manager,
+            risk_manager=base_risk_manager,
+            sentiment=base_sentiment,
+            earnings=base_earnings,
+            config=base_config,
+            db_path=tmp_db_path,
+        )
+
+        n = await sm.drain_disabled_sleeves()
+        assert n == 0
+        base_order_manager.place_exit.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_drain_dry_run_logs_bounded_qty_on_partial(
+        self,
+        base_market_data,
+        base_risk_manager,
+        base_earnings,
+        base_sentiment,
+        base_order_manager,
+        base_portfolio_manager,
+        base_config,
+        tmp_db_path,
+        caplog,
+    ):
+        """Dry-run path must emit the bounded qty in its log line, not
+        the raw DB qty. A regression where the dry-run preview shows
+        ``qty=10`` while the live path SELLs 5 would mask the partial
+        bound during operator review.
+        """
+        import logging
+        import sqlite3
+
+        conn = sqlite3.connect(tmp_db_path)
+        conn.execute(
+            """
+            INSERT INTO positions (
+                ticker, exchange, currency, quantity, entry_price,
+                entry_time, status, hold_type, phase, strategy_id
+            ) VALUES ('SPY', 'US', 'USD', 10.0, 100.0,
+                      '2026-04-27T15:40:00-04:00',
+                      'STOP_AND_TARGET_ACTIVE', 'swing', 1, 'breakout')
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        partial = MagicMock()
+        partial.qty = "5.0"
+        base_order_manager._gw.client.get_open_position.return_value = partial
+
+        sm = StrategyManager(
+            strategies=[_StubStrategy(decision=_make_decision())],
+            portfolio_manager=base_portfolio_manager,
+            market_data=base_market_data,
+            order_manager=base_order_manager,
+            risk_manager=base_risk_manager,
+            sentiment=base_sentiment,
+            earnings=base_earnings,
+            config=base_config,
+            db_path=tmp_db_path,
+            dry_run=True,
+        )
+
+        with caplog.at_level(logging.WARNING, logger="trading_bot.strategy.strategy_manager"):
+            n = await sm.drain_disabled_sleeves()
+
+        # Dry-run skips order submission entirely; no row is closed.
+        assert n == 0
+        base_order_manager.place_exit.assert_not_awaited()
+        # The "Draining orphan position" warning emits the bounded qty.
+        drain_lines = [
+            r.getMessage() for r in caplog.records
+            if "Draining orphan position" in r.getMessage()
+        ]
+        assert drain_lines, "expected a 'Draining orphan position' log line"
+        assert "qty=5.0000" in drain_lines[0], (
+            f"dry-run log must show bounded qty (5), got: {drain_lines[0]}"
+        )
+
+    @pytest.mark.asyncio
     async def test_drain_does_not_close_db_on_transient_alpaca_error(
         self,
         base_market_data,

--- a/trading_bot/tests/test_strategy_manager.py
+++ b/trading_bot/tests/test_strategy_manager.py
@@ -1051,6 +1051,214 @@ class TestDrainDisabledSleeves:
         n = await sm.drain_disabled_sleeves()
         assert n == 1
         base_order_manager.place_exit.assert_awaited_once()
+        # Pin the qty: when DB and Alpaca agree, drain SELLs the full
+        # DB qty. The other tests below pin the partial / overshoot
+        # cases.
+        kwargs = base_order_manager.place_exit.await_args.kwargs
+        assert kwargs["qty"] == pytest.approx(5.0)
+
+    # -----------------------------------------------------------------
+    # Drain SELL qty bounded by Alpaca truth (ai-broker#41)
+    # -----------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_drain_partial_when_alpaca_holds_less_than_db(
+        self,
+        base_market_data,
+        base_risk_manager,
+        base_earnings,
+        base_sentiment,
+        base_order_manager,
+        base_portfolio_manager,
+        base_config,
+        tmp_db_path,
+    ):
+        """DB says +10 SPY, Alpaca holds +5 (e.g. external partial
+        flatten landed between the bot's writes and this tick).
+
+        Submitting SELL 10 here would close the long *and* open a
+        short for the missing 5 — the latent half of the 2026-04-30
+        incident class. The drain SELL must be bounded by Alpaca's
+        actual qty.
+        """
+        import sqlite3
+
+        conn = sqlite3.connect(tmp_db_path)
+        conn.execute(
+            """
+            INSERT INTO positions (
+                ticker, exchange, currency, quantity, entry_price,
+                entry_time, status, hold_type, phase, strategy_id
+            ) VALUES ('SPY', 'US', 'USD', 10.0, 100.0,
+                      '2026-04-27T15:40:00-04:00',
+                      'STOP_AND_TARGET_ACTIVE', 'swing', 1, 'breakout')
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        partial = MagicMock()
+        partial.qty = "5.0"  # Alpaca holds less than DB
+        base_order_manager._gw.client.get_open_position.return_value = partial
+
+        sm = StrategyManager(
+            strategies=[_StubStrategy(decision=_make_decision())],
+            portfolio_manager=base_portfolio_manager,
+            market_data=base_market_data,
+            order_manager=base_order_manager,
+            risk_manager=base_risk_manager,
+            sentiment=base_sentiment,
+            earnings=base_earnings,
+            config=base_config,
+            db_path=tmp_db_path,
+        )
+
+        n = await sm.drain_disabled_sleeves()
+        assert n == 1
+        base_order_manager.place_exit.assert_awaited_once()
+        kwargs = base_order_manager.place_exit.await_args.kwargs
+        assert kwargs["qty"] == pytest.approx(5.0), (
+            "drain SELL must be bounded by Alpaca qty (5), not DB qty (10), "
+            "or it would close +5 and open -5 short"
+        )
+
+    @pytest.mark.asyncio
+    async def test_drain_caps_at_db_qty_when_alpaca_holds_more(
+        self,
+        base_market_data,
+        base_risk_manager,
+        base_earnings,
+        base_sentiment,
+        base_order_manager,
+        base_portfolio_manager,
+        base_config,
+        tmp_db_path,
+    ):
+        """DB says +5 SPY, Alpaca holds +10. The +5 the DB tracks is
+        ours to drain; the additional +5 belongs to some other code
+        path (manual entry, live add-to-position outside the drain
+        loop) and is not the drain's to flatten.
+
+        Submit SELL 5, not 10.
+        """
+        import sqlite3
+
+        conn = sqlite3.connect(tmp_db_path)
+        conn.execute(
+            """
+            INSERT INTO positions (
+                ticker, exchange, currency, quantity, entry_price,
+                entry_time, status, hold_type, phase, strategy_id
+            ) VALUES ('SPY', 'US', 'USD', 5.0, 100.0,
+                      '2026-04-27T15:40:00-04:00',
+                      'STOP_AND_TARGET_ACTIVE', 'swing', 1, 'breakout')
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        bigger = MagicMock()
+        bigger.qty = "10.0"  # Alpaca holds more than DB tracks
+        base_order_manager._gw.client.get_open_position.return_value = bigger
+
+        sm = StrategyManager(
+            strategies=[_StubStrategy(decision=_make_decision())],
+            portfolio_manager=base_portfolio_manager,
+            market_data=base_market_data,
+            order_manager=base_order_manager,
+            risk_manager=base_risk_manager,
+            sentiment=base_sentiment,
+            earnings=base_earnings,
+            config=base_config,
+            db_path=tmp_db_path,
+        )
+
+        n = await sm.drain_disabled_sleeves()
+        assert n == 1
+        base_order_manager.place_exit.assert_awaited_once()
+        kwargs = base_order_manager.place_exit.await_args.kwargs
+        assert kwargs["qty"] == pytest.approx(5.0), (
+            "drain must not overshoot DB-tracked qty even if Alpaca holds "
+            "more — the surplus is not the drain's to flatten"
+        )
+
+    @pytest.mark.asyncio
+    async def test_drain_rechecks_alpaca_per_position(
+        self,
+        base_market_data,
+        base_risk_manager,
+        base_earnings,
+        base_sentiment,
+        base_order_manager,
+        base_portfolio_manager,
+        base_config,
+        tmp_db_path,
+    ):
+        """The Alpaca verification must run before every SELL in the
+        drain loop, not just before the first one. Pre-PR-#20 the
+        drain looped over a stale snapshot and emitted SELLs in
+        pairs ~2 minutes apart — the per-iteration check is what
+        prevents a partial pre-tick drain from wrecking later
+        iterations.
+
+        Seed two orphan positions on different tickers; assert
+        get_open_position is called for each.
+        """
+        import sqlite3
+
+        conn = sqlite3.connect(tmp_db_path)
+        conn.execute(
+            """
+            INSERT INTO positions (
+                ticker, exchange, currency, quantity, entry_price,
+                entry_time, status, hold_type, phase, strategy_id
+            ) VALUES
+              ('SPY',  'US', 'USD', 5.0, 100.0,
+               '2026-04-27T15:40:00-04:00',
+               'STOP_AND_TARGET_ACTIVE', 'swing', 1, 'breakout'),
+              ('XLRE', 'US', 'USD', 20.0, 50.0,
+               '2026-04-28T09:40:00-04:00',
+               'STOP_AND_TARGET_ACTIVE', 'swing', 1, 'trend_following')
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        # Both Alpaca-side positions match DB: SELL fires for each.
+        def _get_open_position(ticker: str):
+            pos = MagicMock()
+            pos.qty = "5.0" if ticker == "SPY" else "20.0"
+            return pos
+
+        base_order_manager._gw.client.get_open_position.side_effect = (
+            _get_open_position
+        )
+
+        sm = StrategyManager(
+            strategies=[_StubStrategy(decision=_make_decision())],
+            portfolio_manager=base_portfolio_manager,
+            market_data=base_market_data,
+            order_manager=base_order_manager,
+            risk_manager=base_risk_manager,
+            sentiment=base_sentiment,
+            earnings=base_earnings,
+            config=base_config,
+            db_path=tmp_db_path,
+        )
+
+        n = await sm.drain_disabled_sleeves()
+        assert n == 2
+        # Per-iteration check ran for each of the two orphan tickers.
+        assert (
+            base_order_manager._gw.client.get_open_position.call_count == 2
+        ), "Alpaca position lookup must run once per orphan position"
+        # Two SELLs submitted, one per ticker.
+        assert base_order_manager.place_exit.await_count == 2
+        called_tickers = {
+            call.kwargs["ticker"]
+            for call in base_order_manager.place_exit.await_args_list
+        }
+        assert called_tickers == {"SPY", "XLRE"}
 
     @pytest.mark.asyncio
     async def test_drain_does_not_close_db_on_transient_alpaca_error(


### PR DESCRIPTION
Closes #41.

## Summary

PR #20 (verify-before-SELL guard) catches the original 2026-04-30 incident — Alpaca holds 0, don't open a fresh short. But it returned a verdict-only string and didn't expose Alpaca's qty to the caller, so when DB said `+10` and Alpaca held `+5` (partial flatten elsewhere, broker stop fill not yet recorded, partial fill mid-tick), the drain still submitted `SELL 10` → first 5 close the long, last 5 open a fresh `-5` short. Same incident class, one degree finer.

## Why now

Issue #41's acceptance criteria explicitly listed this gap:

> "stub Alpaca returning current qty < db_qty (partial drain) → SELL is for the *Alpaca* qty, not the DB qty"

The bot has been paper-only since the original incident and no sleeve has been disabled since 2026-04-29 — so the latent partial-drain path hasn't fired in production. But the next regime rebalance that disables a sleeve with active positions could trip it. Tightening this before any real sleeve-disable event is the cheap window.

## Changes

- `_check_alpaca_position` returns an `AlpacaPositionCheck` NamedTuple `(verdict, alpaca_qty)` instead of a bare verdict string. `alpaca_qty` is signed; meaningful when `verdict == "OK"`.
- The drain loop computes `qty_to_sell = min(db_qty, abs(alpaca_qty))` before `place_exit`. The bot never SELLs more than what Alpaca actually holds, and never overshoots beyond what the DB tracked.
- Defensive `qty_to_sell <= 0` branch (logs + skips, doesn't emit a zero-qty order).
- One-line invariant comment per the issue's acceptance criterion: *"INVARIANT: re-fetch Alpaca qty before EACH SELL. The DB is the bot's intent; the broker is truth."*

## Tests

| Test | Asserts |
|---|---|
| `test_drain_partial_when_alpaca_holds_less_than_db` | DB=+10, Alpaca=+5 → SELL 5 (verified to fail without the fix — got 10) |
| `test_drain_caps_at_db_qty_when_alpaca_holds_more` | DB=+5, Alpaca=+10 → SELL 5 |
| `test_drain_rechecks_alpaca_per_position` | Two orphan tickers → `get_open_position` called twice, two SELLs |
| `test_drain_proceeds_when_alpaca_confirms_same_side` (existing) | Now also pins `place_exit qty == 5.0` |

All 8 pre-existing drain tests still pass.

## Verification

- `pytest trading_bot/tests/` → **808 passed, 2 skipped** (pre-existing missing `hypothesis` dep, unrelated).
- Partial-drain regression test verified to fail without the fix and pass with it.
- `ruff check` on changed files: clean.

## Test plan

- [ ] Next regime rebalance that disables a sleeve with active positions: confirm `get_open_position` log line appears for each orphan, exit submits exactly once per ticker, no follow-up SELLs on subsequent ticks.
- [ ] Paper-trading integration test: out of scope for this PR — needs a real sleeve-disable event. The unit tests cover all the branches the integration test would exercise.

## Acceptance criteria from #41

- [x] Unit test: stub Alpaca returning current qty=0 → `drain_disabled_sleeves` should not submit a SELL (existed in PR #20)
- [x] Unit test: stub Alpaca returning current qty < db_qty (partial drain) → SELL is for the Alpaca qty, not the DB qty (**this PR**)
- [x] Unit test: stub Alpaca returning -qty (short, defensive) → no SELL submitted (existed in PR #20)
- [x] Read PR #20's diff with fresh eyes — confirmed: the per-iteration check fires before each SELL, not just once before the loop. Pinned with a regression test seeding two orphans
- [ ] Integration test on paper — out of scope; no sleeve disable since 2026-04-30
- [x] One-line invariant comment in the drain function

🤖 Generated with [Claude Code](https://claude.com/claude-code)