### PR TITLE
fix(strategy_manager): orphan-drain writes self-healable trades row

### DIFF
--- a/trading_bot/strategy/strategy_manager.py
+++ b/trading_bot/strategy/strategy_manager.py
@@ -617,17 +617,75 @@ class StrategyManager:
         return AlpacaPositionCheck("OK", alpaca_qty)
 
     def _mark_position_closed(self, position_id: int) -> None:
-        """Update positions.status = 'CLOSED' for a single row."""
+        """Mark a drained orphan CLOSED *and* write a backfill-eligible
+        trades row.
+
+        The orphan-drain ``NOT_HELD`` branch fires when the DB believes
+        we hold a position but Alpaca holds zero. Without writing a
+        trades row, the position's P&L is silently dropped from
+        ``daily_summaries`` and the self-improvement postmortem.
+
+        Mirrors ``gateway/recovery.py:_close_db_position``: stamps
+        ``exit_reason='reconciliation_mismatch'`` and leaves
+        ``exit_price``/``net_pnl`` NULL so the nightly
+        ``alpaca_backfill`` job can pair it with the actual Alpaca exit
+        fill via the matcher in
+        ``self_improve/alpaca_backfill.insert_backfilled_trade``.
+
+        Both writes go through ``with conn:`` so the UPDATE+INSERT either
+        commit together or roll back together — never leave a CLOSED
+        position with no audit trail.
+        """
         now_str: str = datetime.now(tz=ET).isoformat()
         try:
             conn: sqlite3.Connection = sqlite3.connect(self._db_path)
+            conn.row_factory = sqlite3.Row
             try:
-                conn.execute(
-                    "UPDATE positions SET status = 'CLOSED', updated_at = ? "
-                    "WHERE id = ? AND status NOT IN ('CLOSED', 'ENTRY_FAILED')",
-                    (now_str, position_id),
-                )
-                conn.commit()
+                with conn:
+                    cur = conn.execute(
+                        "UPDATE positions SET status = 'CLOSED', updated_at = ? "
+                        "WHERE id = ? AND status NOT IN ('CLOSED', 'ENTRY_FAILED')",
+                        (now_str, position_id),
+                    )
+                    if cur.rowcount == 0:
+                        # Already terminal — nothing to backfill.
+                        return
+                    row = conn.execute(
+                        "SELECT * FROM positions WHERE id = ?",
+                        (position_id,),
+                    ).fetchone()
+                    if row is None:
+                        return
+                    qty: float = float(row["quantity"] or 0)
+                    entry_side: str = "BUY" if qty >= 0 else "SELL"
+                    conn.execute(
+                        "INSERT INTO trades "
+                        "(ticker, exchange, currency, side, entry_time, "
+                        " entry_price, quantity, exit_time, exit_reason, "
+                        " hold_type, phase, strategy_id, notes) "
+                        "VALUES (:ticker, :exchange, :currency, :side, "
+                        "        :entry_time, :entry_price, :quantity, "
+                        "        :exit_time, :exit_reason, :hold_type, "
+                        "        :phase, :strategy_id, :notes)",
+                        {
+                            "ticker": row["ticker"],
+                            "exchange": row["exchange"],
+                            "currency": row["currency"],
+                            "side": entry_side,
+                            "entry_time": row["entry_time"],
+                            "entry_price": row["entry_price"],
+                            "quantity": abs(qty),
+                            "exit_time": now_str,
+                            "exit_reason": "reconciliation_mismatch",
+                            "hold_type": row["hold_type"],
+                            "phase": row["phase"],
+                            "strategy_id": row["strategy_id"] or "unknown",
+                            "notes": (
+                                "orphan_sleeve_drain: Alpaca holds 0; "
+                                "exit_price/net_pnl pending alpaca_backfill"
+                            ),
+                        },
+                    )
             finally:
                 conn.close()
         except Exception:

--- a/trading_bot/tests/test_strategy_manager.py
+++ b/trading_bot/tests/test_strategy_manager.py
@@ -929,15 +929,34 @@ class TestDrainDisabledSleeves:
         base_order_manager.place_exit.assert_not_awaited()
 
         # DB row is now CLOSED so we don't retry on every subsequent tick.
+        # AND a matching trades row is written with exit_reason
+        # 'reconciliation_mismatch' and exit_price NULL so the nightly
+        # alpaca_backfill can find and repair it. Without this row the
+        # P&L for this position would be silently dropped from
+        # daily_summaries forever.
         conn = sqlite3.connect(tmp_db_path)
         try:
-            row = conn.execute(
+            pos_row = conn.execute(
                 "SELECT status FROM positions WHERE id = 99"
+            ).fetchone()
+            trade_row = conn.execute(
+                "SELECT exit_reason, exit_price, exit_time, ticker, "
+                "strategy_id FROM trades "
+                "WHERE ticker = 'SPY' AND exit_reason = 'reconciliation_mismatch' "
+                "AND exit_price IS NULL"
             ).fetchone()
         finally:
             conn.close()
-        assert row is not None
-        assert row[0] == "CLOSED"
+        assert pos_row is not None
+        assert pos_row[0] == "CLOSED"
+        assert trade_row is not None, (
+            "Drain NOT_HELD must write a trades row for backfill to repair"
+        )
+        assert trade_row[0] == "reconciliation_mismatch"
+        assert trade_row[1] is None
+        assert trade_row[2] is not None  # exit_time stamped
+        assert trade_row[3] == "SPY"
+        assert trade_row[4] == "breakout"
 
     @pytest.mark.asyncio
     async def test_drain_refuses_when_alpaca_holds_opposite_side(


### PR DESCRIPTION
## Summary

Fixes item 3 from `risk_infrastructure_gaps.md` (2026-05-07 python-review).

`StrategyManager._mark_position_closed` (the orphan-drain `NOT_HELD` branch) previously updated only `positions.status='CLOSED'`. The corresponding trades row kept NULL exit data forever and was silently excluded from `daily_summaries`, the self-improvement postmortem, and the win-rate calculation.

This PR mirrors the `gateway/recovery.py:_close_db_position` pattern: in one atomic `with conn:` transaction, UPDATE positions and INSERT a matching trades row with `exit_reason='reconciliation_mismatch'` and `exit_price=NULL`. The nightly `alpaca_backfill` matcher already pairs this format with the actual Alpaca exit fill and writes the real `exit_price` / `pnl_usd`, so P&L lands in `daily_summaries` after the next daily-review run (after #71 fixed the cache prefix).

Also adds a `cur.rowcount == 0` early-return so we don't write a backfill stub for a row that was already terminal (e.g. raced by another tick).

## Background

PRs #65/67/70/71 tackled adjacent failure modes (workflow_dispatch repair, daily-review cache prefix). Those handle the manual / nightly cleanup path. This PR closes the gap on the per-tick `drain_disabled_sleeves` path itself.

## Test plan
- [x] Existing `test_drain_skips_when_alpaca_holds_zero` extended with explicit assertions on the trades row: `exit_reason='reconciliation_mismatch'`, `exit_price IS NULL`, `exit_time` stamped, `strategy_id` preserved.
- [x] 13/13 in `TestDrainDisabledSleeves`; 35/35 in `test_strategy_manager.py`.
- [ ] CI green.

## Sequence

One of four PRs closing items 1–4 from `risk_infrastructure_gaps.md`. Touches different files than the others and can merge independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)