### PR TITLE
chore(quality): remove dead code, gate vulture at 80% confidence

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -73,6 +73,16 @@ jobs:
         # creep back.
         run: ruff check .
 
+      - name: Vulture (dead code, high confidence)
+        # 80%+ confidence threshold — vulture is noisy below that on a
+        # codebase with reflection-style accessors and test-only entry
+        # points. The 100% finding (`what_to_show` in market_data) and
+        # the placeholder `_check_correlation` were both removed
+        # 2026-05-08; this gate keeps similar dead code from creeping
+        # back. Tests are excluded — pytest fixtures and parametrize
+        # produce false positives.
+        run: vulture trading_bot/ --min-confidence 80 --exclude trading_bot/tests
+
       - name: Bandit (MEDIUM+HIGH severity)
         # MEDIUM+HIGH gate: catches eval/exec, subprocess shell=True,
         # weak crypto, hardcoded passwords, pickle on untrusted data,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,3 +7,4 @@ ruff==0.15.12
 mypy==1.20.2
 bandit==1.9.4
 pip-audit==2.10.0
+vulture==2.16

--- a/trading_bot/data/market_data.py
+++ b/trading_bot/data/market_data.py
@@ -232,7 +232,6 @@ class MarketDataManager:
         exchange: str = "US",
         bar_size: str = "1 min",
         duration: str = "1 D",
-        what_to_show: str = "TRADES",
     ) -> list[dict[str, Any]]:
         """Fetch historical bars from Alpaca (synchronous under the async wrapper)."""
         timeframe: TimeFrame = self._parse_bar_size(bar_size)

--- a/trading_bot/strategy/entry.py
+++ b/trading_bot/strategy/entry.py
@@ -266,16 +266,13 @@ class EntryEvaluator:
                 f"{sector_count}/{max_sector}"
             )
 
-        # -- 14. Correlation check (skip if no positions open) ---------------
-        # Correlation is checked at portfolio level; we log but do not
-        # block in Phase 1 with max 2 positions (low overlap risk).
-        # The check is here for Phase 2/3 readiness.
-        if open_count > 0:
-            corr_ok, corr_reason = self._check_correlation(ticker)
-            if not corr_ok:
-                rejections.append(corr_reason)
+        # (Correlation check was removed — it always returned True/no-block,
+        # so the body produced no behavior. Sector exposure check above
+        # already covers the within-sector overlap case for Phase 1. Real
+        # return-based correlation is a Phase 2+ feature; reintroduce
+        # then with actual blocking logic and tests.)
 
-        # -- 15. Daily trade count -------------------------------------------
+        # -- 14. Daily trade count -------------------------------------------
         max_daily: int = self._config.get_max_daily_trades()
         daily_count: int = self._get_daily_trade_count()
         if daily_count >= max_daily:
@@ -517,44 +514,6 @@ class EntryEvaluator:
             if GICS_SECTOR.get(pos_ticker, "") == sector:
                 count += 1
         return count
-
-    def _check_correlation(self, ticker: str) -> tuple[bool, str]:
-        """Check correlation with existing open positions.
-
-        Uses the configured correlation threshold (0.85).  For Phase 1
-        with max 2 positions this is a lightweight check -- we compare
-        sectors as a proxy.  Full return-correlation requires historical
-        data and will be implemented for Phase 2+.
-        """
-        sector: str = GICS_SECTOR.get(ticker, "Unknown")
-
-        try:
-            conn: sqlite3.Connection = sqlite3.connect(self._db_path)
-            conn.row_factory = sqlite3.Row
-            positions: list[dict[str, Any]] = repo.get_open_positions(conn)
-            conn.close()
-        except sqlite3.Error:
-            logger.exception("Error checking correlation")
-            return True, ""
-
-        for pos in positions:
-            pos_ticker: str = pos.get("ticker", "")
-            pos_sector: str = GICS_SECTOR.get(pos_ticker, "Unknown")
-            # Same sector is a proxy for high correlation at Phase 1 scale.
-            # Sector exposure is checked separately; this is an additional
-            # safeguard for within-sector pairs.
-            if pos_sector == sector and pos_sector != "Unknown":
-                logger.debug(
-                    "%s and %s are in the same sector (%s); flagging correlation",
-                    ticker,
-                    pos_ticker,
-                    sector,
-                )
-                # We do not block here -- sector exposure check handles limits.
-                # This method is a placeholder for Phase 2+ return-based
-                # correlation analysis.
-
-        return True, ""
 
     def _get_daily_trade_count(self) -> int:
         """Get today's trade count from the DB."""


### PR DESCRIPTION
Vulture-led dead-code cleanup. Two real removals; the rest of vulture's 60% findings are false positives (test-only entry points, public API surface, getattr-style accessors) and would be churn to delete.

## Removed

- **\`get_historical_bars(what_to_show=...)\` parameter** ([market_data.py:235](trading_bot/data/market_data.py:235)). Vestigial IBKR-era kwarg that never reached the Alpaca \`StockBarsRequest\`. Vulture 100% confidence; no callers pass it.
- **\`_check_correlation\` method + call site in [entry.py](trading_bot/strategy/entry.py)**. Function always returned \`(True, "")\` — body just logged same-sector matches and fell through. Sector-exposure check above the call site already covers the within-sector overlap concern. Real return-based correlation is a Phase 2+ feature; reintroduce with blocking logic and tests when needed. Tracked as MEDIUM in \`risk_infrastructure_gaps.md\`.

## Gate added

\`vulture trading_bot/ --min-confidence 80 --exclude trading_bot/tests\` in static-checks. 80% threshold avoids the false-positive zone (60% flags ~80 items, almost all reachable via reflection or test-only entry points). Pinned \`vulture==2.16\` in \`requirements-dev.txt\`.

## Test plan

- [x] \`vulture trading_bot/ --min-confidence 80 --exclude trading_bot/tests\` exits 0
- [x] \`ruff check .\` clean
- [x] 841 tests still passing
- [x] CI static-checks gate runs the new vulture step

🤖 Generated with [Claude Code](https://claude.com/claude-code)