### PR TITLE
fix(execution): sweep ENTRY_PENDING rows with NULL alpaca_order_id

### DIFF
--- a/trading_bot/execution/order_manager.py
+++ b/trading_bot/execution/order_manager.py
@@ -232,6 +232,72 @@ class OrderManager:
                 if oid is not None:
                     self._alpaca_to_trade[str(oid)] = trade_id
 
+    def _sweep_uninitiated_pending_entries(self, timeout_seconds: int) -> None:
+        """Mark ghost ENTRY_PENDING rows as ENTRY_FAILED.
+
+        A row with ``status='ENTRY_PENDING'`` and ``alpaca_order_id IS
+        NULL`` is the survivor of a crash between the
+        ``_create_position_record`` INSERT and the ``submit_order`` call.
+        The normal timeout sweep at ``_check_order_statuses`` keys off
+        ``alpaca_entry_order_id`` and would skip these rows forever,
+        permanently consuming a position slot.
+
+        Apply a generous 2× timeout window to avoid racing a slow Alpaca
+        round-trip on a concurrent tick. Anything older is either crashed
+        or stuck and is safe to fail.
+        """
+        cutoff: datetime = datetime.now(tz=ET) - timedelta(
+            seconds=timeout_seconds * 2,
+        )
+        try:
+            conn: sqlite3.Connection = sqlite3.connect(self._db_path)
+            try:
+                conn.row_factory = sqlite3.Row
+                rows = conn.execute(
+                    "SELECT id, ticker, entry_time FROM positions "
+                    "WHERE status = ? AND alpaca_order_id IS NULL",
+                    (PositionStatus.ENTRY_PENDING.value,),
+                ).fetchall()
+            finally:
+                conn.close()
+        except sqlite3.OperationalError:
+            logger.warning(
+                "uninitiated-entry sweep: positions table unreadable",
+                exc_info=True,
+            )
+            return
+
+        for row in rows:
+            entry_time_raw = row["entry_time"]
+            if not entry_time_raw:
+                continue
+            try:
+                entry_time: datetime = datetime.fromisoformat(str(entry_time_raw))
+            except ValueError:
+                logger.warning(
+                    "uninitiated-entry sweep: unparseable entry_time %r "
+                    "for trade_id=%d",
+                    entry_time_raw, int(row["id"]),
+                )
+                continue
+            if entry_time.tzinfo is None:
+                entry_time = entry_time.replace(tzinfo=ET)
+            if entry_time > cutoff:
+                # Recent — submit may still be in flight. Skip.
+                continue
+
+            trade_id: int = int(row["id"])
+            logger.warning(
+                "uninitiated-entry sweep: marking trade_id=%d ticker=%s "
+                "ENTRY_FAILED (status=ENTRY_PENDING but alpaca_order_id "
+                "is NULL; entry_time=%s, age > %ds)",
+                trade_id, row["ticker"], entry_time.isoformat(),
+                timeout_seconds * 2,
+            )
+            self._update_position_status(trade_id, PositionStatus.ENTRY_FAILED)
+            # Drop from the in-memory map if hydration loaded it.
+            self._active_orders.pop(trade_id, None)
+
     async def _check_order_statuses(self) -> None:
         """Check status of all tracked orders via Alpaca API.
 
@@ -245,6 +311,7 @@ class OrderManager:
         timeout_seconds: int = int(
             self._config._get("entry", "entry_timeout_seconds", default=300)
         )
+        self._sweep_uninitiated_pending_entries(timeout_seconds)
         min_fill_pct: float = float(
             self._config._get("entry", "partial_fill_min_pct", default=0.50)
         )

--- a/trading_bot/tests/test_order_manager_lifecycle.py
+++ b/trading_bot/tests/test_order_manager_lifecycle.py
@@ -371,6 +371,97 @@ class TestEntryTimeout:
         om._gw.client.cancel_order_by_id.assert_called()
 
 
+class TestUninitiatedEntrySweep:
+    """ENTRY_PENDING rows with alpaca_order_id IS NULL (crash between
+    INSERT and submit_order) — the timeout sweep at line 257 requires a
+    non-NULL order id, so without an explicit sweep these rows sit forever
+    occupying a position slot. See risk_infrastructure_gaps.md item 4.
+    """
+
+    @pytest.mark.asyncio
+    async def test_aged_pending_with_null_order_id_marked_entry_failed(
+        self, config, tmp_db_path: str, mock_notifier
+    ):
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        # Pre-populate a ghost row directly: status=ENTRY_PENDING, no
+        # alpaca_order_id, entry_time well past the timeout window.
+        old_iso: str = (
+            datetime.now(tz=ET) - timedelta(seconds=3600)
+        ).isoformat()
+        conn = sqlite3.connect(tmp_db_path)
+        try:
+            conn.execute(
+                "INSERT INTO positions (ticker, exchange, currency, "
+                "quantity, entry_price, stop_price, target_price, "
+                "status, hold_type, phase, strategy_id, entry_time, "
+                "updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    "GHOST", "US", "USD", 100, 10.0, 9.8, 10.4,
+                    PositionStatus.ENTRY_PENDING.value, "intraday", 1,
+                    "mean_reversion", old_iso, old_iso,
+                ),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        # No Alpaca calls should be needed — the row has no order id.
+        om._gw.client.get_order_by_id = MagicMock()
+
+        await om._check_order_statuses()
+
+        # Row is now ENTRY_FAILED in the DB and not in _active_orders.
+        conn = sqlite3.connect(tmp_db_path)
+        try:
+            row = conn.execute(
+                "SELECT status FROM positions WHERE ticker = 'GHOST'"
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row[0] == PositionStatus.ENTRY_FAILED.value
+        # Should not have queried Alpaca for an order it never had.
+        om._gw.client.get_order_by_id.assert_not_called()
+        assert all(a.ticker != "GHOST" for a in om._active_orders.values())
+
+    @pytest.mark.asyncio
+    async def test_recent_pending_with_null_order_id_left_alone(
+        self, config, tmp_db_path: str, mock_notifier
+    ):
+        """A row with NULL order id but entry_time within the timeout
+        window must NOT be marked ENTRY_FAILED — the submit could still
+        be in flight (concurrent tick, slow Alpaca round trip).
+        """
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        recent_iso: str = datetime.now(tz=ET).isoformat()
+        conn = sqlite3.connect(tmp_db_path)
+        try:
+            conn.execute(
+                "INSERT INTO positions (ticker, exchange, currency, "
+                "quantity, entry_price, stop_price, target_price, "
+                "status, hold_type, phase, strategy_id, entry_time, "
+                "updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    "FRESH", "US", "USD", 100, 10.0, 9.8, 10.4,
+                    PositionStatus.ENTRY_PENDING.value, "intraday", 1,
+                    "mean_reversion", recent_iso, recent_iso,
+                ),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        await om._check_order_statuses()
+
+        conn = sqlite3.connect(tmp_db_path)
+        try:
+            row = conn.execute(
+                "SELECT status FROM positions WHERE ticker = 'FRESH'"
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row[0] == PositionStatus.ENTRY_PENDING.value
+
+
 # ---------------------------------------------------------------------------
 # Exit fill detection
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes item 4 from `risk_infrastructure_gaps.md` (2026-05-07 python-review).

A crash between `_create_position_record` (INSERT) and `client.submit_order` leaves a `positions` row with `status='ENTRY_PENDING'` and `alpaca_order_id IS NULL`. The existing per-tick timeout sweep at `_check_order_statuses` keys off `alpaca_entry_order_id` being non-NULL and skips these rows forever — permanently consuming a position slot until manual intervention or a `workflow_dispatch` run of `repair_orphans.py`.

This adds `_sweep_uninitiated_pending_entries` which runs immediately after hydration:
- Rows where `status='ENTRY_PENDING'` AND `alpaca_order_id IS NULL` AND `age > 2 * entry_timeout_seconds` are marked `ENTRY_FAILED` and dropped from `_active_orders`.
- The 2× window gives a generous buffer against a slow Alpaca round-trip on a concurrent tick.

No new Alpaca calls. ~70 LOC added.

## Test plan
- [x] New `test_aged_pending_with_null_order_id_marked_entry_failed` — seeds a 1-hour-old NULL-order-id row, confirms ENTRY_FAILED without any Alpaca call.
- [x] New `test_recent_pending_with_null_order_id_left_alone` — fresh row is left alone.
- [x] Full `test_order_manager_lifecycle.py` suite green (39/39).
- [ ] CI green.

## Sequence

This is one of four PRs that close out the items 1–4 from `risk_infrastructure_gaps.md`. The other three are independent (different files):
- Item 3: orphan-drain writes a self-healable trades row
- Item 2: deletes the redundant software-side trailing stop
- Item 1: persists `RiskManager` state via `risk_circuit_state`

🤖 Generated with [Claude Code](https://claude.com/claude-code)