### PR TITLE
fix(strategy_manager): block cross-strategy wash-trade collisions

### DIFF
--- a/trading_bot/strategy/strategy_manager.py
+++ b/trading_bot/strategy/strategy_manager.py
@@ -179,6 +179,20 @@ class StrategyManager:
                 (1.0 - event_mult) * 100,
             )
 
+        # Cross-strategy Alpaca collision guard. The per-strategy
+        # virtual_portfolio.get_open_positions only sees its own sleeve's
+        # holdings — but Alpaca rejects a BUY (code 40310000, "potential
+        # wash trade detected") whenever an opposite-side stop is on the
+        # books for the same ticker, including a stop placed by a
+        # different sleeve's prior entry. Hit twice on 2026-05-07 19:45
+        # UTC: overnight_drift tried SPY/QQQ that mean_reversion already
+        # held earlier in the day. Fetch live positions once per scan and
+        # skip any candidate Alpaca already holds. Fails open on lookup
+        # error — same posture as regime_filter / sentiment.
+        live_alpaca_tickers: frozenset[str] | None = (
+            await self._fetch_live_alpaca_tickers()
+        )
+
         for ticker in watchlist:
             can_trade, reason = self._risk_manager.can_trade()
             if not can_trade:
@@ -245,6 +259,22 @@ class StrategyManager:
 
                 # Don't double up on same ticker in same strategy
                 if any(p["ticker"] == ticker for p in open_positions):
+                    continue
+
+                # Cross-strategy: Alpaca already holds the ticker (under
+                # another sleeve, or a manual position). Submitting a BUY
+                # here would be rejected as a wash trade by Alpaca's
+                # opposite-side-stop check. See ``_fetch_live_alpaca_tickers``
+                # for the data source and the 2026-05-07 incident notes.
+                if (
+                    live_alpaca_tickers is not None
+                    and ticker in live_alpaca_tickers
+                ):
+                    logger.info(
+                        "[%s] %s already held at Alpaca by another "
+                        "sleeve — skipping (cross-strategy collision)",
+                        strategy.strategy_id, ticker,
+                    )
                     continue
 
                 # 2026-04-29 incident dedup: rejected entries get stamped
@@ -567,6 +597,39 @@ class StrategyManager:
             closed += 1
 
         return closed
+
+    async def _fetch_live_alpaca_tickers(self) -> frozenset[str] | None:
+        """Live tickers Alpaca currently holds (long or short, qty != 0).
+
+        Returns ``None`` when the lookup fails — callers must fail open
+        rather than block legitimate entries on a transient broker error.
+        Returns ``frozenset()`` (empty, not ``None``) when Alpaca reports
+        no positions; the empty case still means "we know there's no
+        collision" and should be treated as a clean signal.
+        """
+        try:
+            positions = await self._order_manager._gw.get_positions()
+        except Exception:
+            logger.warning(
+                "Alpaca get_positions failed during entry scan — "
+                "skipping cross-strategy collision guard for this tick",
+                exc_info=True,
+            )
+            return None
+
+        held: set[str] = set()
+        for pos in positions or ():
+            symbol = getattr(pos, "symbol", None)
+            qty_raw = getattr(pos, "qty", None)
+            if not symbol:
+                continue
+            try:
+                qty = float(qty_raw) if qty_raw is not None else 0.0
+            except (TypeError, ValueError):
+                continue
+            if qty != 0.0:
+                held.add(symbol)
+        return frozenset(held)
 
     def _check_alpaca_position(
         self, ticker: str, *, db_qty: float,

--- a/trading_bot/strategy/strategy_manager.py
+++ b/trading_bot/strategy/strategy_manager.py
@@ -606,6 +606,14 @@ class StrategyManager:
         Returns ``frozenset()`` (empty, not ``None``) when Alpaca reports
         no positions; the empty case still means "we know there's no
         collision" and should be treated as a clean signal.
+
+        Note: ``GatewayConnection.get_positions`` already swallows
+        broker-side exceptions and returns ``[]``, so the empty-set
+        path is what fires in practice during a transient API error.
+        The ``try/except`` here is defense in depth in case the
+        gateway contract ever changes — keeps fail-open semantics
+        owned at this call site rather than silently relying on the
+        transport layer's behaviour.
         """
         try:
             positions = await self._order_manager._gw.get_positions()
@@ -627,7 +635,10 @@ class StrategyManager:
                 qty = float(qty_raw) if qty_raw is not None else 0.0
             except (TypeError, ValueError):
                 continue
-            if qty != 0.0:
+            # Use a small epsilon rather than ``!= 0.0`` so a freshly
+            # closed position lingering with a near-zero string qty
+            # ("0.0", "0E-9", etc.) doesn't falsely block entries.
+            if abs(qty) > 1e-9:
                 held.add(symbol)
         return frozenset(held)
 

--- a/trading_bot/tests/test_strategy_manager.py
+++ b/trading_bot/tests/test_strategy_manager.py
@@ -1714,6 +1714,154 @@ class TestSameDayReentryDedup:
 
 
 # ---------------------------------------------------------------------------
+# Cross-strategy Alpaca collision guard
+# ---------------------------------------------------------------------------
+
+
+class TestCrossStrategyAlpacaCollision:
+    """Block BUYs that would wash-trade against another sleeve's stop.
+
+    Alpaca rejects a BUY with code 40310000 ("potential wash trade
+    detected. use complex orders") when an opposite-side stop already
+    rests on the same ticker. The 2026-05-07 19:45 UTC overnight_drift
+    tick hit this twice (SPY + QQQ already held by mean_reversion).
+    The same-strategy ``get_open_positions`` guard misses the case
+    because portfolios are scoped per-strategy_id; the live broker
+    state is the source of truth.
+    """
+
+    def _alpaca_pos(self, symbol: str, qty: str = "1.0") -> Any:
+        pos = MagicMock()
+        pos.symbol = symbol
+        pos.qty = qty
+        return pos
+
+    @pytest.mark.asyncio
+    async def test_skips_when_alpaca_holds_ticker_under_other_strategy(
+        self,
+        base_market_data,
+        base_risk_manager,
+        base_earnings,
+        base_sentiment,
+        base_order_manager,
+        base_portfolio_manager,
+        base_config,
+        fake_5min,
+        fake_daily,
+        tmp_db_path,
+    ):
+        # This strategy's in-memory portfolio is empty (it doesn't think
+        # it holds SPY) — but Alpaca says SPY is held (parked there by
+        # another sleeve's earlier entry).
+        base_order_manager._gw.get_positions = AsyncMock(
+            return_value=[self._alpaca_pos("SPY", "1.0")],
+        )
+
+        sm = StrategyManager(
+            strategies=[_StubStrategy(decision=_make_decision())],
+            portfolio_manager=base_portfolio_manager,
+            market_data=base_market_data,
+            order_manager=base_order_manager,
+            risk_manager=base_risk_manager,
+            sentiment=base_sentiment,
+            earnings=base_earnings,
+            config=base_config,
+            db_path=tmp_db_path,
+        )
+
+        n = await sm.scan_for_entries(
+            watchlist=["SPY"],
+            get_5min_bars=fake_5min,
+            get_daily_bars=fake_daily,
+            account_equity_usd=1000.0,
+        )
+        assert n == 0
+        base_order_manager.place_entry.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_allows_when_alpaca_holds_unrelated_ticker(
+        self,
+        base_market_data,
+        base_risk_manager,
+        base_earnings,
+        base_sentiment,
+        base_order_manager,
+        base_portfolio_manager,
+        base_config,
+        fake_5min,
+        fake_daily,
+        tmp_db_path,
+    ):
+        # Alpaca holds QQQ (unrelated to candidate); SPY scan must proceed.
+        base_order_manager._gw.get_positions = AsyncMock(
+            return_value=[self._alpaca_pos("QQQ", "1.0")],
+        )
+
+        sm = StrategyManager(
+            strategies=[_StubStrategy(decision=_make_decision())],
+            portfolio_manager=base_portfolio_manager,
+            market_data=base_market_data,
+            order_manager=base_order_manager,
+            risk_manager=base_risk_manager,
+            sentiment=base_sentiment,
+            earnings=base_earnings,
+            config=base_config,
+            db_path=tmp_db_path,
+        )
+
+        n = await sm.scan_for_entries(
+            watchlist=["SPY"],
+            get_5min_bars=fake_5min,
+            get_daily_bars=fake_daily,
+            account_equity_usd=1000.0,
+        )
+        assert n == 1
+        base_order_manager.place_entry.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_alpaca_lookup_failure_fails_open(
+        self,
+        base_market_data,
+        base_risk_manager,
+        base_earnings,
+        base_sentiment,
+        base_order_manager,
+        base_portfolio_manager,
+        base_config,
+        fake_5min,
+        fake_daily,
+        tmp_db_path,
+    ):
+        # If get_positions blows up (transient API error), we must NOT
+        # block the entire scan — same fail-open posture used everywhere
+        # else for advisory broker lookups (regime filter, sentiment).
+        base_order_manager._gw.get_positions = AsyncMock(
+            side_effect=RuntimeError("alpaca 503"),
+        )
+
+        sm = StrategyManager(
+            strategies=[_StubStrategy(decision=_make_decision())],
+            portfolio_manager=base_portfolio_manager,
+            market_data=base_market_data,
+            order_manager=base_order_manager,
+            risk_manager=base_risk_manager,
+            sentiment=base_sentiment,
+            earnings=base_earnings,
+            config=base_config,
+            db_path=tmp_db_path,
+        )
+
+        n = await sm.scan_for_entries(
+            watchlist=["SPY"],
+            get_5min_bars=fake_5min,
+            get_daily_bars=fake_daily,
+            account_equity_usd=1000.0,
+        )
+        assert n == 1
+        base_order_manager.place_entry.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
 # check_exits
 # ---------------------------------------------------------------------------
 

--- a/trading_bot/tests/test_strategy_manager.py
+++ b/trading_bot/tests/test_strategy_manager.py
@@ -1819,6 +1819,92 @@ class TestCrossStrategyAlpacaCollision:
         base_order_manager.place_entry.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_zero_qty_position_does_not_block(
+        self,
+        base_market_data,
+        base_risk_manager,
+        base_earnings,
+        base_sentiment,
+        base_order_manager,
+        base_portfolio_manager,
+        base_config,
+        fake_5min,
+        fake_daily,
+        tmp_db_path,
+    ):
+        # A freshly-closed position can linger in get_positions() with
+        # qty="0" before the broker prunes it. Must NOT trigger a false
+        # block — the wash-trade rejection only applies to non-zero
+        # holdings with resting opposite-side stops.
+        base_order_manager._gw.get_positions = AsyncMock(
+            return_value=[self._alpaca_pos("SPY", "0")],
+        )
+
+        sm = StrategyManager(
+            strategies=[_StubStrategy(decision=_make_decision())],
+            portfolio_manager=base_portfolio_manager,
+            market_data=base_market_data,
+            order_manager=base_order_manager,
+            risk_manager=base_risk_manager,
+            sentiment=base_sentiment,
+            earnings=base_earnings,
+            config=base_config,
+            db_path=tmp_db_path,
+        )
+
+        n = await sm.scan_for_entries(
+            watchlist=["SPY"],
+            get_5min_bars=fake_5min,
+            get_daily_bars=fake_daily,
+            account_equity_usd=1000.0,
+        )
+        assert n == 1
+        base_order_manager.place_entry.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_short_position_blocks_entry(
+        self,
+        base_market_data,
+        base_risk_manager,
+        base_earnings,
+        base_sentiment,
+        base_order_manager,
+        base_portfolio_manager,
+        base_config,
+        fake_5min,
+        fake_daily,
+        tmp_db_path,
+    ):
+        # Alpaca holds SPY short (qty="-1.0"). A long BUY would still
+        # be rejected as a wash trade against the resting buy-to-cover
+        # stop, so the guard must block here too — same severity as
+        # the long-side collision.
+        base_order_manager._gw.get_positions = AsyncMock(
+            return_value=[self._alpaca_pos("SPY", "-1.0")],
+        )
+
+        sm = StrategyManager(
+            strategies=[_StubStrategy(decision=_make_decision())],
+            portfolio_manager=base_portfolio_manager,
+            market_data=base_market_data,
+            order_manager=base_order_manager,
+            risk_manager=base_risk_manager,
+            sentiment=base_sentiment,
+            earnings=base_earnings,
+            config=base_config,
+            db_path=tmp_db_path,
+        )
+
+        n = await sm.scan_for_entries(
+            watchlist=["SPY"],
+            get_5min_bars=fake_5min,
+            get_daily_bars=fake_daily,
+            account_equity_usd=1000.0,
+        )
+        assert n == 0
+        base_order_manager.place_entry.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_alpaca_lookup_failure_fails_open(
         self,
         base_market_data,


### PR DESCRIPTION
## Summary

- Add a cross-strategy Alpaca collision guard in `scan_for_entries`: one `get_positions` call per scan, skip any candidate the broker already holds, fail-open on lookup error.
- New unit tests in `TestCrossStrategyAlpacaCollision` for skip / allow / fail-open paths.

## Why

The per-strategy `virtual_portfolio.get_open_positions()` only sees its own sleeve's holdings. When two sleeves trade the same universe (mean_reversion + overnight_drift on SPY/QQQ/sector ETFs), a ticker held by sleeve A is invisible to sleeve B's "already open" guard. Sleeve B then tries to BUY and Alpaca rejects with code **40310000** (`potential wash trade detected. use complex orders. opposite side market/stop order exists`) because of the resting stop from sleeve A's position.

Hit twice on **2026-05-07 19:45 UTC** ([run 25518207820](https://github.com/alex5imon/ai-broker/actions/runs/25518207820)):
- mean_reversion held SPY @ 732.99 (16:25 UTC, position 90) and QQQ @ 696.82 (16:35 UTC, position 91)
- overnight_drift fired BUYs for SPY + QQQ at 19:45 UTC; both rejected
- trades 152 + 153 stamped `entry_failed`

This is structurally different from the bug PR #64 fixed (same-strategy duplicate entries from a `_check_order_statuses` timeout hole). It's a new failure mode unmasked because we now run two sleeves on overlapping watchlists.

## Approach

`_fetch_live_alpaca_tickers()` calls `await self._order_manager._gw.get_positions()` once at the top of `scan_for_entries`, returns a `frozenset[str]` of held tickers (qty != 0), or `None` on lookup failure. The new guard is placed right after the existing same-strategy `if any(p["ticker"] == ticker for p in open_positions)` check — at that point we know this strategy doesn't hold it, so a hit means another sleeve does.

Fail-open posture matches the regime filter and sentiment lookup: log and proceed on broker error. In that case the existing `_already_attempted_today` dedup still short-circuits the retry loop after the first rejection — so we don't lose much.

## Test plan

- [x] New `TestCrossStrategyAlpacaCollision` (3 cases) — skip when Alpaca holds the ticker under another sleeve; allow when unrelated; fail-open on `get_positions` error.
- [x] Full `test_strategy_manager.py` + `test_strategy_manager_gates.py` (55 tests) green.
- [x] Full suite green (829 passed).
- [ ] **Production validation:** watch tomorrow's 19:45 UTC overnight_drift tick — if mean_reversion is holding SPY/QQQ, the log should show `[overnight_drift] SPY already held at Alpaca by another sleeve — skipping (cross-strategy collision)` and no `entry_failed` rows for those tickers.

## Out of scope

- The `risk_manager:global` row in `risk_circuit_state` is still absent in production (PR #79 caveat surfaced today — `_persist_state` may only run on breaker fire). Tracked separately.
- daily_summaries 2026-04-30 onward still showing 0/0/0 wins/losses; today's daily-review cron at 21:30 UTC was delayed. Re-check after it runs.