### PR TITLE
fix(risk_manager): bootstrap risk_circuit_state row on first session

### DIFF
--- a/trading_bot/execution/risk_manager.py
+++ b/trading_bot/execution/risk_manager.py
@@ -141,6 +141,15 @@ class RiskManager:
         self._hydrate_recent_rejections()
 
         if state_row is None:
+            # First-session bootstrap: stamp the sentinel row so the
+            # ``risk_manager:global`` key is present in the table from
+            # tick #1, before any breaker has had a chance to fire.
+            # Without this the row is "write-only-on-fault" — external
+            # monitoring (and post-deploy verification) can't tell the
+            # persistence path is wired correctly until a breaker
+            # actually trips. 2026-05-07 evening discovery: shipped
+            # PR #79 mid-day, end-of-day DB still had no row.
+            self._persist_state()
             return
 
         blob: dict[str, Any] = state_row.get("state") or {}

--- a/trading_bot/tests/test_risk_manager.py
+++ b/trading_bot/tests/test_risk_manager.py
@@ -363,6 +363,36 @@ class TestStatePersistence:
     commission-stop circuits. See risk_infrastructure_gaps.md item 1.
     """
 
+    def test_first_session_writes_sentinel_row(
+        self, config: Config, tmp_db_path: str, mock_notifier
+    ) -> None:
+        """First session against a fresh DB must stamp the
+        ``risk_manager:global`` row even when no breaker has tripped.
+
+        Without this the row is "write-only-on-fault" — external
+        monitoring can't tell PR #79's persistence path is wired
+        until something actually goes wrong. Discovered 2026-05-07
+        evening: PR #79 shipped mid-day, end-of-day DB had no row.
+        """
+        import sqlite3
+
+        from trading_bot.db.repository import load_risk_state
+
+        # Fresh RiskManager against a brand-new (no risk_manager:global
+        # row yet) DB.
+        RiskManager(config, tmp_db_path, mock_notifier)
+
+        with sqlite3.connect(tmp_db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            row = load_risk_state(conn, "risk_manager:global")
+
+        assert row is not None, (
+            "first-session bootstrap must write the sentinel row so "
+            "the persistence path is verifiable before any breaker fires"
+        )
+        # Default state — nothing tripped.
+        assert row["tripped"] is False
+
     def test_pause_survives_new_instance(
         self, config: Config, tmp_db_path: str, mock_notifier
     ) -> None:


### PR DESCRIPTION
## Summary

- Stamp the `risk_manager:global` row in `risk_circuit_state` from tick #1 instead of waiting for a breaker to fire.
- New regression test: a fresh `RiskManager` against a clean DB must write the sentinel row with `tripped=False`.

## Why

[#79](https://github.com/alex5imon/ai-broker/pull/79) added persistence for `RiskManager` state, but `_persist_state` is only called from state-mutating methods (pause, drawdown breaker fire, daily-loss-limit hit, commission stop, day rollover, `record_trade`). The first-session path in `_load_state` early-returns when no row exists, so the sentinel is never created until something actually goes wrong.

**Symptom from 2026-05-07 evening DB inspection:** PR #79 shipped mid-day, end-of-day `risk_circuit_state` had only the `loss_cooldown:mean_reversion` row. No `risk_manager:global` row, even though the bot ran ~80 ticks today. The persistence path works — there was just no way to verify it from the DB alone, because nothing tripped a breaker.

## Approach

In `_load_state`, when `state_row is None`, call `_persist_state()` before returning. That writes the default (un-tripped) blob with `tripped=False`. Subsequent ticks find a same-day row and restore from it; breakers continue to update the row when they fire.

This converts the row from "write-only-on-fault" to "always-present, mutated-on-fault" — which is what external monitoring and post-deploy verification need.

## Test plan

- [x] New `test_first_session_writes_sentinel_row` — fresh `RiskManager` against an empty DB writes `risk_manager:global` with `tripped=False`.
- [x] **Verified the test fails without the fix** (stashed the fix, re-ran the test, confirmed `AssertionError`, popped the stash).
- [x] All 8 existing `TestStatePersistence` tests still green.
- [x] Full suite green (830 passed, 2 skipped).
- [ ] Production validation: after merge, the next bot tick should populate `risk_manager:global` in the persisted DB. Query: `SELECT key, tripped, datetime(updated_at) FROM risk_circuit_state WHERE key='risk_manager:global'`.

## Risk

Minimal. The change is a single extra `_persist_state()` call on the cold-start path; everything else is identical. No new state is introduced — the row content is whatever the existing `_persist_state` already writes for an un-tripped RiskManager.