### PR TITLE
docs: note global risk state persistence in stateless-tick description

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,7 @@ close (via `.github/workflows/daily-review.yml`, 21:30 UTC weekdays). It:
 
 - Modular package under `trading_bot/` — each subsystem (strategy, execution, risk, reporting, etc.) is its own module.
 - **US-only** — trades US equities via Alpaca (NYSE/NASDAQ), commission-free.
-- **Stateless tick model** — each `python -m trading_bot.main` invocation runs one `tick()` and exits. Per-strategy state (day flags, spread-defer timers) is persisted in the `tick_state` / `risk_circuit_state` SQLite tables, so the next cron invocation picks up cleanly. No long-running process, no WebSocket stream, no heartbeat loop.
+- **Stateless tick model** — each `python -m trading_bot.main` invocation runs one `tick()` and exits. Per-strategy state (day flags, spread-defer timers, loss-cooldown counters) and global risk state (pause window, drawdown breaker, daily-loss-limit hit, commission stop) are persisted in the `tick_state` / `risk_circuit_state` SQLite tables, so the next cron invocation picks up cleanly. No long-running process, no WebSocket stream, no heartbeat loop.
 - **Alpaca integration:**
   - `TradingClient` (REST) for orders, positions, account queries
   - `StockHistoricalDataClient` for historical OHLCV bars

--- a/README.md
+++ b/README.md
@@ -224,10 +224,12 @@ Each invocation runs one `tick()` and exits:
    whichever windows are active, gated by day-scoped flags.
 7. Phase-transition + daily-summary checks once per day.
 
-Per-strategy state (day flags, spread-defer timers, strategy sleeves)
-lives in the `tick_state` / `risk_circuit_state` SQLite tables so the
-next cron invocation picks up cleanly. There is no long-running
-process, no WebSocket stream, and no heartbeat loop.
+Per-strategy state (day flags, spread-defer timers, strategy sleeves,
+loss-cooldown counters) and global risk state (pause window, drawdown
+breaker, daily-loss-limit hit, commission stop, recent rejections) live
+in the `tick_state` / `risk_circuit_state` SQLite tables so the next
+cron invocation picks up cleanly. There is no long-running process, no
+WebSocket stream, and no heartbeat loop.
 
 ## Heartbeat
 


### PR DESCRIPTION
## Summary

After PR #79 (RiskManager state persistence), the `risk_circuit_state` table now also holds the global pause window, drawdown breaker, daily-loss-limit hit, commission stop, and recent rejections — not just the per-strategy loss cooldown.

This PR updates `CLAUDE.md` and `README.md` so the stateless-tick description matches the actual persisted surface. **No code change.**

## Test plan
- [x] Diff is two-file, doc-only.
- [ ] CI green (formality — no executable code touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)