### PR TITLE
fix(risk-infra): defer loss-cooldown record_outcome to broker fill (item 9)

### DIFF
--- a/trading_bot/execution/order_manager.py
+++ b/trading_bot/execution/order_manager.py
@@ -25,7 +25,7 @@ import logging
 import sqlite3
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Callable
 from zoneinfo import ZoneInfo
 
 from alpaca.trading.client import TradingClient
@@ -55,6 +55,16 @@ if TYPE_CHECKING:
 logger: logging.Logger = logging.getLogger(__name__)
 
 ET: ZoneInfo = TZ_EASTERN
+
+
+# Callback fired when a strategy-driven exit order (place_exit /
+# place_limit_exit) actually FILLS at the broker. Args:
+# (strategy_id, ticker, filled_qty, realized_pnl). The pnl is computed
+# from the real broker fill price, so the loss-cooldown tracker sees
+# slippage-true outcomes rather than signal-time mid-price estimates.
+# Bracket-leg exits (stop/target/trail) intentionally do not fire this
+# callback today — see item #9 follow-up in risk-infrastructure-gaps.
+ExitFillCallback = Callable[[str, str, float, float], None]
 
 
 # ---------------------------------------------------------------------------
@@ -158,6 +168,14 @@ class OrderManager:
         # and place_entry constructing the _ActiveOrder. Cleared once the
         # tracker takes ownership.
         self._pending_db_trade_ids: dict[int, int] = {}
+        # Optional observer fired on strategy-driven exit fills, with the
+        # actual broker fill price. StrategyManager wires this to the
+        # loss-cooldown tracker so slippage is reflected in the streak.
+        self._exit_fill_callback: ExitFillCallback | None = None
+
+    def set_exit_fill_callback(self, callback: ExitFillCallback | None) -> None:
+        """Register the strategy-exit fill observer (idempotent)."""
+        self._exit_fill_callback = callback
 
     # ------------------------------------------------------------------
     # Tick-model hydration + status check
@@ -453,21 +471,51 @@ class OrderManager:
                     # accesses across this block.
                     if exit_order.status.value == "filled":  # type: ignore[union-attr]
                         exit_px: float = float(exit_order.filled_avg_price or 0)  # type: ignore[union-attr]
+                        # Prefer the broker's reported filled_qty over the
+                        # cached entry-fill qty so partial-fill exits (rare
+                        # but possible) feed the cooldown tracker the qty
+                        # that actually transacted, not the qty we sent.
+                        filled_exit_qty: float = float(
+                            exit_order.filled_qty or 0  # type: ignore[union-attr]
+                        )
+                        if filled_exit_qty <= 0:
+                            filled_exit_qty = active.filled_shares
                         reason_str: str = active.exit_reason or "strategy_exit"
                         logger.info(
-                            "Strategy exit FILLED: %s reason=%s @ %.4f (trade_id=%d)",
-                            active.ticker, reason_str, exit_px, trade_id,
+                            "Strategy exit FILLED: %s reason=%s @ %.4f qty=%.4f (trade_id=%d)",
+                            active.ticker, reason_str, exit_px,
+                            filled_exit_qty, trade_id,
                         )
                         await self._close_position(
                             trade_id, active, exit_px, reason_str,
                         )
                         pnl_strategy: float = (
-                            (exit_px - active.entry_price) * active.filled_shares
+                            (exit_px - active.entry_price) * filled_exit_qty
                         )
                         await self._notifier.position_closed(
                             ticker=active.ticker, pnl=pnl_strategy,
                             hold_time="", exit_reason=reason_str,
                         )
+                        # Deferred loss-cooldown bookkeeping — keyed on the
+                        # actual broker fill price, not the signal-time mid
+                        # that check_exits had to estimate. Fire only on
+                        # FILL; cancel/expire/reject leaves the position
+                        # open and is handled by the rollback branch below
+                        # without touching the cooldown streak.
+                        cb: ExitFillCallback | None = self._exit_fill_callback
+                        if cb is not None and active.strategy_id:
+                            try:
+                                cb(
+                                    active.strategy_id,
+                                    active.ticker,
+                                    filled_exit_qty,
+                                    pnl_strategy,
+                                )
+                            except Exception:
+                                logger.exception(
+                                    "exit_fill_callback raised for %s (trade_id=%d)",
+                                    active.ticker, trade_id,
+                                )
                     elif exit_order.status.value in ("canceled", "expired", "rejected"):  # type: ignore[union-attr]
                         # Limit exit didn't fill (e.g. price gapped through
                         # the limit). Roll back to STOP_AND_TARGET_ACTIVE so

--- a/trading_bot/execution/order_manager.py
+++ b/trading_bot/execution/order_manager.py
@@ -488,6 +488,7 @@ class OrderManager:
                         )
                         await self._close_position(
                             trade_id, active, exit_px, reason_str,
+                            filled_qty=filled_exit_qty,
                         )
                         pnl_strategy: float = (
                             (exit_px - active.entry_price) * filled_exit_qty
@@ -1347,8 +1348,15 @@ class OrderManager:
     async def _close_position(
         self, trade_id: int, active: _ActiveOrder,
         exit_price: float, exit_reason: str,
+        filled_qty: float | None = None,
     ) -> None:
-        """Mark a position as CLOSED in the DB and clean up tracking."""
+        """Mark a position as CLOSED in the DB and clean up tracking.
+
+        ``filled_qty`` lets the caller override the share count used for
+        P&L when the broker fill diverges from ``active.filled_shares``
+        (e.g. a partial-fill exit). Defaults to ``active.filled_shares``
+        for callers that don't have a broker-reported quantity in hand.
+        """
         now_str: str = datetime.now(tz=ET).isoformat()
 
         active.status = PositionStatus.CLOSED
@@ -1356,7 +1364,11 @@ class OrderManager:
 
         # Compute realised P&L while we still have the active order in hand.
         # The bot is commission-free so net == gross; FX is 1.0 for USD.
-        gross_pnl: float = (exit_price - active.entry_price) * active.filled_shares
+        qty_for_pnl: float = (
+            filled_qty if filled_qty is not None and filled_qty > 0
+            else active.filled_shares
+        )
+        gross_pnl: float = (exit_price - active.entry_price) * qty_for_pnl
 
         # B3: target the trades row by trades.id, not positions.id. The two
         # tables have independent autoincrements; pre-fix this UPDATE

--- a/trading_bot/strategy/strategy_manager.py
+++ b/trading_bot/strategy/strategy_manager.py
@@ -135,6 +135,23 @@ class StrategyManager:
         # Reset on any success. See `_DB_ERROR_FAIL_CLOSED_THRESHOLD`.
         self._db_error_streak: int = 0
 
+        # Wire the loss-cooldown tracker to the order manager's exit-fill
+        # observer so outcomes are recorded with the actual broker fill
+        # price (slippage-true) rather than the signal-time mid the strategy
+        # saw when emitting the exit. Duck-typed because OrderManager is
+        # passed as ``Any`` to keep test stubs simple.
+        if self._loss_cooldown is not None:
+            setter = getattr(self._order_manager, "set_exit_fill_callback", None)
+            if callable(setter):
+                tracker: LossCooldownTracker = self._loss_cooldown
+
+                def _on_exit_fill(
+                    strategy_id: str, _ticker: str, _qty: float, pnl: float,
+                ) -> None:
+                    tracker.record_outcome(strategy_id, pnl)
+
+                setter(_on_exit_fill)
+
     @property
     def strategies(self) -> list[StrategyBase]:
         return list(self._strategies)
@@ -469,22 +486,11 @@ class StrategyManager:
                 portfolio.record_exit(shares, current_price, entry_price)
                 exits += 1
 
-                # Loss-cooldown bookkeeping — must follow record_exit so the
-                # virtual portfolio's tally is consistent with the tracker's.
-                #
-                # KNOWN LIMITATION (tracked as item #9 in the risk-infra
-                # gaps memo): `current_price` here is the live mid at
-                # signal time, not the actual broker fill price. Under
-                # paper this is harmless; under live the loss-cooldown
-                # threshold will activate slightly later than the real
-                # P&L would justify when slippage is significant.
-                # Fix path is a deferred record_outcome keyed on
-                # exit_order_id (set when the fill is polled in
-                # `_check_order_statuses`) — non-trivial refactor, kept
-                # separate from this correctness pass.
-                if self._loss_cooldown is not None:
-                    pnl: float = shares * (current_price - entry_price)
-                    self._loss_cooldown.record_outcome(strategy.strategy_id, pnl)
+                # Loss-cooldown bookkeeping happens later, when
+                # OrderManager polls the exit order and observes the
+                # actual broker fill price. That callback is registered
+                # in __init__. Recording eagerly here would use the
+                # signal-time mid and miss slippage.
 
         return exits
 

--- a/trading_bot/tests/test_order_manager_lifecycle.py
+++ b/trading_bot/tests/test_order_manager_lifecycle.py
@@ -1275,3 +1275,152 @@ class TestPlaceLimitExit:
             ticker="SPY", qty=0, limit_price=100.0, reason="bug",
         )
         assert order_id is None
+
+
+# ---------------------------------------------------------------------------
+# Strategy-exit fill callback (item #9 follow-up)
+# ---------------------------------------------------------------------------
+
+
+class TestStrategyExitFillCallback:
+    """The OrderManager invokes ``exit_fill_callback`` when a strategy-driven
+    exit FILLS — with the actual broker fill price, not the signal-time
+    mid. The callback must NOT fire on cancel/expire/reject, since the
+    position is left open and no realised P&L exists.
+    """
+
+    def _seed_closing_position(
+        self, om: OrderManager, *, exit_oid: str = "exit-1",
+        entry_price: float = 100.0, filled_shares: float = 10.0,
+        strategy_id: str | None = "mean_reversion",
+    ) -> _ActiveOrder:
+        active = _ActiveOrder(
+            trade_id=1,
+            ticker="SPY",
+            exchange="US",
+            alpaca_entry_order_id="entry-1",
+            alpaca_exit_order_id=exit_oid,
+            status=PositionStatus.CLOSING,
+            entry_shares=filled_shares,
+            filled_shares=filled_shares,
+            entry_price=entry_price,
+            stop_price=entry_price * 0.98,
+            target_price=entry_price * 1.04,
+            hold_type="intraday",
+            strategy_id=strategy_id,
+            exit_reason="rsi_normalized",
+        )
+        om._active_orders[1] = active
+        om._update_position_status(1, PositionStatus.CLOSING)
+        return active
+
+    @pytest.mark.asyncio
+    async def test_callback_fires_with_actual_fill_price(
+        self, config, tmp_db_path: str, mock_notifier,
+    ):
+        """Signal-time mid was 95.00; broker filled at 94.85 (15c slippage)
+        — callback must see the slippage-true P&L, not the signal-time one.
+        """
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        # Seed a trades row so _close_position can update it.
+        om._create_position_record(_entry("SPY"))
+        active = self._seed_closing_position(om)
+        active.db_trade_id = 1
+
+        captured: list[tuple[str, str, float, float]] = []
+        om.set_exit_fill_callback(
+            lambda sid, tkr, qty, pnl: captured.append((sid, tkr, qty, pnl)),
+        )
+
+        # Broker fill at 94.85 — 15c worse than the signal mid 95.00.
+        om._gw.client.get_order_by_id = MagicMock(
+            return_value=_alpaca_order(
+                "exit-1", "filled", filled_qty=10.0, filled_avg_price=94.85,
+            ),
+        )
+
+        await om._check_order_statuses()
+
+        assert active.status == PositionStatus.CLOSED
+        assert len(captured) == 1
+        sid, tkr, qty, pnl = captured[0]
+        assert sid == "mean_reversion"
+        assert tkr == "SPY"
+        assert qty == 10.0
+        # Real P&L = (94.85 - 100) * 10 = -51.50, not the -50.00 a
+        # signal-time recording would have produced from mid=95.00.
+        assert pnl == pytest.approx(-51.50, rel=1e-6)
+
+    @pytest.mark.asyncio
+    async def test_callback_not_fired_on_cancelled_exit(
+        self, config, tmp_db_path: str, mock_notifier,
+    ):
+        """A limit exit that gets cancelled rolls back to
+        STOP_AND_TARGET_ACTIVE — the position remains open, so no
+        outcome is recorded.
+        """
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        active = self._seed_closing_position(om)
+
+        captured: list[Any] = []
+        om.set_exit_fill_callback(lambda *args: captured.append(args))
+
+        om._gw.client.get_order_by_id = MagicMock(
+            return_value=_alpaca_order("exit-1", "canceled"),
+        )
+
+        await om._check_order_statuses()
+
+        assert active.status == PositionStatus.STOP_AND_TARGET_ACTIVE
+        assert captured == []
+
+    @pytest.mark.asyncio
+    async def test_callback_skipped_when_strategy_id_unknown(
+        self, config, tmp_db_path: str, mock_notifier,
+    ):
+        """Drain/recovery exits without a sleeve label must not fire the
+        cooldown callback — there's no strategy to charge the loss to.
+        """
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        om._create_position_record(_entry("SPY"))
+        active = self._seed_closing_position(om, strategy_id=None)
+        active.db_trade_id = 1
+
+        captured: list[Any] = []
+        om.set_exit_fill_callback(lambda *args: captured.append(args))
+
+        om._gw.client.get_order_by_id = MagicMock(
+            return_value=_alpaca_order(
+                "exit-1", "filled", filled_qty=10.0, filled_avg_price=99.0,
+            ),
+        )
+
+        await om._check_order_statuses()
+        assert active.status == PositionStatus.CLOSED
+        assert captured == []
+
+    @pytest.mark.asyncio
+    async def test_callback_exception_does_not_crash_status_poll(
+        self, config, tmp_db_path: str, mock_notifier,
+    ):
+        """A misbehaving observer must not derail order-state reconciliation.
+        The fill still completes; the callback failure is logged only.
+        """
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        om._create_position_record(_entry("SPY"))
+        active = self._seed_closing_position(om)
+        active.db_trade_id = 1
+
+        def boom(*_args):
+            raise RuntimeError("tracker offline")
+
+        om.set_exit_fill_callback(boom)
+
+        om._gw.client.get_order_by_id = MagicMock(
+            return_value=_alpaca_order(
+                "exit-1", "filled", filled_qty=10.0, filled_avg_price=99.0,
+            ),
+        )
+
+        await om._check_order_statuses()
+        assert active.status == PositionStatus.CLOSED

--- a/trading_bot/tests/test_order_manager_lifecycle.py
+++ b/trading_bot/tests/test_order_manager_lifecycle.py
@@ -1424,3 +1424,109 @@ class TestStrategyExitFillCallback:
 
         await om._check_order_statuses()
         assert active.status == PositionStatus.CLOSED
+
+    @pytest.mark.asyncio
+    async def test_partial_fill_uses_broker_qty_for_callback_and_db(
+        self, config, tmp_db_path: str, mock_notifier,
+    ):
+        """A partial-fill exit must report the same qty-true P&L to both
+        the cooldown callback AND the trades-table row. Previously,
+        ``_close_position`` recomputed using ``active.filled_shares``
+        while the callback used ``exit_order.filled_qty`` — the two
+        diverged on partial fills.
+        """
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        om._create_position_record(_entry("SPY", shares=10, price=100.0))
+        active = self._seed_closing_position(
+            om, entry_price=100.0, filled_shares=10.0,
+        )
+        active.db_trade_id = 1
+
+        captured: list[tuple[str, str, float, float]] = []
+        om.set_exit_fill_callback(
+            lambda sid, tkr, qty, pnl: captured.append((sid, tkr, qty, pnl)),
+        )
+
+        # Only 4 of 10 shares fill at 95.00 — the position closes but
+        # the realised loss is bounded by the partial qty.
+        om._gw.client.get_order_by_id = MagicMock(
+            return_value=_alpaca_order(
+                "exit-1", "filled", filled_qty=4.0, filled_avg_price=95.0,
+            ),
+        )
+
+        await om._check_order_statuses()
+
+        # Callback sees the broker-reported qty (4), not the entry qty (10).
+        assert len(captured) == 1
+        _sid, _tkr, qty, pnl = captured[0]
+        assert qty == 4.0
+        assert pnl == pytest.approx(-20.0, rel=1e-6)  # (95 - 100) * 4
+
+        # And the trades row was written with the SAME qty-true P&L.
+        conn = sqlite3.connect(tmp_db_path)
+        try:
+            row = conn.execute(
+                "SELECT gross_pnl, net_pnl, exit_price FROM trades WHERE id = 1"
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row is not None
+        gross_pnl, net_pnl, exit_price = row
+        assert gross_pnl == pytest.approx(-20.0, rel=1e-6)
+        assert net_pnl == pytest.approx(-20.0, rel=1e-6)
+        assert exit_price == pytest.approx(95.0, rel=1e-6)
+
+    @pytest.mark.asyncio
+    async def test_callback_fires_via_place_limit_exit_path(
+        self, config, tmp_db_path: str, mock_notifier,
+    ):
+        """``place_limit_exit`` transitions to CLOSING and sets
+        ``alpaca_exit_order_id`` the same way ``place_exit`` does, so
+        the same _check_order_statuses fill branch handles both. This
+        test seeds the position via the real ``place_limit_exit`` call
+        to guard against future drift between the two paths.
+        """
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        # Real entry → real DB row → real trades row, so _close_position
+        # has something to update.
+        om._create_position_record(_entry("SPY"))
+        active = _ActiveOrder(
+            trade_id=1, ticker="SPY", exchange="US",
+            alpaca_entry_order_id="entry-1",
+            status=PositionStatus.STOP_AND_TARGET_ACTIVE,
+            entry_shares=10.0, filled_shares=10.0,
+            entry_price=100.0, stop_price=98.0, target_price=104.0,
+            hold_type="intraday", strategy_id="mean_reversion",
+            db_trade_id=1,
+        )
+        om._active_orders[1] = active
+
+        om._gw.client.submit_order = MagicMock(
+            return_value=_alpaca_order("exit-limit-1", "new"),
+        )
+        order_id = await om.place_limit_exit(
+            ticker="SPY", qty=10, limit_price=99.50, reason="time_stop",
+        )
+        assert order_id == "exit-limit-1"
+        assert active.status == PositionStatus.CLOSING
+
+        captured: list[tuple[str, str, float, float]] = []
+        om.set_exit_fill_callback(
+            lambda sid, tkr, qty, pnl: captured.append((sid, tkr, qty, pnl)),
+        )
+
+        om._gw.client.get_order_by_id = MagicMock(
+            return_value=_alpaca_order(
+                "exit-limit-1", "filled",
+                filled_qty=10.0, filled_avg_price=99.40,
+            ),
+        )
+        await om._check_order_statuses()
+
+        assert active.status == PositionStatus.CLOSED
+        assert len(captured) == 1
+        sid, _tkr, qty, pnl = captured[0]
+        assert sid == "mean_reversion"
+        assert qty == 10.0
+        assert pnl == pytest.approx(-6.0, rel=1e-6)  # (99.40 - 100) * 10

--- a/trading_bot/tests/test_strategy_manager_gates.py
+++ b/trading_bot/tests/test_strategy_manager_gates.py
@@ -410,10 +410,17 @@ class TestLossCooldownGate:
         order_manager.place_entry.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_check_exits_records_loss_outcome(
+    async def test_check_exits_defers_outcome_to_fill_callback(
         self, market_data, risk_manager, order_manager, sentiment, earnings,
         portfolio_manager, tmp_db_path,
     ):
+        """``check_exits`` must NOT record an outcome eagerly.
+
+        Recording at signal time would use the live mid (``current_price``)
+        and silently miss broker slippage. The tracker is fed by the
+        ``exit_fill_callback`` from OrderManager once the actual fill
+        is polled. Item #9 of the 2026-05-07 risk-infra gaps memo.
+        """
         cfg = _config()
         tracker = LossCooldownTracker(
             db_path=tmp_db_path,
@@ -426,8 +433,6 @@ class TestLossCooldownGate:
         market_data.get_latest_price = MagicMock(return_value=95.0)
 
         strategy = _StubStrategy("stub", None)
-        # Force exit
-        strategy._exit_signal = ExitSignal(should_exit=True, reason="stop_loss")
         strategy.evaluate_exit = lambda *a, **kw: ExitSignal(
             should_exit=True, reason="stop_loss",
         )
@@ -440,12 +445,75 @@ class TestLossCooldownGate:
             earnings=earnings, config=cfg, db_path=tmp_db_path,
             loss_cooldown=tracker,
         )
+        # Broker order goes out twice — but the tracker still sees no
+        # losses until the fill callback fires.
         await sm.check_exits()
-        # First loss recorded; not yet on cooldown (threshold=2)
+        await sm.check_exits()
+        assert order_manager.place_exit.await_count == 2
         assert tracker.is_on_cooldown("stub")[0] is False
-        await sm.check_exits()
-        # Second consecutive loss → cooldown engaged
+
+    @pytest.mark.asyncio
+    async def test_fill_callback_records_actual_pnl(
+        self, market_data, risk_manager, order_manager, sentiment, earnings,
+        portfolio_manager, tmp_db_path,
+    ):
+        """The registered fill callback feeds the tracker the broker P&L.
+
+        Two consecutive losing fills must engage the cooldown — exercising
+        the path that previously fired eagerly from ``check_exits``.
+        """
+        cfg = _config()
+        tracker = LossCooldownTracker(
+            db_path=tmp_db_path,
+            config=LossCooldownConfig(enabled=True, threshold_losses=2),
+        )
+
+        captured: dict[str, Any] = {}
+
+        def fake_set_callback(cb):
+            captured["cb"] = cb
+
+        order_manager.set_exit_fill_callback = MagicMock(
+            side_effect=fake_set_callback,
+        )
+
+        StrategyManager(
+            strategies=[_StubStrategy("stub", None)],
+            portfolio_manager=portfolio_manager,
+            market_data=market_data, order_manager=order_manager,
+            risk_manager=risk_manager, sentiment=sentiment,
+            earnings=earnings, config=cfg, db_path=tmp_db_path,
+            loss_cooldown=tracker,
+        )
+
+        cb = captured.get("cb")
+        assert callable(cb), "StrategyManager must register exit_fill_callback"
+
+        # Simulate two losing strategy-driven exit fills coming back from
+        # _check_order_statuses on subsequent ticks.
+        cb("stub", "SPY", 3.0, -15.30)
+        assert tracker.is_on_cooldown("stub")[0] is False
+        cb("stub", "SPY", 3.0, -8.05)
         assert tracker.is_on_cooldown("stub")[0] is True
+
+    @pytest.mark.asyncio
+    async def test_no_callback_registration_without_loss_cooldown(
+        self, market_data, risk_manager, order_manager, sentiment, earnings,
+        portfolio_manager, tmp_db_path,
+    ):
+        """Without a tracker, the wiring is skipped — OrderManager stays
+        free of a stray reference to a None tracker."""
+        cfg = _config()
+        order_manager.set_exit_fill_callback = MagicMock()
+        StrategyManager(
+            strategies=[_StubStrategy("stub", None)],
+            portfolio_manager=portfolio_manager,
+            market_data=market_data, order_manager=order_manager,
+            risk_manager=risk_manager, sentiment=sentiment,
+            earnings=earnings, config=cfg, db_path=tmp_db_path,
+            loss_cooldown=None,
+        )
+        order_manager.set_exit_fill_callback.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes the last open item (item 9) from the 2026-05-07 risk-infrastructure gaps review.

Previously, `StrategyManager.check_exits` called `loss_cooldown.record_outcome(strategy_id, pnl)` immediately after `place_exit` returned, where `pnl = shares * (current_price - entry_price)` and `current_price` was the signal-time mid — **not** the actual broker fill price. Under paper this is harmless; under live, a $10 realised loss with $1 of slippage looks like $9 to the cooldown tracker, so the 3-loss threshold engages one trade later than the real P&L would justify.

## What changed

- **`OrderManager`** now exposes `set_exit_fill_callback(cb)`. The strategy-exit fill branch of `_check_order_statuses` recomputes P&L from `exit_order.filled_avg_price` × `exit_order.filled_qty` and invokes the callback only when the order **actually fills**. Cancel/expire/reject paths leave the position open and skip recording. Callback exceptions are caught so a misbehaving observer can't derail status reconciliation.
- **`StrategyManager.__init__`** wires the callback to `loss_cooldown.record_outcome` (duck-typed via `getattr` so existing test stubs keep working). The eager call in `check_exits` and the inline "KNOWN LIMITATION" comment block are gone.
- Drain/recovery exits without a `strategy_id` are skipped (no sleeve to charge).
- Partial-fill edge case: callback uses `exit_order.filled_qty` (with `active.filled_shares` fallback if Alpaca reports zero), not the signal-time `shares`.

## Caveat

Bracket-leg exits (stop/target/trail fills polled at `_check_order_statuses` lines ~393–432) still bypass the cooldown tracker entirely. That's pre-existing behaviour, intentionally out of scope for item 9, and worth a separate item if cooldowns should react to those exits too.

## Tick-ordering check

`main.py` runs `_check_order_statuses` (step 6) **before** `scan_for_entries` (step 12) and `check_exits` (step 13). So on the tick after `place_exit`, the fill is observed and the cooldown updated before the next entry scan consults `is_on_cooldown` — the deferred recording does not let an extra entry slip through.

## Test plan

- [x] `pytest trading_bot/tests/` — 865 passed, 2 skipped (pre-existing)
- [x] `ruff check` — clean on touched files
- [x] `mypy --ignore-missing-imports` on the CI critical path (`main.py`, `config.py`, `execution/`, `gateway/`, `strategy_manager.py`) — clean
- [x] New: `TestStrategyExitFillCallback` (4 tests) — slippage-true P&L, cancel no-fire, None strategy_id skip, callback-exception isolation
- [x] New: `test_check_exits_defers_outcome_to_fill_callback`, `test_fill_callback_records_actual_pnl`, `test_no_callback_registration_without_loss_cooldown`
- [x] Old `test_check_exits_records_loss_outcome` retired (the eager contract it asserted is gone)