### PR TITLE
refactor(exit): delete redundant software-side trailing stop

### DIFF
--- a/trading_bot/strategy/exit.py
+++ b/trading_bot/strategy/exit.py
@@ -16,7 +16,6 @@ from zoneinfo import ZoneInfo
 from trading_bot.config import Config
 from trading_bot.constants import TZ_EASTERN, ExitReason, HoldType
 from trading_bot.data.market_data import MarketDataManager
-from trading_bot.utils import coalesce
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -122,89 +121,6 @@ class ExitManager:
         # Short
         return current_price <= target_price
 
-    def check_trailing_stop(
-        self, position: dict[str, Any], current_price: float
-    ) -> tuple[bool, float | None]:
-        """Check the trailing stop.
-
-        Returns ``(triggered, new_highest_price)``.
-
-        Activation thresholds (from entry price):
-        - Intraday: +1.5%
-        - Swing: +2.5%
-
-        Once active, trails at:
-        - Intraday: -1% from highest price
-        - Swing: -1.5% from highest price
-        """
-        entry_price: float = position.get("entry_price", 0.0)
-        direction: str = position.get("direction", "long")
-        hold_type_str: str = position.get("hold_type", "intraday")
-        hold_type: HoldType = HoldType(hold_type_str)
-
-        params: dict[str, Any] = self.get_exit_params(hold_type)
-        activation_pct: float = float(params["trailing_activation_pct"])
-        trail_distance_pct: float = float(params["trailing_distance_pct"])
-
-        # highest_price may be NULL in DB before first trail update; use
-        # coalesce so a stored None falls back to entry_price.
-        highest_price: float = float(coalesce(position, "highest_price", entry_price))
-        trailing_active: bool = bool(coalesce(position, "trailing_active", False))
-
-        if entry_price <= 0:
-            return False, None
-
-        if direction == "long":
-            # Update highest
-            if current_price > highest_price:
-                highest_price = current_price
-
-            # Check activation
-            pct_from_entry: float = (highest_price - entry_price) / entry_price
-            if not trailing_active and pct_from_entry < activation_pct:
-                # Not yet activated
-                return False, highest_price
-
-            # Trailing stop is active (or just activated)
-            trail_price: float = highest_price * (1.0 - trail_distance_pct)
-            triggered: bool = current_price <= trail_price
-
-            if not trailing_active:
-                logger.info(
-                    "%s: Trailing stop ACTIVATED at +%.1f%% (high=%.4f, trail=%.4f)",
-                    position.get("ticker", "?"),
-                    pct_from_entry * 100,
-                    highest_price,
-                    trail_price,
-                )
-
-            return triggered, highest_price
-
-        else:
-            # Short position: track lowest price
-            lowest_price: float = float(coalesce(position, "lowest_price", entry_price))
-            if current_price < lowest_price:
-                lowest_price = current_price
-
-            pct_from_entry = (entry_price - lowest_price) / entry_price
-            if not trailing_active and pct_from_entry < activation_pct:
-                return False, lowest_price
-
-            trail_price = lowest_price * (1.0 + trail_distance_pct)
-            triggered = current_price >= trail_price
-
-            if not trailing_active:
-                logger.info(
-                    "%s: Trailing stop ACTIVATED (short) at +%.1f%% "
-                    "(low=%.4f, trail=%.4f)",
-                    position.get("ticker", "?"),
-                    pct_from_entry * 100,
-                    lowest_price,
-                    trail_price,
-                )
-
-            return triggered, lowest_price
-
     def check_time_stop(
         self, position: dict[str, Any], current_time: datetime
     ) -> bool:
@@ -273,8 +189,16 @@ class ExitManager:
         Checks in priority order:
         1. Stop loss (emergency)
         2. Take profit
-        3. Trailing stop
-        4. Time stop
+        3. Time stop
+
+        Trailing stops are managed by Alpaca natively via
+        ``TrailingStopOrderRequest`` (submitted by
+        ``OrderManager.activate_trailing_stop`` once
+        ``trail_activation_price`` is reached). The broker tracks the
+        high-water mark and fires the stop autonomously, so there is no
+        software-side trail check here. The previous duplicate check
+        risked racing the broker's stop and never persisted
+        ``highest_price`` between ticks.
 
         Returns an :class:`ExitDecision`.
         """
@@ -306,26 +230,7 @@ class ExitManager:
                 use_market_order=False,
             )
 
-        # Priority 3: Trailing stop
-        trailing_triggered, new_high = self.check_trailing_stop(
-            position, current_price
-        )
-        if trailing_triggered:
-            logger.info(
-                "%s: TRAILING STOP triggered at %.4f (high=%.4f)",
-                ticker,
-                current_price,
-                new_high,
-            )
-            return ExitDecision(
-                should_exit=True,
-                reason=ExitReason.TRAILING_STOP,
-                is_emergency=False,
-                exit_price=current_price,
-                use_market_order=False,
-            )
-
-        # Priority 4: Time stop
+        # Priority 3: Time stop
         if self.check_time_stop(position, current_time):
             hold_type_str: str = position.get("hold_type", "intraday")
             hold_type: HoldType = HoldType(hold_type_str)

--- a/trading_bot/tests/test_exit_logic.py
+++ b/trading_bot/tests/test_exit_logic.py
@@ -110,57 +110,39 @@ class TestTakeProfit:
 
 
 # ---------------------------------------------------------------------------
-# Trailing stop
+# Trailing stop is broker-managed
 # ---------------------------------------------------------------------------
 
 
-class TestTrailingStop:
-    def test_trailing_stop_activation(self, exit_manager: ExitManager) -> None:
-        """Price rises +1.5% — trailing stop should activate for intraday."""
-        pos = _long_position(entry_price=10.0, hold_type="intraday",
-                             trailing_active=False, highest_price=10.0)
-        # activation at +1.5% = 10.15
-        triggered, high = exit_manager.check_trailing_stop(pos, 10.16)
-        # Should activate (pct_from_entry >= 0.015) but not triggered yet
-        assert triggered is False  # price hasn't dropped 1% from high
-        assert high is not None and high >= 10.15
+class TestTrailingStopIsBrokerManaged:
+    """The software-side trailing stop was removed in favour of Alpaca's
+    native ``TrailingStopOrderRequest``. ``ExitManager`` no longer offers
+    a ``check_trailing_stop`` method, and ``should_exit`` never produces
+    an ``ExitReason.TRAILING_STOP`` decision — the broker fires the stop
+    autonomously and the bot picks up the fill via order-status polling.
+    See ``risk_infrastructure_gaps.md`` item 2.
+    """
 
-    def test_trailing_stop_triggers(self, exit_manager: ExitManager) -> None:
-        """Trailing active, price falls 1% from high — should trigger."""
-        # Simulate: entry=10, high=10.20 (already at +2%), trailing active
-        pos = _long_position(entry_price=10.0, hold_type="intraday",
-                             trailing_active=True, highest_price=10.20)
-        # Trail distance = 1%, so trail price = 10.20 * 0.99 = 10.098
-        triggered, _ = exit_manager.check_trailing_stop(pos, 10.05)
-        assert triggered is True
-
-    def test_trailing_stop_not_yet_activated(self, exit_manager: ExitManager) -> None:
-        """Price at +1.4% — below 1.5% activation threshold."""
-        pos = _long_position(entry_price=10.0, hold_type="intraday",
-                             trailing_active=False, highest_price=10.0)
-        # +1.4% = 10.14
-        triggered, _ = exit_manager.check_trailing_stop(pos, 10.14)
-        assert triggered is False
-
-    def test_trailing_stop_swing_higher_activation(
+    def test_check_trailing_stop_is_removed(
         self, exit_manager: ExitManager
     ) -> None:
-        """Swing activation is 2.5%, not 1.5%."""
-        pos = _long_position(entry_price=10.0, hold_type="swing",
-                             trailing_active=False, highest_price=10.0)
-        # +2.4% — below swing 2.5% activation
-        triggered, _ = exit_manager.check_trailing_stop(pos, 10.24)
-        assert triggered is False
+        assert not hasattr(exit_manager, "check_trailing_stop")
 
-    def test_trailing_stop_does_not_trigger_if_price_holds(
+    def test_should_exit_does_not_fire_trailing_stop(
         self, exit_manager: ExitManager
     ) -> None:
-        """Trailing active, price remains above trail level — no exit."""
-        # high=10.20, trail distance=1%, trail_price=10.098; price=10.15 > trail
-        pos = _long_position(entry_price=10.0, hold_type="intraday",
-                             trailing_active=True, highest_price=10.20)
-        triggered, _ = exit_manager.check_trailing_stop(pos, 10.15)
-        assert triggered is False
+        # Position deeply in trailing-stop territory: high=10.20, trailing
+        # active, current price 10.05 (would have triggered the old
+        # software-side trail). Stop loss / take profit / time stop are
+        # all clear.
+        pos = _long_position(
+            entry_price=10.0, stop_price=9.80, target_price=10.30,
+            hold_type="intraday", trailing_active=True,
+            highest_price=10.20,
+        )
+        decision = exit_manager.should_exit(pos, 10.05, datetime.now(ET))
+        assert decision.should_exit is False
+        assert decision.reason is None
 
 
 # ---------------------------------------------------------------------------
@@ -233,15 +215,6 @@ class TestShouldExit:
         assert decision.should_exit is True
         assert decision.reason == ExitReason.TAKE_PROFIT
         assert decision.is_emergency is False
-
-    def test_trailing_stop_fires(self, exit_manager: ExitManager) -> None:
-        pos = _long_position(entry_price=10.0, stop_price=9.80,
-                             target_price=10.30, hold_type="intraday",
-                             trailing_active=True, highest_price=10.20)
-        # trail_price = 10.20 * 0.99 = 10.098; current = 10.05 < trail
-        decision = exit_manager.should_exit(pos, 10.05, datetime.now(ET))
-        assert decision.should_exit is True
-        assert decision.reason == ExitReason.TRAILING_STOP
 
     def test_no_exit_all_conditions_clear(self, exit_manager: ExitManager) -> None:
         pos = _long_position(entry_price=10.0, stop_price=9.80,


### PR DESCRIPTION
## Summary

Fixes item 2 from \`risk_infrastructure_gaps.md\` (2026-05-07 python-review).

Alpaca's native \`TrailingStopOrderRequest\` is the authoritative trail. \`OrderManager.activate_trailing_stop\` submits it once \`trail_activation_price\` is reached, and Alpaca tracks the high-water mark autonomously. The parallel software-side \`ExitManager.check_trailing_stop\` was:

- **Redundant pre-activation:** activation thresholds are shared, so it could only fire when the broker would have activated too.
- **A race risk post-activation:** could fire an exit decision ahead of Alpaca's broker-side stop.
- **Effectively blind to inter-tick gains:** read \`highest_price\` from the DB and returned an updated value to \`should_exit\`, but the caller never wrote it back. Every tick reset the high-water mark to whatever \`OrderManager\` last persisted (only seeded at entry and on activation).

This PR removes \`ExitManager.check_trailing_stop\` and the priority-3 block in \`should_exit\`. The DB columns (\`highest_price\`, \`trailing_active\`, etc.) and the \`ExitReason.TRAILING_STOP\` enum stay — they're still used by \`OrderManager\`, \`alpaca_backfill._infer_exit_reason\`, and the backtest engine's self-contained trail.

Net diff: -120 LOC.

## Test plan
- [x] Replaced the 5-test \`TestTrailingStop\` class with a 2-test \`TestTrailingStopIsBrokerManaged\` regression guard:
  - \`test_check_trailing_stop_is_removed\` — \`hasattr\` guard against re-introduction.
  - \`test_should_exit_does_not_fire_trailing_stop\` — seeds a position deep in trailing-stop territory; asserts no exit fires.
- [x] Removed \`test_trailing_stop_fires\` from \`TestShouldExit\`.
- [x] 23/23 in \`test_exit_logic.py\`.
- [ ] CI green.

## Sequence

One of four PRs closing items 1–4 from \`risk_infrastructure_gaps.md\`. Touches different files than the others and can merge independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)