### PR TITLE
fix(risk_manager): persist circuit-breaker state via risk_circuit_state

### DIFF
--- a/trading_bot/execution/risk_manager.py
+++ b/trading_bot/execution/risk_manager.py
@@ -20,7 +20,12 @@ from trading_bot.constants import (
     GICS_SECTOR,
     TZ_EASTERN,
 )
+from trading_bot.db import repository as repo
 from trading_bot.utils.time import trading_today
+
+# State key for the global RiskManager circuit. Per-strategy circuits
+# (e.g. loss_cooldown) use their own keys via the same table.
+_RISK_STATE_KEY: str = "risk_manager:global"
 
 if TYPE_CHECKING:
     from trading_bot.config import Config
@@ -84,6 +89,220 @@ class RiskManager:
         # reader scanning for object state.
         self._daily_loss_limit_hit: bool = False
         self._commission_stop_active: bool = False
+
+        # Hydrate persisted state from risk_circuit_state. Done last in
+        # __init__ so all defaults are in place before any field is
+        # selectively overwritten. See _load_state for the day-rollover
+        # semantics that distinguish day-scoped from cross-day fields.
+        self._load_state()
+
+    # ------------------------------------------------------------------
+    # State persistence (item 1, risk_infrastructure_gaps.md)
+    # ------------------------------------------------------------------
+
+    def _load_state(self) -> None:
+        """Hydrate fields from the ``risk_circuit_state`` table.
+
+        Cron model: every tick constructs a new RiskManager. Without
+        persistence the daily-loss-limit, drawdown breaker, pause, and
+        commission-stop circuits silently reset to defaults each tick,
+        rendering them inert across the 5-minute boundary.
+
+        Day-rollover semantics:
+        - **Day-scoped** fields (``_daily_pnl_usd``, ``_trade_count``,
+          ``_daily_loss_limit_hit``, ``_commission_stop_active``,
+          ``_commission_cooldown_until``) reset on a new trading day.
+        - **Cross-day** fields (``_is_paused`` + ``_pause_reason`` +
+          ``_pause_until`` if its window straddles a day boundary,
+          ``_drawdown_breaker_active`` + ``_recovery_trades_remaining``
+          + ``_recovery_size_pct``) survive day rollover.
+
+        Always reads ``_daily_pnl_usd`` from today's actual closed
+        trades (``repo.get_daily_pnl_usd``) rather than the stored blob,
+        so the field reflects ground truth even if a tick crashed
+        mid-record.
+
+        Always rebuilds ``_recent_rejections`` from the
+        ``order_rejections`` table within the configured window —
+        ``time.monotonic()`` values are meaningless across processes.
+        """
+        try:
+            with sqlite3.connect(self._db_path) as conn:
+                self._daily_pnl_usd = repo.get_daily_pnl_usd(conn)
+                state_row = repo.load_risk_state(conn, _RISK_STATE_KEY)
+        except Exception:
+            logger.warning(
+                "RiskManager: failed to hydrate persisted state; "
+                "starting from defaults",
+                exc_info=True,
+            )
+            return
+
+        self._hydrate_recent_rejections()
+
+        if state_row is None:
+            return
+
+        blob: dict[str, Any] = state_row.get("state") or {}
+        today: date = datetime.now(tz=ET).date()
+        stored_day_str: str | None = blob.get("trading_day")
+        try:
+            stored_day: date | None = (
+                date.fromisoformat(stored_day_str) if stored_day_str else None
+            )
+        except ValueError:
+            stored_day = None
+
+        same_day: bool = stored_day == today
+
+        # Cross-day fields — restored regardless of day rollover.
+        self._is_paused = bool(blob.get("is_paused", False))
+        self._pause_reason = blob.get("pause_reason")
+        pause_until_iso: str | None = blob.get("pause_until")
+        if pause_until_iso:
+            try:
+                pause_until: datetime = datetime.fromisoformat(pause_until_iso)
+                if pause_until.tzinfo is None:
+                    pause_until = pause_until.replace(tzinfo=ET)
+                self._pause_until = pause_until
+            except ValueError:
+                self._pause_until = None
+        self._drawdown_breaker_active = bool(blob.get("drawdown_breaker_active", False))
+        self._recovery_trades_remaining = int(blob.get("recovery_trades_remaining", 0))
+        self._recovery_size_pct = float(blob.get("recovery_size_pct", 1.0))
+
+        if same_day:
+            # Day-scoped fields restored only on the same trading day.
+            self._trade_count = int(blob.get("trade_count", 0))
+            self._daily_gross_pnl_usd = float(blob.get("daily_gross_pnl_usd", 0.0))
+            self._daily_commissions_usd = float(blob.get("daily_commissions_usd", 0.0))
+            self._daily_loss_limit_hit = bool(blob.get("daily_loss_limit_hit", False))
+            self._commission_stop_active = bool(blob.get("commission_stop_active", False))
+            cooldown_iso: str | None = blob.get("commission_cooldown_until")
+            if cooldown_iso:
+                try:
+                    cooldown_until: datetime = datetime.fromisoformat(cooldown_iso)
+                    if cooldown_until.tzinfo is None:
+                        cooldown_until = cooldown_until.replace(tzinfo=ET)
+                    self._commission_cooldown_until = cooldown_until
+                except ValueError:
+                    self._commission_cooldown_until = None
+            if stored_day is not None:
+                self._trading_day = stored_day
+        else:
+            # New day — day-scoped fields stay at __init__ defaults (zero),
+            # cross-day fields above stay restored. Stamp _trading_day to
+            # today and flush the corrected state so the next tick reads
+            # post-rollover values without redoing this work.
+            self._trading_day = today
+            logger.info(
+                "RiskManager: day rollover detected (stored=%s, today=%s); "
+                "day-scoped counters zeroed, cross-day breakers preserved",
+                stored_day, today,
+            )
+            self._persist_state()
+
+    def _hydrate_recent_rejections(self) -> None:
+        """Repopulate the rejections deque from the ``order_rejections``
+        table within the configured window.
+
+        ``_recent_rejections`` stores ``time.monotonic()`` floats — those
+        are meaningless after a process restart. Convert the table's
+        wallclock timestamps into the current process's monotonic clock
+        so the existing window/cutoff arithmetic in
+        ``check_order_rejections`` keeps working unchanged.
+        """
+        window_minutes: int = int(
+            self._config._get(
+                "risk", "order_rejections", "window_minutes", default=10,
+            )
+        )
+        cutoff_dt: datetime = datetime.now(tz=ET) - timedelta(
+            minutes=window_minutes,
+        )
+        try:
+            with sqlite3.connect(self._db_path) as conn:
+                rows = conn.execute(
+                    "SELECT timestamp FROM order_rejections "
+                    "WHERE timestamp >= ? ORDER BY timestamp ASC",
+                    (cutoff_dt.isoformat(),),
+                ).fetchall()
+        except sqlite3.OperationalError:
+            return
+
+        now_mono: float = time.monotonic()
+        now_wall: datetime = datetime.now(tz=ET)
+        self._recent_rejections.clear()
+        for row in rows:
+            ts_raw = row[0]
+            if not ts_raw:
+                continue
+            try:
+                ts: datetime = datetime.fromisoformat(str(ts_raw))
+            except ValueError:
+                continue
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=ET)
+            age_seconds: float = (now_wall - ts).total_seconds()
+            self._recent_rejections.append(now_mono - age_seconds)
+
+    def _persist_state(self) -> None:
+        """Write the current state back to ``risk_circuit_state``.
+
+        Called from every state-mutating method. ``tripped`` is True
+        when any breaker or pause is active so external monitoring of
+        the table keys off a single bool.
+        """
+        any_active: bool = (
+            self._is_paused
+            or self._drawdown_breaker_active
+            or self._daily_loss_limit_hit
+            or self._commission_stop_active
+        )
+        reason: str | None = None
+        if self._is_paused:
+            reason = self._pause_reason
+        elif self._daily_loss_limit_hit:
+            reason = "daily_loss_limit"
+        elif self._commission_stop_active:
+            reason = "commission_stop"
+        elif self._drawdown_breaker_active:
+            reason = "drawdown_breaker_recovery"
+
+        blob: dict[str, Any] = {
+            "trading_day": self._trading_day.isoformat(),
+            "trade_count": int(self._trade_count),
+            "daily_gross_pnl_usd": float(self._daily_gross_pnl_usd),
+            "daily_commissions_usd": float(self._daily_commissions_usd),
+            "is_paused": bool(self._is_paused),
+            "pause_reason": self._pause_reason,
+            "pause_until": (
+                self._pause_until.isoformat()
+                if self._pause_until is not None else None
+            ),
+            "drawdown_breaker_active": bool(self._drawdown_breaker_active),
+            "recovery_trades_remaining": int(self._recovery_trades_remaining),
+            "recovery_size_pct": float(self._recovery_size_pct),
+            "daily_loss_limit_hit": bool(self._daily_loss_limit_hit),
+            "commission_stop_active": bool(self._commission_stop_active),
+            "commission_cooldown_until": (
+                self._commission_cooldown_until.isoformat()
+                if self._commission_cooldown_until is not None else None
+            ),
+        }
+        try:
+            with sqlite3.connect(self._db_path) as conn:
+                repo.save_risk_state(
+                    conn,
+                    _RISK_STATE_KEY,
+                    tripped=any_active,
+                    reason=reason,
+                    state=blob,
+                )
+        except Exception:
+            logger.exception(
+                "RiskManager: failed to persist risk_circuit_state",
+            )
 
     # ------------------------------------------------------------------
     # Top-level gate
@@ -163,6 +382,7 @@ class RiskManager:
                 limit,
                 self._config.daily_loss_limit_pct * 100,
             )
+            self._persist_state()
         return breached
 
     def check_max_positions(self, current_count: int) -> bool:
@@ -401,6 +621,7 @@ class RiskManager:
             f"Paused until {pause_until.strftime('%Y-%m-%d %H:%M ET')}",
         )
         self._pause_until = pause_until
+        self._persist_state()
 
         # Synchronous send — risk-manager methods run from sync code
         # (``can_trade()``).  Scheduling via ``asyncio.ensure_future`` could be
@@ -465,6 +686,7 @@ class RiskManager:
                 f"{pause_until.strftime('%H:%M ET')}",
             )
             self._pause_until = pause_until
+            self._persist_state()
 
             self._notifier.send_sync(
                 "Order Rejections",
@@ -478,7 +700,12 @@ class RiskManager:
         return False
 
     def record_rejection(self, ticker: str, reason: str) -> None:
-        """Record an order rejection for the sliding-window counter."""
+        """Record an order rejection for the sliding-window counter.
+
+        Persists to ``order_rejections`` so the deque can be rebuilt on
+        the next tick (the in-memory ``time.monotonic()`` values are
+        meaningless across processes — see ``_hydrate_recent_rejections``).
+        """
         self._recent_rejections.append(time.monotonic())
         logger.warning("Order rejection recorded: %s - %s", ticker, reason)
 
@@ -531,6 +758,7 @@ class RiskManager:
                     daily_commissions,
                     daily_gross_pnl,
                 )
+                self._persist_state()
                 return "stop"
             return None
 
@@ -545,6 +773,7 @@ class RiskManager:
                 daily_commissions,
                 daily_gross_pnl,
             )
+            self._persist_state()
             return "stop"
 
         if ratio >= warning_ratio:
@@ -557,6 +786,7 @@ class RiskManager:
                 ratio * 100,
                 cooldown_min,
             )
+            self._persist_state()
             return "warning"
 
         return None
@@ -604,6 +834,8 @@ class RiskManager:
                     self._recovery_size_pct = 1.0
                     logger.info("Drawdown recovery complete - normal sizing resumed")
 
+        self._persist_state()
+
     # ------------------------------------------------------------------
     # Daily lifecycle
     # ------------------------------------------------------------------
@@ -621,6 +853,7 @@ class RiskManager:
         self._recent_rejections.clear()
 
         logger.info("Risk manager daily counters reset for %s", self._trading_day)
+        self._persist_state()
 
     # ------------------------------------------------------------------
     # Pause / resume
@@ -631,6 +864,7 @@ class RiskManager:
         self._is_paused = True
         self._pause_reason = reason
         logger.warning("Trading PAUSED: %s", reason)
+        self._persist_state()
 
     def resume_trading(self) -> None:
         """Resume trading after a pause."""
@@ -641,6 +875,7 @@ class RiskManager:
         self._is_paused = False
         self._pause_reason = None
         self._pause_until = None
+        self._persist_state()
 
     # ------------------------------------------------------------------
     # Kill switch
@@ -677,6 +912,7 @@ class RiskManager:
         # 4. Permanent close-only mode
         self.pause_trading("Kill switch activated - permanent close-only mode")
         self._pause_until = None  # No auto-resume
+        self._persist_state()
 
         logger.critical("Kill switch execution complete")
 

--- a/trading_bot/main.py
+++ b/trading_bot/main.py
@@ -337,7 +337,11 @@ class TradingBot:
             # --- 8. Day-scoped flags (persisted via tick_state "__day__") ---
             flags: dict[str, Any] = self._load_day_flags(today_et)
 
-            # --- 9. Daily risk counter reset (only once per day) ---
+            # --- 9. Daily risk counter reset (intra-tick fallback) ---
+            # RiskManager._load_state handles the normal cron-tick day
+            # rollover at construction time. This branch only fires if
+            # the tick itself crosses midnight ET — possible during
+            # overnight maintenance ticks but otherwise dead.
             if today_et != self._risk_manager._trading_day:
                 self._risk_manager.reset_daily()
 

--- a/trading_bot/tests/test_risk_manager.py
+++ b/trading_bot/tests/test_risk_manager.py
@@ -348,3 +348,153 @@ class TestDailyReset:
         risk_manager.record_trade(3.0, 0.0)    # winner +3
         # Expected gross profit = 10 + 3 = 13 (losses excluded)
         assert abs(risk_manager._daily_gross_pnl_usd - 13.0) < 0.01
+
+
+# ---------------------------------------------------------------------------
+# Cross-tick state persistence (item 1 — risk_circuit_state)
+# ---------------------------------------------------------------------------
+
+
+class TestStatePersistence:
+    """RiskManager state must survive across the stateless cron tick.
+
+    Pre-fix: every tick constructed a fresh RiskManager with all defaults,
+    silently inerting the daily-loss-limit, drawdown-breaker, pause, and
+    commission-stop circuits. See risk_infrastructure_gaps.md item 1.
+    """
+
+    def test_pause_survives_new_instance(
+        self, config: Config, tmp_db_path: str, mock_notifier
+    ) -> None:
+        rm1 = RiskManager(config, tmp_db_path, mock_notifier)
+        rm1.pause_trading("test pause")
+
+        # Simulate new tick — fresh process, fresh RiskManager.
+        rm2 = RiskManager(config, tmp_db_path, mock_notifier)
+        ok, reason = rm2.can_trade()
+        assert ok is False
+        assert reason == "test pause"
+
+    def test_drawdown_breaker_survives_new_instance(
+        self, config: Config, tmp_db_path: str, mock_notifier
+    ) -> None:
+        rm1 = RiskManager(config, tmp_db_path, mock_notifier)
+        rm1._activate_drawdown_breaker(0.06)
+        assert rm1.drawdown_breaker_active is True
+
+        rm2 = RiskManager(config, tmp_db_path, mock_notifier)
+        assert rm2.drawdown_breaker_active is True
+
+    def test_recovery_trades_remaining_survives_new_instance(
+        self, config: Config, tmp_db_path: str, mock_notifier
+    ) -> None:
+        rm1 = RiskManager(config, tmp_db_path, mock_notifier)
+        rm1._activate_drawdown_breaker(0.06)
+        # Mid-recovery — one winning trade has decremented the counter.
+        rm1.record_trade(5.0, 0.0)
+
+        rm2 = RiskManager(config, tmp_db_path, mock_notifier)
+        # Recovery state, including the decremented counter, persists.
+        assert rm2.drawdown_breaker_active is True
+        assert rm2._recovery_trades_remaining == rm1._recovery_trades_remaining
+
+    def test_daily_loss_limit_hit_survives_within_same_day(
+        self, config: Config, tmp_db_path: str, mock_notifier
+    ) -> None:
+        rm1 = RiskManager(config, tmp_db_path, mock_notifier)
+        rm1.check_daily_loss_limit(-100.0, 1000.0)  # -10% — well past 1% limit
+        ok1, _ = rm1.can_trade()
+        assert ok1 is False
+
+        rm2 = RiskManager(config, tmp_db_path, mock_notifier)
+        ok2, _ = rm2.can_trade()
+        assert ok2 is False, (
+            "daily-loss-limit hit must persist across ticks within the same day"
+        )
+
+    def test_commission_stop_survives_new_instance(
+        self, config: Config, tmp_db_path: str, mock_notifier
+    ) -> None:
+        rm1 = RiskManager(config, tmp_db_path, mock_notifier)
+        # >50% commission ratio — fires commission stop.
+        rm1._trade_count = 5
+        rm1.check_commission_budget(daily_commissions=10.0, daily_gross_pnl=15.0)
+        assert rm1._commission_stop_active is True
+
+        rm2 = RiskManager(config, tmp_db_path, mock_notifier)
+        assert rm2._commission_stop_active is True
+        ok, _ = rm2.can_trade()
+        assert ok is False
+
+    def test_resume_clears_persisted_pause(
+        self, config: Config, tmp_db_path: str, mock_notifier
+    ) -> None:
+        rm1 = RiskManager(config, tmp_db_path, mock_notifier)
+        rm1.pause_trading("temporary")
+
+        rm1.resume_trading()
+
+        rm2 = RiskManager(config, tmp_db_path, mock_notifier)
+        ok, _ = rm2.can_trade()
+        assert ok is True
+        assert rm2.is_paused is False
+
+    def test_day_rollover_zeros_day_scoped_only(
+        self, config: Config, tmp_db_path: str, mock_notifier
+    ) -> None:
+        """A new day must reset trade_count/daily_pnl/daily_loss_limit_hit
+        but preserve the pause/drawdown breaker if they're still active."""
+        rm1 = RiskManager(config, tmp_db_path, mock_notifier)
+        # Set up state: pause active, daily-loss-limit hit, some trade count.
+        rm1.pause_trading("multi-day pause")
+        # Set pause_until to tomorrow so it survives day rollover.
+        rm1._pause_until = datetime.now(tz=ET) + timedelta(days=2)
+        rm1.check_daily_loss_limit(-100.0, 1000.0)
+        rm1._trade_count = 7
+        # Force-persist with the updated pause_until
+        rm1._persist_state()
+
+        # Construct a new instance "tomorrow".
+        from trading_bot.execution import risk_manager as rm_module
+        future = datetime.now(tz=ET) + timedelta(days=1)
+        with patch.object(
+            rm_module, "datetime",
+            new=type("D", (), {
+                "now": staticmethod(lambda tz=None: future),
+                "fromisoformat": datetime.fromisoformat,
+            }),
+        ):
+            rm2 = RiskManager(config, tmp_db_path, mock_notifier)
+
+        # Day-scoped fields zeroed:
+        assert rm2._daily_loss_limit_hit is False
+        assert rm2._trade_count == 0
+        # Cross-day fields preserved:
+        assert rm2.is_paused is True
+        assert rm2._pause_reason == "multi-day pause"
+
+    def test_record_rejection_persists_via_order_rejections_table(
+        self, config: Config, tmp_db_path: str, mock_notifier
+    ) -> None:
+        """The deque uses time.monotonic() which is meaningless across
+        processes. New instance should rebuild the deque from the
+        order_rejections table."""
+        import sqlite3
+
+        rm1 = RiskManager(config, tmp_db_path, mock_notifier)
+        rm1.record_rejection("SPY", "out_of_money")
+        rm1.record_rejection("QQQ", "out_of_money")
+
+        # Sanity: rejections actually landed in the DB.
+        conn = sqlite3.connect(tmp_db_path)
+        try:
+            count = conn.execute(
+                "SELECT COUNT(*) FROM order_rejections"
+            ).fetchone()[0]
+        finally:
+            conn.close()
+        assert count == 2
+
+        # New instance hydrates the deque from the table within window.
+        rm2 = RiskManager(config, tmp_db_path, mock_notifier)
+        assert len(rm2._recent_rejections) == 2


### PR DESCRIPTION
## Summary

Fixes item 1 from \`risk_infrastructure_gaps.md\` (2026-05-07 python-review) — the highest-impact of the four blockers.

**Pre-fix:** every cron tick constructed a fresh \`RiskManager\` with all defaults. The daily-loss-limit, drawdown breaker, pause window, commission-stop, and order-rejection deque silently reset to zero on the 5-minute boundary. The \`risk_circuit_state\` table existed but was only used by \`loss_cooldown.py\`.

**Concrete consequence:** at \`main.py:596\`, \`check_daily_loss_limit(self._risk_manager.daily_pnl_usd, ...)\` was called with \`0.0\` every tick — the loss limit could never trip across ticks. Same for the drawdown-breaker pause window.

## Approach

Wires \`RiskManager\` to the same \`risk_circuit_state\` table the loss-cooldown tracker already uses, mirroring its proven pattern:

1. **Two helpers.** \`_load_state\` hydrates at end of \`__init__\`; \`_persist_state\` upserts the full state blob and is called from every mutation point (\`pause_trading\`, \`resume_trading\`, \`_activate_drawdown_breaker\`, \`record_trade\`, \`check_daily_loss_limit\`, \`check_commission_budget\`, \`reset_daily\`, \`handle_kill_switch\`, \`check_order_rejections\`).

2. **Day-rollover semantics.** Day-scoped fields (\`trade_count\`, daily P&L, \`daily_loss_limit_hit\`, \`commission_stop_active\`, \`commission_cooldown_until\`) zero on a new day. Cross-day fields (\`is_paused\` + \`pause_until\`, \`drawdown_breaker_active\`, \`recovery_trades_remaining\`, \`recovery_size_pct\`) survive day rollover.

3. **\`_daily_pnl_usd\` is hydrated from \`repo.get_daily_pnl_usd\`, not the stored blob.** The blob is updated on every \`record_trade\`, but \`get_daily_pnl_usd\` reads ground truth directly from \`trades.pnl_usd\` so a tick that crashes mid-record still sees correct realized P&L on the next tick.

4. **\`_recent_rejections\` deque is rebuilt from \`order_rejections\` table.** \`time.monotonic()\` floats are meaningless across processes; convert wallclock timestamps into the current process's monotonic clock so the existing window/cutoff arithmetic in \`check_order_rejections\` keeps working unchanged.

5. **Comment fix in \`main.py:341\`.** The \`today_et != _trading_day\` rollover check is now an intra-tick fallback (only fires if the tick crosses midnight ET) since \`_load_state\` handles the normal cron-tick rollover at construction time.

Net diff: +392 LOC (~240 of which is the \`risk_manager.py\` persistence layer + docstrings; the rest is tests).

## Test plan

8 new tests in \`TestStatePersistence\`:
- [x] \`test_pause_survives_new_instance\`
- [x] \`test_drawdown_breaker_survives_new_instance\`
- [x] \`test_recovery_trades_remaining_survives_new_instance\`
- [x] \`test_daily_loss_limit_hit_survives_within_same_day\`
- [x] \`test_commission_stop_survives_new_instance\`
- [x] \`test_resume_clears_persisted_pause\`
- [x] \`test_day_rollover_zeros_day_scoped_only\`
- [x] \`test_record_rejection_persists_via_order_rejections_table\`

- [x] 36/36 in \`test_risk_manager.py\`.
- [ ] CI green.

## Pre-live verification

After this lands and a few paper-trading days run:
\`\`\`sql
SELECT key, tripped, reason, updated_at
FROM risk_circuit_state
WHERE key = 'risk_manager:global';
\`\`\`
should show real values when any breaker fires (vs. NULL pre-fix).

## Sequence

This is the largest of four PRs closing items 1–4 from \`risk_infrastructure_gaps.md\`. Touches \`risk_manager.py\`, \`main.py\`, and \`test_risk_manager.py\` exclusively — no overlap with the other three PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)