### PR TITLE
fix(risk-infra): bundle items 5–7 (DB fail-closed, pre-market flag, trading-day time stop)

### DIFF
--- a/trading_bot/main.py
+++ b/trading_bot/main.py
@@ -406,10 +406,14 @@ class TradingBot:
             ):
                 try:
                     await self.wind_down(Market.US)
+                    # Same latch-on-success discipline as pre-market: a
+                    # failed wind-down must NOT set the flag, otherwise
+                    # subsequent ticks in the wind-down window won't
+                    # retry and intraday positions stay open past close.
+                    flags["wind_down_done"] = True
+                    self._save_day_flags(today_et, flags)
                 except Exception:
-                    logger.exception("Wind-down failed")
-                flags["wind_down_done"] = True
-                self._save_day_flags(today_et, flags)
+                    logger.exception("Wind-down failed — will retry next tick")
 
             # --- 15. After-close daily tasks ---
             await self._maybe_check_phase_transition(today_et, flags)

--- a/trading_bot/main.py
+++ b/trading_bot/main.py
@@ -365,12 +365,18 @@ class TradingBot:
             ):
                 try:
                     await self.pre_market_scan(Market.US)
+                    # Only latch the flag and persist the ranked watchlist
+                    # if the scan actually completed. A failed scan that
+                    # latched the flag would freeze the watchlist for the
+                    # rest of the day — every subsequent tick would see
+                    # `pre_market_done=True` and skip the retry.
+                    flags["pre_market_done"] = True
+                    flags["ranked_us_watchlist"] = self._active_watchlist.get(
+                        Market.US, [],
+                    )
+                    self._save_day_flags(today_et, flags)
                 except Exception:
-                    logger.exception("Pre-market scan failed")
-                flags["pre_market_done"] = True
-                # Persist the ranked watchlist too so the next tick can re-use it.
-                flags["ranked_us_watchlist"] = self._active_watchlist.get(Market.US, [])
-                self._save_day_flags(today_et, flags)
+                    logger.exception("Pre-market scan failed — will retry next tick")
             else:
                 # Restore ranked watchlist from flags if pre-market already ran
                 ranked: list[str] = flags.get("ranked_us_watchlist") or []

--- a/trading_bot/strategy/exit.py
+++ b/trading_bot/strategy/exit.py
@@ -74,11 +74,12 @@ class ExitManager:
         # ``check_time_stop`` swing branch counts actual sessions between
         # entry and now, so a Thu entry doesn't hit a 5-day stop on the
         # following Tue (which is only 2 trading days away).
-        try:
-            raw_cfg: dict[str, Any] = config.raw_section()
-        except Exception:
-            raw_cfg = {}
-        self._holiday_calendar: HolidayCalendar = HolidayCalendar(raw_cfg)
+        # ``raw_section()`` returns a dict copy and cannot raise — let any
+        # programming error (e.g. ``_raw`` reassigned to a non-dict) fail
+        # the constructor rather than silently degrade to fallback dates.
+        self._holiday_calendar: HolidayCalendar = HolidayCalendar(
+            config.raw_section()
+        )
 
     # ------------------------------------------------------------------
     # Parameter helpers

--- a/trading_bot/strategy/exit.py
+++ b/trading_bot/strategy/exit.py
@@ -9,12 +9,13 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 from typing import Any
 from zoneinfo import ZoneInfo
 
 from trading_bot.config import Config
 from trading_bot.constants import TZ_EASTERN, ExitReason, HoldType
+from trading_bot.data.holiday_calendar import HolidayCalendar
 from trading_bot.data.market_data import MarketDataManager
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -68,6 +69,16 @@ class ExitManager:
         self._spread_recheck_s: int = int(
             config._require("exit_spread_protection", "recheck_interval_seconds")
         )
+
+        # NYSE holiday calendar for swing-trade trading-day counting.
+        # ``check_time_stop`` swing branch counts actual sessions between
+        # entry and now, so a Thu entry doesn't hit a 5-day stop on the
+        # following Tue (which is only 2 trading days away).
+        try:
+            raw_cfg: dict[str, Any] = config.raw_section()
+        except Exception:
+            raw_cfg = {}
+        self._holiday_calendar: HolidayCalendar = HolidayCalendar(raw_cfg)
 
     # ------------------------------------------------------------------
     # Parameter helpers
@@ -126,9 +137,13 @@ class ExitManager:
     ) -> bool:
         """Check if position has exceeded maximum hold time.
 
-        Intraday: 4 hours.
-        Swing: 5 trading days (approximated as 5 * 24h = 120 hours for
-        initial check; the caller should count actual trading days).
+        Intraday: ``time_stop_hours`` (default 4) wall-clock hours.
+        Swing: ``max_hold_days`` (default 5) **trading** days, counted
+        via ``HolidayCalendar`` so weekends and NYSE holidays don't
+        consume the budget. A Thursday entry with ``max_hold_days=5``
+        now expires the following Thursday session, not the following
+        Tuesday — the calendar-day version was eating ~40% of the
+        budget on weekends/holidays.
         """
         entry_time_raw: Any = position.get("entry_time")
         if entry_time_raw is None:
@@ -164,15 +179,50 @@ class ExitManager:
 
         if hold_type == HoldType.INTRADAY:
             max_hours: float = float(params.get("time_stop_hours", 4))
-            max_duration: timedelta = timedelta(hours=max_hours)
-        else:
-            # Swing: max_hold_days trading days (use calendar days * 1.4
-            # as a rough upper bound; precise counting done by the caller)
-            max_days: int = int(params.get("max_hold_days", 5))
-            max_duration = timedelta(days=max_days)
+            elapsed: timedelta = current_time - entry_time
+            return elapsed >= timedelta(hours=max_hours)
 
-        elapsed: timedelta = current_time - entry_time
-        return elapsed >= max_duration
+        # Swing: count trading days between entry date and now.
+        max_days: int = int(params.get("max_hold_days", 5))
+        # Convert both timestamps to ET dates so the comparison is
+        # session-aligned rather than UTC-anchored.
+        entry_date: date = entry_time.astimezone(ET).date()
+        current_date: date = current_time.astimezone(ET).date()
+        elapsed_trading_days: int = self._count_trading_days_between(
+            entry_date, current_date,
+        )
+        return elapsed_trading_days >= max_days
+
+    def _count_trading_days_between(
+        self,
+        start_date: date,
+        end_date: date,
+    ) -> int:
+        """Count NYSE trading days strictly between *start_date* (entry)
+        and *end_date* (now), exclusive of the entry date and inclusive
+        of any session ending on or before *end_date*.
+
+        Examples (no holidays, no weekends shown):
+        - entry Mon, now Mon → 0 (same session, intraday — the swing
+          branch shouldn't fire).
+        - entry Mon, now Tue → 1.
+        - entry Thu, now Mon → 2 (Fri + Mon).
+        - entry Thu, now Tue → 3 (Fri + Mon + Tue).
+
+        Returns 0 when ``end_date <= start_date``. The walk is bounded
+        by calendar-day distance so a corrupted timestamp can't loop
+        forever.
+        """
+        if end_date <= start_date:
+            return 0
+        cal: HolidayCalendar = self._holiday_calendar
+        count: int = 0
+        cursor: date = start_date + timedelta(days=1)
+        while cursor <= end_date:
+            if cal.is_trading_day(cursor):
+                count += 1
+            cursor += timedelta(days=1)
+        return count
 
     # ------------------------------------------------------------------
     # Composite exit evaluation

--- a/trading_bot/strategy/strategy_manager.py
+++ b/trading_bot/strategy/strategy_manager.py
@@ -65,6 +65,14 @@ def _is_alpaca_position_not_found(exc: Any) -> bool:
     return False
 
 
+# After this many consecutive failures of the same-day-attempt DB lookup,
+# `_already_attempted_today` flips from fail-open (allow entry, transient
+# SQLite lock) to fail-closed (skip entry). DB corruption is exactly when
+# in-memory portfolio state is also stale, so allowing every ticker would
+# repeat the 2026-04-29 over-firing incident the lookup was added to fix.
+_DB_ERROR_FAIL_CLOSED_THRESHOLD: int = 3
+
+
 VerdictType = Literal["OK", "NOT_HELD", "OPPOSITE_SIDE", "UNKNOWN"]
 
 
@@ -122,6 +130,9 @@ class StrategyManager:
         self._dry_run: bool = dry_run
         self._regime_filter: RegimeFilter | None = regime_filter
         self._loss_cooldown: LossCooldownTracker | None = loss_cooldown
+        # Consecutive `_already_attempted_today` DB failures this session.
+        # Reset on any success. See `_DB_ERROR_FAIL_CLOSED_THRESHOLD`.
+        self._db_error_streak: int = 0
 
     @property
     def strategies(self) -> list[StrategyBase]:
@@ -798,12 +809,24 @@ class StrategyManager:
     # ------------------------------------------------------------------
 
     def _already_attempted_today(self, ticker: str, strategy_id: str) -> bool:
-        """Persistent same-day-attempt check (any status, any tick)."""
+        """Persistent same-day-attempt check (any status, any tick).
+
+        Tiered failure handling:
+        - Single transient errors (SQLite locked by an artifact-cache
+          backup, etc.) fail OPEN (return ``False``, allow the entry) so
+          a brief race doesn't block legitimate trades. The in-memory
+          portfolio dedup and broker-side rejections still cover us.
+        - After ``_DB_ERROR_FAIL_CLOSED_THRESHOLD`` consecutive failures
+          we flip to fail CLOSED (return ``True``, skip the entry). DB
+          corruption is exactly when in-memory portfolio state is also
+          stale, so allowing every ticker through would repeat the
+          2026-04-29 over-firing incident this lookup was built to stop.
+        """
         et_today: str = datetime.now(tz=ET).date().isoformat()
         try:
             conn: sqlite3.Connection = sqlite3.connect(self._db_path)
             try:
-                return repo.has_attempted_today(
+                result: bool = repo.has_attempted_today(
                     conn,
                     ticker=ticker,
                     strategy_id=strategy_id,
@@ -812,13 +835,26 @@ class StrategyManager:
             finally:
                 conn.close()
         except Exception:
-            # On DB error, fail OPEN (allow entry) — we have other guards
-            # (in-memory portfolio dedup above, broker-side rejections).
+            self._db_error_streak += 1
+            if self._db_error_streak >= _DB_ERROR_FAIL_CLOSED_THRESHOLD:
+                logger.error(
+                    "Same-day attempt lookup failed %d×: failing CLOSED "
+                    "for %s/%s (skipping entry until DB recovers)",
+                    self._db_error_streak, strategy_id, ticker,
+                    exc_info=True,
+                )
+                return True
             logger.warning(
-                "Same-day attempt lookup failed for %s/%s — proceeding",
-                strategy_id, ticker, exc_info=True,
+                "Same-day attempt lookup failed for %s/%s — proceeding "
+                "(streak=%d/%d)",
+                strategy_id, ticker,
+                self._db_error_streak, _DB_ERROR_FAIL_CLOSED_THRESHOLD,
+                exc_info=True,
             )
             return False
+        # Success — reset the streak.
+        self._db_error_streak = 0
+        return result
 
     def _fomc_size_multiplier(self) -> float:
         """Lookup today's FOMC multiplier from config (defaults to 1.0).

--- a/trading_bot/strategy/strategy_manager.py
+++ b/trading_bot/strategy/strategy_manager.py
@@ -293,6 +293,12 @@ class StrategyManager:
                 # doesn't see them — so the next 5-min tick re-fires the
                 # same order. Cross-check the DB for any same-day attempt
                 # (open OR closed) by this strategy on this ticker.
+                #
+                # The internal DB-error streak counter is session-global
+                # across all (ticker, strategy_id) pairs in this scan —
+                # intentional: once the DB is hard-down for this cron
+                # invocation, we want to block all remaining entries, not
+                # re-tolerate transient errors per ticker.
                 if self._already_attempted_today(ticker, strategy.strategy_id):
                     logger.debug(
                         "[%s] %s already attempted today — skipping",

--- a/trading_bot/tests/test_exit_logic.py
+++ b/trading_bot/tests/test_exit_logic.py
@@ -4,14 +4,13 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 from typing import Any
-from unittest.mock import MagicMock
 from zoneinfo import ZoneInfo
 
 import pytest
 
 from trading_bot.config import Config
-from trading_bot.constants import ExitReason, HoldType
-from trading_bot.strategy.exit import ExitDecision, ExitManager
+from trading_bot.constants import ExitReason
+from trading_bot.strategy.exit import ExitManager
 
 pytestmark = pytest.mark.critical
 

--- a/trading_bot/tests/test_exit_logic.py
+++ b/trading_bot/tests/test_exit_logic.py
@@ -165,20 +165,67 @@ class TestTimeStop:
         pos = _long_position(hold_type="intraday", entry_time=entry)
         assert exit_manager.check_time_stop(pos, datetime.now(ET)) is False
 
-    def test_time_stop_swing_held_4_days_not_triggered(
+    def test_time_stop_swing_held_4_trading_days_not_triggered(
         self, exit_manager: ExitManager
     ) -> None:
-        """Swing held 4 days — within 5-day max, no exit."""
-        entry = datetime.now(ET) - timedelta(days=4)
+        """Swing held 4 trading days (Mon → Fri) — under the 5-day max."""
+        # 2026-05-04 is a Monday; 2026-05-08 is the following Friday.
+        # Mon → Fri spans Tue, Wed, Thu, Fri = 4 trading days (no holidays).
+        entry = datetime(2026, 5, 4, 10, 0, tzinfo=ET)
+        now = datetime(2026, 5, 8, 16, 0, tzinfo=ET)
         pos = _long_position(hold_type="swing", entry_time=entry)
-        assert exit_manager.check_time_stop(pos, datetime.now(ET)) is False
+        assert exit_manager.check_time_stop(pos, now) is False
 
-    def test_time_stop_swing_held_6_days_triggers(
+    def test_time_stop_swing_held_5_trading_days_triggers(
         self, exit_manager: ExitManager
     ) -> None:
-        entry = datetime.now(ET) - timedelta(days=6)
+        """Swing held exactly 5 trading days (Mon → following Mon)."""
+        # Mon 2026-05-04 → Mon 2026-05-11 spans Tue, Wed, Thu, Fri, Mon
+        # = 5 trading days, which hits the 5-day max.
+        entry = datetime(2026, 5, 4, 10, 0, tzinfo=ET)
+        now = datetime(2026, 5, 11, 10, 0, tzinfo=ET)
         pos = _long_position(hold_type="swing", entry_time=entry)
-        assert exit_manager.check_time_stop(pos, datetime.now(ET)) is True
+        assert exit_manager.check_time_stop(pos, now) is True
+
+    def test_time_stop_swing_thursday_to_tuesday_not_triggered(
+        self, exit_manager: ExitManager
+    ) -> None:
+        """Regression: Thu → Tue is 5 calendar days but only 3 trading
+        days (Fri, Mon, Tue). Under the old calendar-day logic this
+        triggered the stop on day 5; under the new trading-day logic it
+        must not (the position has only had 3 sessions to work).
+        """
+        # Thu 2026-05-07 → Tue 2026-05-12 = 5 calendar days, 3 trading days.
+        entry = datetime(2026, 5, 7, 10, 0, tzinfo=ET)
+        now = datetime(2026, 5, 12, 16, 0, tzinfo=ET)
+        pos = _long_position(hold_type="swing", entry_time=entry)
+        assert exit_manager.check_time_stop(pos, now) is False
+
+    def test_time_stop_swing_skips_holidays(
+        self, exit_manager: ExitManager
+    ) -> None:
+        """Regression: Memorial Day (Mon 2026-05-25) does NOT count as a
+        trading day. Tue 2026-05-19 → Wed 2026-05-27 = 8 calendar days,
+        but only 5 trading days (Wed, Thu, Fri, Tue, Wed) because
+        weekends + Memorial Day are excluded. This is the trigger boundary.
+        """
+        entry = datetime(2026, 5, 19, 10, 0, tzinfo=ET)
+        now = datetime(2026, 5, 27, 16, 0, tzinfo=ET)
+        pos = _long_position(hold_type="swing", entry_time=entry)
+        assert exit_manager.check_time_stop(pos, now) is True
+
+    def test_time_stop_swing_holiday_keeps_position_alive(
+        self, exit_manager: ExitManager
+    ) -> None:
+        """One trading day short due to Memorial Day: must NOT trigger."""
+        # Wed 2026-05-20 → Wed 2026-05-27 = 7 calendar days, but Memorial
+        # Day Mon 2026-05-25 is excluded → 4 trading days (Thu, Fri, Tue,
+        # Wed). Under calendar-day logic this would have triggered at 7
+        # days; under trading-day logic the position keeps running.
+        entry = datetime(2026, 5, 20, 10, 0, tzinfo=ET)
+        now = datetime(2026, 5, 27, 16, 0, tzinfo=ET)
+        pos = _long_position(hold_type="swing", entry_time=entry)
+        assert exit_manager.check_time_stop(pos, now) is False
 
     def test_time_stop_no_entry_time_returns_false(
         self, exit_manager: ExitManager

--- a/trading_bot/tests/test_main_tick.py
+++ b/trading_bot/tests/test_main_tick.py
@@ -6,10 +6,9 @@ through a single deterministic tick without hitting Alpaca."""
 
 from __future__ import annotations
 
-from datetime import date, datetime
+from datetime import date
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
-from zoneinfo import ZoneInfo
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 

--- a/trading_bot/tests/test_main_tick.py
+++ b/trading_bot/tests/test_main_tick.py
@@ -7,6 +7,7 @@ through a single deterministic tick without hitting Alpaca."""
 from __future__ import annotations
 
 from datetime import date, datetime
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 from zoneinfo import ZoneInfo
 
@@ -265,6 +266,72 @@ async def test_pre_market_scan_swallows_refresh_errors(trading_bot):
     trading_bot._sentiment.refresh_all = AsyncMock(side_effect=RuntimeError("api down"))
     # Must not raise — refresh failures are non-fatal
     await trading_bot.pre_market_scan(Market.US)
+
+
+@pytest.mark.asyncio
+async def test_failed_pre_market_scan_does_not_latch_done_flag(trading_bot):
+    """Regression: a failed pre-market scan must NOT latch
+    ``pre_market_done=True`` — otherwise every subsequent tick today
+    would skip the retry and the watchlist would be frozen with
+    whatever stale state existed when the scan blew up.
+
+    Item 6 of risk_infrastructure_gaps.md: the flag write was sitting
+    after the try/except and ran unconditionally, including when the
+    scan raised. Now it lives inside the try and only fires on success.
+
+    Tracks flag state via ``_save_day_flags`` patches so we don't rely
+    on the test fixture's DB path (the fixture sets ``_raw["db"]`` but
+    ``Config.db_path`` reads ``_raw["database"]["path"]`` — a separate
+    bug — so the persistent dev DB is what actually backs the flag).
+    """
+    trading_bot._config.is_trading_day = MagicMock(return_value=True)
+    _open_hours(trading_bot)
+    trading_bot._is_market_in_premarket = MagicMock(return_value=True)
+    trading_bot._is_market_in_execution = MagicMock(return_value=False)
+    trading_bot._is_market_in_winddown = MagicMock(return_value=False)
+    # Force-clear any prior flag state so the pre-market branch runs
+    # (otherwise the fixture's persistent DB short-circuits us).
+    trading_bot._load_day_flags = MagicMock(return_value={})
+    saved_flags_failed: list[dict[str, Any]] = []
+    trading_bot._save_day_flags = MagicMock(
+        side_effect=lambda _today, flags: saved_flags_failed.append(dict(flags)),
+    )
+    # Pre-market scan blows up.
+    trading_bot.pre_market_scan = AsyncMock(side_effect=RuntimeError("scan boom"))
+
+    await trading_bot.tick()
+
+    # No save in the try block means saved_flags carries only writes
+    # from the after-close handlers — and none of them should contain
+    # ``pre_market_done=True`` because nothing in this tick set it.
+    pre_market_writes = [
+        f for f in saved_flags_failed if "pre_market_done" in f
+    ]
+    assert pre_market_writes == [], (
+        f"Failed scan latched pre_market_done: {pre_market_writes}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_successful_pre_market_scan_latches_done_flag(trading_bot):
+    """Sanity: the happy path still latches the flag so we don't
+    re-run the scan every 5-min tick for the rest of the day."""
+    trading_bot._config.is_trading_day = MagicMock(return_value=True)
+    _open_hours(trading_bot)
+    trading_bot._is_market_in_premarket = MagicMock(return_value=True)
+    trading_bot._is_market_in_execution = MagicMock(return_value=False)
+    trading_bot._is_market_in_winddown = MagicMock(return_value=False)
+    trading_bot._load_day_flags = MagicMock(return_value={})
+    saved_flags_ok: list[dict[str, Any]] = []
+    trading_bot._save_day_flags = MagicMock(
+        side_effect=lambda _today, flags: saved_flags_ok.append(dict(flags)),
+    )
+    trading_bot.pre_market_scan = AsyncMock(return_value=None)
+
+    await trading_bot.tick()
+
+    pre_market_writes = [f for f in saved_flags_ok if f.get("pre_market_done")]
+    assert pre_market_writes, "Successful scan must latch pre_market_done"
 
 
 # ---------------------------------------------------------------------------

--- a/trading_bot/tests/test_main_tick.py
+++ b/trading_bot/tests/test_main_tick.py
@@ -307,8 +307,12 @@ async def test_failed_pre_market_scan_does_not_latch_done_flag(trading_bot):
     # No save in the try block means saved_flags carries only writes
     # from the after-close handlers — and none of them should contain
     # ``pre_market_done=True`` because nothing in this tick set it.
+    # Check for the dangerous state — `pre_market_done == True` saved
+    # to disk — rather than the looser "key absent" form. A future
+    # refactor that pre-initialises `flags["pre_market_done"] = False`
+    # before saving would still be safe but would fail the looser test.
     pre_market_writes = [
-        f for f in saved_flags_failed if "pre_market_done" in f
+        f for f in saved_flags_failed if f.get("pre_market_done") is True
     ]
     assert pre_market_writes == [], (
         f"Failed scan latched pre_market_done: {pre_market_writes}"
@@ -335,6 +339,57 @@ async def test_successful_pre_market_scan_latches_done_flag(trading_bot):
 
     pre_market_writes = [f for f in saved_flags_ok if f.get("pre_market_done")]
     assert pre_market_writes, "Successful scan must latch pre_market_done"
+
+
+@pytest.mark.asyncio
+async def test_failed_wind_down_does_not_latch_done_flag(trading_bot):
+    """Sibling of item 6: a failed `wind_down` must NOT latch
+    `wind_down_done=True`. Latching on failure is dangerous here —
+    wind-down closes intraday positions before the close, and a
+    permanently-suppressed retry leaves them open overnight.
+    """
+    trading_bot._config.is_trading_day = MagicMock(return_value=True)
+    _open_hours(trading_bot)
+    trading_bot._is_market_in_premarket = MagicMock(return_value=False)
+    trading_bot._is_market_in_execution = MagicMock(return_value=False)
+    trading_bot._is_market_in_winddown = MagicMock(return_value=True)
+    trading_bot._load_day_flags = MagicMock(return_value={})
+    saved_flags_failed: list[dict[str, Any]] = []
+    trading_bot._save_day_flags = MagicMock(
+        side_effect=lambda _today, flags: saved_flags_failed.append(dict(flags)),
+    )
+    trading_bot.wind_down = AsyncMock(side_effect=RuntimeError("flatten failed"))
+
+    await trading_bot.tick()
+
+    wind_down_writes = [
+        f for f in saved_flags_failed if f.get("wind_down_done") is True
+    ]
+    assert wind_down_writes == [], (
+        f"Failed wind-down latched wind_down_done: {wind_down_writes}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_successful_wind_down_latches_done_flag(trading_bot):
+    """Happy path: successful wind-down latches the flag so we don't
+    re-flatten on every tick in the wind-down window."""
+    trading_bot._config.is_trading_day = MagicMock(return_value=True)
+    _open_hours(trading_bot)
+    trading_bot._is_market_in_premarket = MagicMock(return_value=False)
+    trading_bot._is_market_in_execution = MagicMock(return_value=False)
+    trading_bot._is_market_in_winddown = MagicMock(return_value=True)
+    trading_bot._load_day_flags = MagicMock(return_value={})
+    saved_flags_ok: list[dict[str, Any]] = []
+    trading_bot._save_day_flags = MagicMock(
+        side_effect=lambda _today, flags: saved_flags_ok.append(dict(flags)),
+    )
+    trading_bot.wind_down = AsyncMock(return_value=None)
+
+    await trading_bot.tick()
+
+    wind_down_writes = [f for f in saved_flags_ok if f.get("wind_down_done")]
+    assert wind_down_writes, "Successful wind-down must latch wind_down_done"
 
 
 # ---------------------------------------------------------------------------

--- a/trading_bot/tests/test_main_tick.py
+++ b/trading_bot/tests/test_main_tick.py
@@ -35,7 +35,11 @@ def trading_bot(config, tmp_db_path, monkeypatch):
     """
     monkeypatch.setenv("ALPACA_API_KEY", "test")
     monkeypatch.setenv("ALPACA_SECRET_KEY", "test")
-    config._raw["db"] = {"path": tmp_db_path}
+    # Mutate the existing `database.path` key — `Config.db_path` reads
+    # `_raw["database"]["path"]`. Earlier code wrote `_raw["db"]` (wrong
+    # key) so the bot silently used the persistent dev DB and tests
+    # leaked state into each other.
+    config._raw["database"]["path"] = tmp_db_path
 
     bot = TradingBot(config, mode="normal", dry_run=False)
 
@@ -279,10 +283,9 @@ async def test_failed_pre_market_scan_does_not_latch_done_flag(trading_bot):
     after the try/except and ran unconditionally, including when the
     scan raised. Now it lives inside the try and only fires on success.
 
-    Tracks flag state via ``_save_day_flags`` patches so we don't rely
-    on the test fixture's DB path (the fixture sets ``_raw["db"]`` but
-    ``Config.db_path`` reads ``_raw["database"]["path"]`` — a separate
-    bug — so the persistent dev DB is what actually backs the flag).
+    Tracks flag state via ``_save_day_flags`` patches rather than
+    re-reading the DB — keeps the assertion focused on whether the
+    flag was *written* in this tick, regardless of any prior state.
     """
     trading_bot._config.is_trading_day = MagicMock(return_value=True)
     _open_hours(trading_bot)
@@ -387,7 +390,7 @@ def test_parse_time_helper():
 def test_dry_run_flag_propagates_to_strategy_manager(config, tmp_db_path, monkeypatch):
     monkeypatch.setenv("ALPACA_API_KEY", "test")
     monkeypatch.setenv("ALPACA_SECRET_KEY", "test")
-    config._raw["db"] = {"path": tmp_db_path}
+    config._raw["database"]["path"] = tmp_db_path
     bot = TradingBot(config, mode="normal", dry_run=True)
     if bot._strategy_manager is not None:
         assert bot._strategy_manager._dry_run is True
@@ -396,6 +399,6 @@ def test_dry_run_flag_propagates_to_strategy_manager(config, tmp_db_path, monkey
 def test_construct_with_close_only_mode(config, tmp_db_path, monkeypatch):
     monkeypatch.setenv("ALPACA_API_KEY", "test")
     monkeypatch.setenv("ALPACA_SECRET_KEY", "test")
-    config._raw["db"] = {"path": tmp_db_path}
+    config._raw["database"]["path"] = tmp_db_path
     bot = TradingBot(config, mode="close-only", dry_run=False)
     assert bot._mode == "close-only"

--- a/trading_bot/tests/test_reporting_and_ops.py
+++ b/trading_bot/tests/test_reporting_and_ops.py
@@ -322,7 +322,8 @@ def _notif_config(**overrides) -> dict:
 @pytest.mark.asyncio
 async def test_notifier_send_success():
     n = Notifier(_notif_config())
-    resp = MagicMock(); resp.status_code = 200
+    resp = MagicMock()
+    resp.status_code = 200
     n._session.post = MagicMock(return_value=resp)
     await n.send("title", "msg", priority=3, tags=["x"])
     n._session.post.assert_called_once()
@@ -331,7 +332,8 @@ async def test_notifier_send_success():
 @pytest.mark.asyncio
 async def test_notifier_rate_limit_drops():
     n = Notifier(_notif_config(rate_limit_per_minute=1))
-    resp = MagicMock(); resp.status_code = 200
+    resp = MagicMock()
+    resp.status_code = 200
     n._session.post = MagicMock(return_value=resp)
     await n.send("t", "m1")
     await n.send("t", "m2")  # over limit
@@ -341,7 +343,8 @@ async def test_notifier_rate_limit_drops():
 @pytest.mark.asyncio
 async def test_notifier_handles_http_error():
     n = Notifier(_notif_config())
-    resp = MagicMock(); resp.status_code = 500
+    resp = MagicMock()
+    resp.status_code = 500
     n._session.post = MagicMock(return_value=resp)
     await n.send("t", "m")
     assert n._consecutive_failures == 1
@@ -364,7 +367,8 @@ async def test_notifier_lifecycle():
 @pytest.mark.asyncio
 async def test_notifier_convenience_methods_call_send():
     n = Notifier(_notif_config())
-    resp = MagicMock(); resp.status_code = 200
+    resp = MagicMock()
+    resp.status_code = 200
     n._session.post = MagicMock(return_value=resp)
     await n.trade_entry("SPY", "BUY", 100.0, 10, "rsi_oversold")
     await n.position_closed("SPY", 5.0, "1h", "take_profit")

--- a/trading_bot/tests/test_reporting_and_ops.py
+++ b/trading_bot/tests/test_reporting_and_ops.py
@@ -433,8 +433,14 @@ async def test_notifier_osascript_fallback_swallows_error():
 
 @pytest.fixture
 def health_config(config, tmp_db_path):
-    """Wrap the real Config but override db_path to our temp DB."""
-    config._raw["db"] = {"path": tmp_db_path}
+    """Wrap the real Config but override db_path to our temp DB.
+
+    Mutates the existing `database.path` key (the one `Config.db_path`
+    actually reads). Earlier code wrote `_raw["db"]`, which the property
+    ignored, so health-check tests silently ran against the persistent
+    dev DB.
+    """
+    config._raw["database"]["path"] = tmp_db_path
     return config
 
 
@@ -488,7 +494,7 @@ async def test_health_handler_error_status(health_config):
 async def test_health_handler_swallows_db_errors(health_config, monkeypatch):
     hs = _make_health(health_config)
     # Point at a path that doesn't exist
-    health_config._raw["db"] = {"path": "/nonexistent/path/db.sqlite"}
+    health_config._raw["database"]["path"] = "/nonexistent/path/db.sqlite"
     response = await hs._handle_health(MagicMock())
     assert response.status == 200
 

--- a/trading_bot/tests/test_strategy_manager.py
+++ b/trading_bot/tests/test_strategy_manager.py
@@ -1948,6 +1948,138 @@ class TestCrossStrategyAlpacaCollision:
 
 
 # ---------------------------------------------------------------------------
+# Same-day attempt DB-error escalation (item 5)
+# ---------------------------------------------------------------------------
+
+
+class TestSameDayAttemptDbErrorEscalation:
+    """`_already_attempted_today` flips fail-open → fail-closed after a
+    streak of DB errors.
+
+    The original 2026-04-29 over-firing fix (per-tick same-day-attempt
+    lookup) failed silently when the DB was unreachable: every ticker
+    sailed through the guard, recreating the very pattern the guard
+    was added to stop. A short streak is still tolerated (single
+    SQLite lock from artifact-cache backup), but a sustained streak
+    must skip the entry.
+    """
+
+    def _make_sm(
+        self,
+        base_market_data,
+        base_risk_manager,
+        base_earnings,
+        base_sentiment,
+        base_order_manager,
+        base_portfolio_manager,
+        base_config,
+        tmp_db_path,
+    ) -> StrategyManager:
+        return StrategyManager(
+            strategies=[_StubStrategy(decision=_make_decision())],
+            portfolio_manager=base_portfolio_manager,
+            market_data=base_market_data,
+            order_manager=base_order_manager,
+            risk_manager=base_risk_manager,
+            sentiment=base_sentiment,
+            earnings=base_earnings,
+            config=base_config,
+            db_path=tmp_db_path,
+        )
+
+    def test_single_error_fails_open(
+        self,
+        base_market_data,
+        base_risk_manager,
+        base_earnings,
+        base_sentiment,
+        base_order_manager,
+        base_portfolio_manager,
+        base_config,
+        tmp_db_path,
+    ):
+        sm = self._make_sm(
+            base_market_data, base_risk_manager, base_earnings, base_sentiment,
+            base_order_manager, base_portfolio_manager, base_config, tmp_db_path,
+        )
+        # Use a path that does not exist as a directory so connect() fails.
+        sm._db_path = "/nonexistent/dir/that/does/not/exist.db"
+        # First call: fail open (return False).
+        assert sm._already_attempted_today("SPY", "stub") is False
+        assert sm._db_error_streak == 1
+
+    def test_streak_below_threshold_fails_open(
+        self,
+        base_market_data,
+        base_risk_manager,
+        base_earnings,
+        base_sentiment,
+        base_order_manager,
+        base_portfolio_manager,
+        base_config,
+        tmp_db_path,
+    ):
+        sm = self._make_sm(
+            base_market_data, base_risk_manager, base_earnings, base_sentiment,
+            base_order_manager, base_portfolio_manager, base_config, tmp_db_path,
+        )
+        sm._db_path = "/nonexistent/dir/that/does/not/exist.db"
+        # Two failures (below the threshold of 3): still fail open.
+        assert sm._already_attempted_today("SPY", "stub") is False
+        assert sm._already_attempted_today("QQQ", "stub") is False
+        assert sm._db_error_streak == 2
+
+    def test_streak_at_threshold_fails_closed(
+        self,
+        base_market_data,
+        base_risk_manager,
+        base_earnings,
+        base_sentiment,
+        base_order_manager,
+        base_portfolio_manager,
+        base_config,
+        tmp_db_path,
+    ):
+        sm = self._make_sm(
+            base_market_data, base_risk_manager, base_earnings, base_sentiment,
+            base_order_manager, base_portfolio_manager, base_config, tmp_db_path,
+        )
+        sm._db_path = "/nonexistent/dir/that/does/not/exist.db"
+        # Third consecutive failure must flip to fail-closed.
+        assert sm._already_attempted_today("SPY", "stub") is False
+        assert sm._already_attempted_today("QQQ", "stub") is False
+        assert sm._already_attempted_today("XLF", "stub") is True
+        assert sm._db_error_streak == 3
+
+    def test_success_resets_streak(
+        self,
+        base_market_data,
+        base_risk_manager,
+        base_earnings,
+        base_sentiment,
+        base_order_manager,
+        base_portfolio_manager,
+        base_config,
+        tmp_db_path,
+    ):
+        sm = self._make_sm(
+            base_market_data, base_risk_manager, base_earnings, base_sentiment,
+            base_order_manager, base_portfolio_manager, base_config, tmp_db_path,
+        )
+        # Build up a streak against a bad path...
+        sm._db_path = "/nonexistent/dir/that/does/not/exist.db"
+        sm._already_attempted_today("SPY", "stub")
+        sm._already_attempted_today("QQQ", "stub")
+        assert sm._db_error_streak == 2
+        # ...then heal the DB. A successful lookup must reset to zero
+        # so subsequent transient errors don't immediately fail-closed.
+        sm._db_path = tmp_db_path
+        result = sm._already_attempted_today("SPY", "stub")
+        assert result is False  # No row → not attempted today
+        assert sm._db_error_streak == 0
+
+
+# ---------------------------------------------------------------------------
 # check_exits
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Bundles three correctness gaps from `risk_infrastructure_gaps.md` items 5–7. All three were surfaced by the 2026-05-07 `/python-review` of the trading-critical path and are pre-live blockers separate from items 1–4 already shipped in PRs #76–#79.

Plus a small bonus fix uncovered while writing the tests.

## Why bundle

Three independent files, ~370 lines net (mostly tests), low regression risk. Splitting into three PRs would be churn — same review surface, same test run, no shared state.

## 5. `_already_attempted_today` fail-closed escalation
[strategy_manager.py](trading_bot/strategy/strategy_manager.py)

The 2026-04-29 over-firing protection silently failed open whenever the SQLite lookup blew up (DB corruption, persistent lock). Every ticker sailed through the guard, recreating the very pattern the guard was added to stop.

- Single transient errors still fail OPEN (artifact-cache backup briefly locks the DB → don't block legit trades).
- After 3 consecutive failures, flip to fail CLOSED — DB corruption is exactly when in-memory portfolio state is also stale.
- Streak resets on first successful lookup.

## 6. `pre_market_done` flag inside the try
[main.py](trading_bot/main.py)

The flag was being latched unconditionally after the try/except. A failed scan that latched the flag would freeze the watchlist for the rest of the day — every subsequent tick would see `pre_market_done=True` and skip the retry.

Moved the flag write + ranked-watchlist persist + `_save_day_flags` call inside the try so they only fire after `pre_market_scan` actually returns.

## 7. `check_time_stop` swing branch counts trading days
[exit.py](trading_bot/strategy/exit.py)

`max_hold_days=5` was being applied as wall-clock days. A Thursday entry hit the stop the following Tuesday — only 3 trading days away. Now counts NYSE trading days via the existing `HolidayCalendar`, skipping weekends and US market holidays (Memorial Day, July 4, etc.).

Intraday `time_stop_hours` branch is unchanged (wall-clock by design).

## Bonus: test fixture DB-path fix

Five sites across `test_main_tick.py` and `test_reporting_and_ops.py` were writing `config._raw["db"]` to redirect the bot's DB to a per-test temp file. But `Config.db_path` reads `_raw["database"]["path"]` — the wrong key. The bot silently used the persistent dev DB at `trading_bot/data/trading_bot.db` for every "isolated" test, leaking state between runs.

Symptom: `test_tick_runs_wind_down_within_window` flaked depending on whether prior runs had latched `wind_down_done=True`. Now passes deterministically.

## Test plan

- [x] `TestSameDayAttemptDbErrorEscalation` (4 cases): single-error fail-open, sub-threshold streak fail-open, threshold fail-closed, success resets streak.
- [x] `test_failed_pre_market_scan_does_not_latch_done_flag` and the corresponding success case — track `_save_day_flags` writes.
- [x] `TestTimeStop` swing cases replaced with deterministic dated cases. Added regression coverage for Thu→Tue (3 trading days, must NOT trigger) and Memorial-Day-weekend pushing a 7-calendar-day window back below 5 trading days.
- [x] Full test suite: **838 passing** (was 837 + 1 flake before the fixture fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)