### PR TITLE
feat(data): --full-daily-history flag for alpaca_downloader

### DIFF
--- a/.github/workflows/weekly-walkforward.yml
+++ b/.github/workflows/weekly-walkforward.yml
@@ -75,10 +75,17 @@ jobs:
           ALPACA_LIVE_SECRET: ${{ secrets.ALPACA_LIVE_SECRET }}
         run: |
           # Cache miss is OK — the downloader skips dates already cached.
+          # --full-daily-history writes one daily parquet per trading day so
+          # the regime filter calibration in run_multi_ticker_intraday can
+          # see a continuous SPY history across every walkforward window,
+          # not just the last 120 days before the run. Without it, the first
+          # 90-day window only sees ~12 SMA-eligible bars (see memory:
+          # feedback_daily_cache_regime_trap).
           python -m trading_bot.data.alpaca_downloader \
             --from "${{ steps.dates.outputs.bt_from }}" \
             --to "${{ steps.dates.outputs.bt_to }}" \
-            --tickers SPY QQQ XLF XLK XLE XLV XLI XLY XLP
+            --tickers SPY QQQ XLF XLK XLE XLV XLI XLY XLP \
+            --full-daily-history
 
       - name: Run walkforward
         env:

--- a/trading_bot/data/alpaca_downloader.py
+++ b/trading_bot/data/alpaca_downloader.py
@@ -7,6 +7,14 @@ Usage::
 Downloads 1-min intraday bars for each trading day and daily bars (120-day
 lookback) for all watchlist tickers. Results are saved to the same parquet
 cache used by the backtester (``data/cache/{TICKER}/{DATE}_{type}.parquet``).
+
+Pass ``--full-daily-history`` to write a per-trading-day daily parquet
+across the full range (one file per trading day, each carrying the last
+``lookback_days`` of trading-day bars ending on that date) instead of the
+default behaviour of saving a single daily file at the endpoint. This is
+required for multi-year backtests / walkforward windows where the regime
+filter needs a continuous daily history to calibrate against, not just the
+last 120 days before the run.
 """
 
 from __future__ import annotations
@@ -171,17 +179,119 @@ async def download_daily_bars(
     return df, "downloaded"
 
 
+async def download_daily_history(
+    client: StockHistoricalDataClient,
+    ticker: str,
+    from_date: date,
+    to_date: date,
+    config: Config,
+    lookback_days: int = 120,
+    feed: str = "iex",
+) -> tuple[int, int, int]:
+    """Download a full daily history and emit one cached parquet per trading day.
+
+    Fetches a single Alpaca daily-bars request covering
+    ``[from_date - buffer, to_date]`` and, for every trading day ``D`` in
+    ``[from_date, to_date]``, writes ``<TICKER>/<D>_daily.parquet`` containing
+    the last ``lookback_days`` trading-day bars ending on ``D``. Days that
+    already have a cached file are skipped (idempotent).
+
+    Returns ``(written, skipped, requests_made)`` so callers can update
+    progress counters and rate-limit windows.
+    """
+    trading_days: list[date] = _get_trading_days(from_date, to_date, config)
+    if not trading_days:
+        return 0, 0, 0
+
+    targets: list[date] = [
+        d for d in trading_days if load_cached(ticker, d, "daily") is None
+    ]
+    skipped: int = len(trading_days) - len(targets)
+    if not targets:
+        logger.debug(
+            "All %d daily files already cached for %s", len(trading_days), ticker,
+        )
+        return 0, skipped, 0
+
+    # Fetch enough calendar days to cover ``lookback_days`` trading days plus
+    # holidays/weekends. ``lookback_days * 1.5 + 30`` is generous; the cost is
+    # one extra Alpaca request slice, not per-day requests.
+    buffer_days: int = int(lookback_days * 1.5) + 30
+    request_start: datetime = datetime(
+        from_date.year, from_date.month, from_date.day, tzinfo=TZ_UTC,
+    ) - timedelta(days=buffer_days)
+    request_end: datetime = datetime(
+        to_date.year, to_date.month, to_date.day,
+        23, 59, 59, tzinfo=TZ_UTC,
+    )
+
+    try:
+        from alpaca.data.enums import DataFeed, Adjustment
+        feed_enum = DataFeed.IEX if feed.lower() == "iex" else DataFeed.SIP
+
+        request = StockBarsRequest(
+            symbol_or_symbols=ticker,
+            timeframe=TimeFrame(1, TimeFrameUnit.Day),
+            start=request_start,
+            end=request_end,
+            feed=feed_enum,
+            adjustment=Adjustment.ALL,
+        )
+        response = client.get_stock_bars(request)
+        bars = response.data.get(ticker, [])
+    except Exception:
+        logger.exception(
+            "Failed to download daily history for %s (%s to %s)",
+            ticker, request_start.date(), request_end.date(),
+        )
+        return 0, skipped, 1
+
+    if not bars:
+        logger.warning(
+            "Empty daily history for %s (%s to %s)",
+            ticker, request_start.date(), request_end.date(),
+        )
+        return 0, skipped, 1
+
+    df_full: pd.DataFrame = _bars_to_df(bars)
+    # Per-bar trading day, tz-normalised to UTC date for inclusive comparison.
+    bar_dates = df_full.index.tz_convert(TZ_UTC).date
+
+    written: int = 0
+    for d in targets:
+        mask = bar_dates <= d
+        df_slice: pd.DataFrame = df_full.loc[mask]
+        if df_slice.empty:
+            continue
+        if len(df_slice) > lookback_days:
+            df_slice = df_slice.iloc[-lookback_days:]
+        save_to_cache(ticker, d, "daily", df_slice)
+        written += 1
+
+    logger.info(
+        "Daily history for %s: %d written, %d skipped (cached) — 1 API request",
+        ticker, written, skipped,
+    )
+    return written, skipped, 1
+
+
 async def download_all(
     config: Config,
     tickers: list[str],
     from_date: date,
     to_date: date,
     rate_limit_per_min: int = 180,
+    full_daily_history: bool = False,
 ) -> dict[str, int]:
     """Download intraday + daily bars for all tickers across the date range.
 
     Respects Alpaca's free-tier rate limit (~200 req/min).
     Returns a dict of status counts.
+
+    When ``full_daily_history`` is True, daily bars are saved as one parquet
+    per trading day across ``[from_date, to_date]`` (see
+    :func:`download_daily_history`). Otherwise a single 120-day file is saved
+    at the endpoint, matching the legacy single-tick consumption pattern.
     """
     api_key: str = os.environ.get("ALPACA_API_KEY", "")
     secret_key: str = os.environ.get("ALPACA_SECRET_KEY", "")
@@ -204,14 +314,28 @@ async def download_all(
     request_count: int = 0
     window_start: float = time.monotonic()
 
+    stats.setdefault("daily_written", 0)
+    stats.setdefault("daily_skipped", 0)
+
     for ticker in tickers:
-        # Download daily bars once per ticker (for the last trading day, covers lookback)
-        _, daily_status = await download_daily_bars(
-            client, ticker, to_date, lookback_days=120, feed=feed,
-        )
-        stats[daily_status] = stats.get(daily_status, 0) + 1
-        if daily_status == "downloaded":
-            request_count += 1
+        if full_daily_history:
+            written, skipped, reqs = await download_daily_history(
+                client, ticker, from_date, to_date, config,
+                lookback_days=120, feed=feed,
+            )
+            stats["daily_written"] += written
+            stats["daily_skipped"] += skipped
+            request_count += reqs
+        else:
+            # Legacy single-file path: one daily parquet per ticker, anchored
+            # on ``to_date`` with 120-day lookback. Sufficient for the live
+            # bot's single-tick read.
+            _, daily_status = await download_daily_bars(
+                client, ticker, to_date, lookback_days=120, feed=feed,
+            )
+            stats[daily_status] = stats.get(daily_status, 0) + 1
+            if daily_status == "downloaded":
+                request_count += 1
 
         for day in trading_days:
             # Rate limiting
@@ -254,6 +378,15 @@ async def main() -> None:
     parser.add_argument("--to", dest="to_date", required=True, help="End date (YYYY-MM-DD)")
     parser.add_argument("--config", default="config.yaml", help="Config file path")
     parser.add_argument("--tickers", nargs="*", help="Override tickers (default: watchlist from config)")
+    parser.add_argument(
+        "--full-daily-history",
+        action="store_true",
+        help=(
+            "Write one daily parquet per trading day across [from, to] "
+            "(needed for multi-year backtests where the regime filter "
+            "must calibrate against more than the last 120 days)."
+        ),
+    )
     args = parser.parse_args()
 
     from dotenv import load_dotenv
@@ -269,7 +402,10 @@ async def main() -> None:
         raw = config._raw.get("watchlist", {})
         tickers = list(raw.get("us", []))
 
-    stats = await download_all(config, tickers, d_from, d_to)
+    stats = await download_all(
+        config, tickers, d_from, d_to,
+        full_daily_history=args.full_daily_history,
+    )
     print(f"\nDownload complete: {stats}")
     print(f"Log file: {log_path}")
 

--- a/trading_bot/data/alpaca_downloader.py
+++ b/trading_bot/data/alpaca_downloader.py
@@ -25,7 +25,7 @@ import logging
 import os
 import time
 from datetime import date, datetime, timedelta
-from typing import Any
+from typing import Any, NamedTuple
 
 import pandas as pd
 
@@ -38,6 +38,23 @@ from trading_bot.constants import TZ_EASTERN, TZ_UTC
 from trading_bot.data_cache import load_cached, save_to_cache
 
 logger: logging.Logger = logging.getLogger(__name__)
+
+
+class DailyHistoryResult(NamedTuple):
+    """Outcome of a :func:`download_daily_history` call.
+
+    ``missed`` counts target trading days that were requested but produced
+    an empty slice (typically: the target predates Alpaca's available
+    history for the ticker, or the API returned no bars covering it).
+    Callers should surface a non-zero ``missed`` count loudly — a missed
+    day means the cache is incomplete, which is exactly the failure mode
+    this helper exists to prevent.
+    """
+
+    written: int
+    skipped: int
+    missed: int
+    requests_made: int
 
 
 def _get_trading_days(start: date, end: date, config: Config) -> list[date]:
@@ -187,7 +204,7 @@ async def download_daily_history(
     config: Config,
     lookback_days: int = 120,
     feed: str = "iex",
-) -> tuple[int, int, int]:
+) -> DailyHistoryResult:
     """Download a full daily history and emit one cached parquet per trading day.
 
     Fetches a single Alpaca daily-bars request covering
@@ -196,12 +213,12 @@ async def download_daily_history(
     the last ``lookback_days`` trading-day bars ending on ``D``. Days that
     already have a cached file are skipped (idempotent).
 
-    Returns ``(written, skipped, requests_made)`` so callers can update
-    progress counters and rate-limit windows.
+    Returns a :class:`DailyHistoryResult` so callers can update progress
+    counters, rate-limit windows, and surface coverage gaps.
     """
     trading_days: list[date] = _get_trading_days(from_date, to_date, config)
     if not trading_days:
-        return 0, 0, 0
+        return DailyHistoryResult(0, 0, 0, 0)
 
     targets: list[date] = [
         d for d in trading_days if load_cached(ticker, d, "daily") is None
@@ -211,7 +228,7 @@ async def download_daily_history(
         logger.debug(
             "All %d daily files already cached for %s", len(trading_days), ticker,
         )
-        return 0, skipped, 0
+        return DailyHistoryResult(0, skipped, 0, 0)
 
     # Fetch enough calendar days to cover ``lookback_days`` trading days plus
     # holidays/weekends. ``lookback_days * 1.5 + 30`` is generous; the cost is
@@ -225,6 +242,9 @@ async def download_daily_history(
         23, 59, 59, tzinfo=TZ_UTC,
     )
 
+    # Narrow try/except around the API call so transient network/auth errors
+    # are absorbed but structural surprises (e.g. response shape mismatch)
+    # surface to the caller instead of being conflated with "0 bars".
     try:
         from alpaca.data.enums import DataFeed, Adjustment
         feed_enum = DataFeed.IEX if feed.lower() == "iex" else DataFeed.SIP
@@ -238,41 +258,72 @@ async def download_daily_history(
             adjustment=Adjustment.ALL,
         )
         response = client.get_stock_bars(request)
-        bars = response.data.get(ticker, [])
     except Exception:
         logger.exception(
             "Failed to download daily history for %s (%s to %s)",
             ticker, request_start.date(), request_end.date(),
         )
-        return 0, skipped, 1
+        return DailyHistoryResult(0, skipped, len(targets), 1)
+
+    # The Alpaca SDK return type is union'd with ``dict[str, Any]`` (hence the
+    # standing mypy ``union-attr`` warning at other call sites). A dict-shaped
+    # response is a structural surprise — surface it rather than swallow it.
+    raw_data: Any = getattr(response, "data", None)
+    if raw_data is None:
+        if isinstance(response, dict):
+            raw_data = response
+        else:
+            logger.error(
+                "Unexpected Alpaca response shape for %s: %s — treating as empty",
+                ticker, type(response).__name__,
+            )
+            return DailyHistoryResult(0, skipped, len(targets), 1)
+    bars: list = list(raw_data.get(ticker, []))
 
     if not bars:
         logger.warning(
-            "Empty daily history for %s (%s to %s)",
-            ticker, request_start.date(), request_end.date(),
+            "Empty daily history for %s (%s to %s) — %d target days unwritten",
+            ticker, request_start.date(), request_end.date(), len(targets),
         )
-        return 0, skipped, 1
+        return DailyHistoryResult(0, skipped, len(targets), 1)
 
     df_full: pd.DataFrame = _bars_to_df(bars)
     # Per-bar trading day, tz-normalised to UTC date for inclusive comparison.
     bar_dates = df_full.index.tz_convert(TZ_UTC).date
 
     written: int = 0
+    missed: int = 0
     for d in targets:
         mask = bar_dates <= d
         df_slice: pd.DataFrame = df_full.loc[mask]
         if df_slice.empty:
+            # Target predates Alpaca's history for this ticker — silent skip
+            # here is exactly the failure mode this PR is meant to prevent.
+            logger.warning(
+                "No daily bars at-or-before %s for %s — file not written "
+                "(check ticker history start vs from_date - buffer=%s)",
+                d.isoformat(), ticker, request_start.date().isoformat(),
+            )
+            missed += 1
             continue
+        if len(df_slice) < lookback_days:
+            logger.debug(
+                "Truncated lookback for %s @ %s: %d/%d bars (likely near "
+                "Alpaca data-availability boundary)",
+                ticker, d.isoformat(), len(df_slice), lookback_days,
+            )
         if len(df_slice) > lookback_days:
             df_slice = df_slice.iloc[-lookback_days:]
         save_to_cache(ticker, d, "daily", df_slice)
         written += 1
 
-    logger.info(
-        "Daily history for %s: %d written, %d skipped (cached) — 1 API request",
-        ticker, written, skipped,
+    log = logger.warning if missed else logger.info
+    log(
+        "Daily history for %s: %d written, %d skipped (cached), "
+        "%d missed (no coverage) — 1 API request",
+        ticker, written, skipped, missed,
     )
-    return written, skipped, 1
+    return DailyHistoryResult(written, skipped, missed, 1)
 
 
 async def download_all(
@@ -311,21 +362,34 @@ async def download_all(
     )
 
     stats: dict[str, int] = {"cached": 0, "downloaded": 0, "empty": 0, "error": 0}
+    if full_daily_history:
+        stats.update({"daily_written": 0, "daily_skipped": 0, "daily_missed": 0})
     request_count: int = 0
     window_start: float = time.monotonic()
 
-    stats.setdefault("daily_written", 0)
-    stats.setdefault("daily_skipped", 0)
+    async def _respect_rate_limit() -> None:
+        """Pause if we've sent ``rate_limit_per_min`` requests this window."""
+        nonlocal request_count, window_start
+        if request_count >= rate_limit_per_min:
+            elapsed: float = time.monotonic() - window_start
+            if elapsed < 60:
+                wait: float = 60 - elapsed + 1
+                logger.info("Rate limit: waiting %.0fs...", wait)
+                await asyncio.sleep(wait)
+            request_count = 0
+            window_start = time.monotonic()
 
     for ticker in tickers:
         if full_daily_history:
-            written, skipped, reqs = await download_daily_history(
+            await _respect_rate_limit()
+            result: DailyHistoryResult = await download_daily_history(
                 client, ticker, from_date, to_date, config,
                 lookback_days=120, feed=feed,
             )
-            stats["daily_written"] += written
-            stats["daily_skipped"] += skipped
-            request_count += reqs
+            stats["daily_written"] += result.written
+            stats["daily_skipped"] += result.skipped
+            stats["daily_missed"] += result.missed
+            request_count += result.requests_made
         else:
             # Legacy single-file path: one daily parquet per ticker, anchored
             # on ``to_date`` with 120-day lookback. Sufficient for the live
@@ -338,16 +402,7 @@ async def download_all(
                 request_count += 1
 
         for day in trading_days:
-            # Rate limiting
-            if request_count >= rate_limit_per_min:
-                elapsed: float = time.monotonic() - window_start
-                if elapsed < 60:
-                    wait: float = 60 - elapsed + 1
-                    logger.info("Rate limit: waiting %.0fs...", wait)
-                    await asyncio.sleep(wait)
-                request_count = 0
-                window_start = time.monotonic()
-
+            await _respect_rate_limit()
             _, status = await download_ticker_day(client, ticker, day, feed=feed)
             stats[status] = stats.get(status, 0) + 1
             if status == "downloaded":
@@ -360,9 +415,21 @@ async def download_all(
                     stats["empty"], stats["error"],
                 )
 
+    if stats.get("daily_missed"):
+        logger.warning(
+            "Download complete with %d missed daily targets — cache may be "
+            "incomplete; see prior warnings for affected (ticker, date) pairs.",
+            stats["daily_missed"],
+        )
     logger.info(
-        "Download complete: cached=%d downloaded=%d empty=%d error=%d",
+        "Download complete: cached=%d downloaded=%d empty=%d error=%d%s",
         stats["cached"], stats["downloaded"], stats["empty"], stats["error"],
+        (
+            f" daily_written={stats['daily_written']} "
+            f"daily_skipped={stats['daily_skipped']} "
+            f"daily_missed={stats['daily_missed']}"
+            if full_daily_history else ""
+        ),
     )
     return stats
 

--- a/trading_bot/tests/test_multi_strategy_backtest.py
+++ b/trading_bot/tests/test_multi_strategy_backtest.py
@@ -556,16 +556,17 @@ class TestAlpacaDownloader:
 
         config = Config.load("config.yaml")
 
-        written, skipped, reqs = asyncio.run(
+        result = asyncio.run(
             alpaca_downloader.download_daily_history(
                 client, "SPY", from_date, to_date, config,
                 lookback_days=120, feed="iex",
             )
         )
 
-        assert reqs == 1, "Should issue exactly one Alpaca request"
-        assert skipped == 0, "Fresh cache → nothing skipped"
-        assert written == 5, "One file per trading day Mon-Fri"
+        assert result.requests_made == 1, "Should issue exactly one Alpaca request"
+        assert result.skipped == 0, "Fresh cache → nothing skipped"
+        assert result.missed == 0, "150 bars of synthetic history covers every target"
+        assert result.written == 5, "One file per trading day Mon-Fri"
 
         cache_root = tmp_path / "cache" / "SPY"
         files = sorted(cache_root.glob("*_daily.parquet"))
@@ -631,15 +632,124 @@ class TestAlpacaDownloader:
         # Second run: every target is now cached; expect 0 writes and 0
         # API requests.
         client.get_stock_bars.reset_mock()
-        written, skipped, reqs = asyncio.run(
+        result = asyncio.run(
             alpaca_downloader.download_daily_history(
                 client, "SPY", from_date, to_date, config,
             )
         )
-        assert written == 0
-        assert skipped == 3
-        assert reqs == 0
+        assert result.written == 0
+        assert result.skipped == 3
+        assert result.missed == 0
+        assert result.requests_made == 0
         client.get_stock_bars.assert_not_called()
+
+    def test_download_daily_history_records_missed_when_targets_predate_data(
+        self,
+        tmp_path: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Targets earlier than the API's history must count as ``missed``, not be silently skipped."""
+        import asyncio
+
+        from trading_bot.data import alpaca_downloader
+        from trading_bot import data_cache
+
+        monkeypatch.setattr(data_cache, "_CACHE_DIR", tmp_path / "cache")
+
+        from_date = date(2026, 1, 5)
+        to_date = date(2026, 1, 9)  # 5 trading days
+
+        # Only return bars for the last 2 trading days. The first 3 targets
+        # have no bar at-or-before them → should bump ``missed``.
+        bars = []
+        for d in [date(2026, 1, 8), date(2026, 1, 9)]:
+            bar = MagicMock()
+            bar.timestamp = datetime(d.year, d.month, d.day, 0, 0, 0, tzinfo=TZ_UTC)
+            bar.open = 400.0
+            bar.high = 401.0
+            bar.low = 399.0
+            bar.close = 400.5
+            bar.volume = 1_000_000
+            bars.append(bar)
+
+        mock_response = MagicMock()
+        mock_response.data = {"SPY": bars}
+        client = MagicMock()
+        client.get_stock_bars.return_value = mock_response
+
+        config = Config.load("config.yaml")
+
+        result = asyncio.run(
+            alpaca_downloader.download_daily_history(
+                client, "SPY", from_date, to_date, config,
+            )
+        )
+        assert result.written == 2
+        assert result.missed == 3, "Targets predating the bar series must be reported as missed"
+        assert result.skipped == 0
+        assert result.requests_made == 1
+
+    def test_download_daily_history_with_trading_days_only_bars(
+        self,
+        tmp_path: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Realistic Alpaca shape: bars only on trading days, no weekends.
+
+        The bar list passed to the slicing logic in real use only contains
+        trading days. This verifies the date-based mask still produces the
+        right per-day slice counts under that shape.
+        """
+        import asyncio
+
+        from trading_bot.data import alpaca_downloader
+        from trading_bot import data_cache
+
+        monkeypatch.setattr(data_cache, "_CACHE_DIR", tmp_path / "cache")
+
+        from_date = date(2026, 1, 5)
+        to_date = date(2026, 1, 9)  # 5 trading days
+        config = Config.load("config.yaml")
+
+        # Build trading-days-only bars walking backwards from to_date.
+        bars: list[Any] = []
+        d_cursor = to_date
+        while len(bars) < 160:
+            if d_cursor.weekday() < 5:
+                bar = MagicMock()
+                bar.timestamp = datetime(
+                    d_cursor.year, d_cursor.month, d_cursor.day, 0, 0, 0, tzinfo=TZ_UTC,
+                )
+                bar.open = 400.0
+                bar.high = 401.0
+                bar.low = 399.0
+                bar.close = 400.5
+                bar.volume = 1_000_000
+                bars.append(bar)
+            d_cursor -= timedelta(days=1)
+        bars.reverse()  # chronological order
+
+        mock_response = MagicMock()
+        mock_response.data = {"SPY": bars}
+        client = MagicMock()
+        client.get_stock_bars.return_value = mock_response
+
+        result = asyncio.run(
+            alpaca_downloader.download_daily_history(
+                client, "SPY", from_date, to_date, config,
+                lookback_days=120, feed="iex",
+            )
+        )
+        assert result.written == 5
+        assert result.missed == 0
+
+        cache_root = tmp_path / "cache" / "SPY"
+        for f in sorted(cache_root.glob("*_daily.parquet")):
+            df = pd.read_parquet(f)
+            # All bars in a per-day file must be on weekdays.
+            for ts in df.index:
+                assert ts.weekday() < 5, f"weekend bar leaked into {f.name}"
+            assert len(df) == 120, f"{f.name} should be capped at lookback_days"
 
 
 # ---------------------------------------------------------------------------

--- a/trading_bot/tests/test_multi_strategy_backtest.py
+++ b/trading_bot/tests/test_multi_strategy_backtest.py
@@ -507,6 +507,140 @@ class TestAlpacaDownloader:
             assert d.weekday() < 5
         assert len(days) == 5  # Mon-Fri
 
+    def test_download_daily_history_writes_per_day_files(
+        self,
+        tmp_path: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``--full-daily-history`` should emit one parquet per trading day.
+
+        Mocks the Alpaca client to return one bar per weekday, then verifies
+        that ``download_daily_history`` writes a separate file at every
+        target trading day whose slice is bounded by that day and capped at
+        ``lookback_days``.
+        """
+        import asyncio
+
+        from trading_bot.data import alpaca_downloader
+        from trading_bot import data_cache
+
+        # Redirect the cache directory at the source of truth in ``data_cache``
+        # so both ``save_to_cache`` writes and ``load_cached`` reads agree.
+        monkeypatch.setattr(data_cache, "_CACHE_DIR", tmp_path / "cache")
+
+        from_date = date(2026, 1, 5)   # Monday
+        to_date = date(2026, 1, 9)     # Friday → 5 trading days
+
+        # Build 150 daily bars ending at to_date so each per-day slice can
+        # be capped at lookback_days=120.
+        n_bars = 150
+        bars = []
+        for i in range(n_bars):
+            bar_day = to_date - timedelta(days=n_bars - 1 - i)
+            bar = MagicMock()
+            bar.timestamp = datetime(
+                bar_day.year, bar_day.month, bar_day.day, 0, 0, 0, tzinfo=TZ_UTC,
+            )
+            bar.open = 400.0 + i * 0.1
+            bar.high = 401.0 + i * 0.1
+            bar.low = 399.0 + i * 0.1
+            bar.close = 400.5 + i * 0.1
+            bar.volume = 1_000_000
+            bars.append(bar)
+
+        mock_response = MagicMock()
+        mock_response.data = {"SPY": bars}
+
+        client = MagicMock()
+        client.get_stock_bars.return_value = mock_response
+
+        config = Config.load("config.yaml")
+
+        written, skipped, reqs = asyncio.run(
+            alpaca_downloader.download_daily_history(
+                client, "SPY", from_date, to_date, config,
+                lookback_days=120, feed="iex",
+            )
+        )
+
+        assert reqs == 1, "Should issue exactly one Alpaca request"
+        assert skipped == 0, "Fresh cache → nothing skipped"
+        assert written == 5, "One file per trading day Mon-Fri"
+
+        cache_root = tmp_path / "cache" / "SPY"
+        files = sorted(cache_root.glob("*_daily.parquet"))
+        assert len(files) == 5
+        assert files[0].name == "2026-01-05_daily.parquet"
+        assert files[-1].name == "2026-01-09_daily.parquet"
+
+        # Each per-day file must be capped at lookback_days and stop at its
+        # filename date (not bleed in bars from after it).
+        for f in files:
+            df = pd.read_parquet(f)
+            assert len(df) <= 120, f"{f.name} exceeded lookback cap"
+            file_day = date.fromisoformat(f.stem.split("_")[0])
+            max_bar_day = df.index.tz_convert(TZ_UTC).date.max()
+            assert max_bar_day <= file_day, (
+                f"{f.name} contains bars dated after its filename"
+            )
+
+    def test_download_daily_history_skips_cached_days(
+        self,
+        tmp_path: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Idempotency: a second run on a populated cache writes nothing."""
+        import asyncio
+
+        from trading_bot.data import alpaca_downloader
+        from trading_bot import data_cache
+
+        monkeypatch.setattr(data_cache, "_CACHE_DIR", tmp_path / "cache")
+
+        from_date = date(2026, 1, 5)
+        to_date = date(2026, 1, 7)  # 3 trading days
+
+        bars = []
+        for i in range(60):
+            bar_day = to_date - timedelta(days=59 - i)
+            bar = MagicMock()
+            bar.timestamp = datetime(
+                bar_day.year, bar_day.month, bar_day.day, 0, 0, 0, tzinfo=TZ_UTC,
+            )
+            bar.open = 400.0
+            bar.high = 401.0
+            bar.low = 399.0
+            bar.close = 400.5
+            bar.volume = 1_000_000
+            bars.append(bar)
+
+        mock_response = MagicMock()
+        mock_response.data = {"SPY": bars}
+        client = MagicMock()
+        client.get_stock_bars.return_value = mock_response
+
+        config = Config.load("config.yaml")
+
+        # First run populates the cache.
+        asyncio.run(
+            alpaca_downloader.download_daily_history(
+                client, "SPY", from_date, to_date, config,
+            )
+        )
+
+        # Second run: every target is now cached; expect 0 writes and 0
+        # API requests.
+        client.get_stock_bars.reset_mock()
+        written, skipped, reqs = asyncio.run(
+            alpaca_downloader.download_daily_history(
+                client, "SPY", from_date, to_date, config,
+            )
+        )
+        assert written == 0
+        assert skipped == 3
+        assert reqs == 0
+        client.get_stock_bars.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # StrategyResult tests


### PR DESCRIPTION
## Summary

- New `--full-daily-history` flag on `alpaca_downloader` writes one `<TICKER>/<YYYY-MM-DD>_daily.parquet` per trading day across `[from, to]`, each containing the last 120 trading-day bars ending on that date.
- Legacy single-file mode (one daily file anchored on `to_date`) remains the default so the live tick path is unchanged.
- `weekly-walkforward.yml` now passes the flag so the regime filter can calibrate against a continuous SPY history across every window.

## Why

The 2026-05-11 3y local walkforward logged `Regime filter calibrated on SPY: 12/12 days bullish` — calibration only saw 12 days because the cache held a single `<latest>_daily.parquet` with 120-day lookback, and older walkforward windows fell back silently to that one file. This flag pre-positions a full per-day daily cache so the SMA-50 gate has enough warmup at the start of every window.

Per-ticker cost is **one** Alpaca request (range slice covering `from - buffer .. to`), then in-process slicing to write per-day files. Idempotent — already-cached days are skipped.

## Files

- `trading_bot/data/alpaca_downloader.py` — new `download_daily_history()` helper + `--full-daily-history` CLI flag + `download_all(full_daily_history=…)` plumbing.
- `trading_bot/tests/test_multi_strategy_backtest.py` — two new tests under `TestAlpacaDownloader`: per-day file emission (slice bounded by filename date, capped at lookback) and skip-cached idempotency.
- `.github/workflows/weekly-walkforward.yml` — adds the flag to the download step with an explanatory comment.

## Known follow-up

`run_multi_ticker_intraday` still builds daily bars from the intraday cache for the active window — it does **not** yet consult `load_cached(ticker, day, \"daily\")`. So this PR pre-positions the data; flipping the consumer to prefer the cached daily file is a separate change. The verification scenario in the original task (\"NN/NN matching the trading-day count\") needs that follow-up to take effect.

The shape of `load_cached(ticker, target_date, \"daily\")` already supports per-date lookup via `data_cache.cache_key`, so the consumer flip is a small, isolated change when ready.

## Test plan

- [x] Two new unit tests pass (`TestAlpacaDownloader::test_download_daily_history_writes_per_day_files`, `…_skips_cached_days`)
- [x] Full local suite green: **847 passed, 2 skipped** (two pre-existing hypothesis modules skipped due to missing `hypothesis` in the local venv; same status as `main`)
- [x] `ruff check` clean
- [ ] (post-merge) First scheduled weekly-walkforward run downloads the per-day cache; spot-check `data/cache/SPY/*_daily.parquet` count matches trading-day count for the 2y window