### PR TITLE
ci(static-checks): pin dev tools, warm pip cache

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -47,12 +47,18 @@ jobs:
         with:
           python-version: "3.12"
           cache: pip
-          cache-dependency-path: requirements.txt
+          # Cache invalidates when either file changes. requirements-dev.txt
+          # holds the pinned static-analysis tools (ruff/mypy/bandit/
+          # pip-audit) so setup-python warms them up alongside the
+          # trading deps, instead of cold-installing them every run.
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
 
       - name: Install deps
         run: |
           pip install -r requirements.txt
-          pip install ruff mypy bandit pip-audit
+          pip install -r requirements-dev.txt
 
       - name: Live-path regex guards
         run: bash scripts/check_live_path.sh

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,9 @@
+# Static-analysis tools used by .github/workflows/static-checks.yml.
+# Pinned so CI is deterministic against tool-release breakage (e.g. a
+# new ruff rule landing on `latest` and flagging existing code), and
+# so setup-python's pip cache can warm them up — these aren't in
+# requirements.txt and otherwise cold-install on every run.
+ruff==0.15.12
+mypy==1.20.2
+bandit==1.9.4
+pip-audit==2.10.0


### PR DESCRIPTION
## Why

Static-checks took **1m3s** on the first run after adding bandit + pip-audit (PR #74), nudging the documented <60s budget. Root cause: \`ruff\`, \`mypy\`, \`bandit\`, and \`pip-audit\` weren't in any cache-keyed file, so \`setup-python\`'s pip cache never warmed them up — they cold-installed every run.

## What

- Pin the four static-analysis tools in [requirements-dev.txt](requirements-dev.txt) at their currently-installed versions (\`ruff==0.15.12\`, \`mypy==1.20.2\`, \`bandit==1.9.4\`, \`pip-audit==2.10.0\`).
- Reference both files in \`cache-dependency-path\` so the pip cache invalidates on either change.
- Replace inline \`pip install ruff mypy bandit pip-audit\` with \`pip install -r requirements-dev.txt\`.

## Why caching, not parallelization

Each parallel job pays ~15s of fixed overhead (checkout + setup-python + pip-install of the trading deps). bandit (~5s) and pip-audit (~10s) are dwarfed by that overhead — wall time = max-job ≈ same as today's main job. Caching solves the actual issue (cold install) without fragmenting the workflow into multiple status checks.

## Bonus

Pinning makes CI deterministic against tool-release breakage. A new ruff rule landing on \`latest\` no longer silently flags existing code on the next PR.

## Test plan

- [ ] First run on this PR will still cold-install (cache key just changed) — measure baseline
- [ ] Re-run with \`workflow_dispatch\` after merge to confirm warm-cache wall time
- [ ] All gates still pass (no functional changes)