### PR TITLE
fix(execution): cancel all open orders for ticker before strategy exit

### DIFF
--- a/trading_bot/execution/order_manager.py
+++ b/trading_bot/execution/order_manager.py
@@ -872,20 +872,16 @@ class OrderManager:
             )
             return None
 
-        if matching_active is not None:
-            for oid in (
-                matching_active.alpaca_stop_order_id,
-                matching_active.alpaca_target_order_id,
-                matching_active.alpaca_trail_order_id,
-            ):
-                if oid is not None:
-                    await self.cancel_order(oid)
-        else:
-            # Recovery / orphan-drain path: no in-memory order tracked
-            # for this ticker (e.g., position predates this process).
-            # Cancel any orphan child orders so the SELL isn't blocked
-            # by reserved qty.
-            await self.cancel_all_for_ticker(ticker)
+        # Cancel ALL open orders for the ticker, not just the locally
+        # tracked bracket legs. Phantom stops (placed by earlier retry
+        # paths and never linked back into the DB) hold the qty as
+        # ``held_for_orders`` on Alpaca and cause the subsequent SELL
+        # to fail with code 40310000 ("insufficient qty available").
+        # Observed 2026-05-08 → 2026-05-11: XLK overnight_drift exit
+        # blocked for 3 trading days by an untracked stop, only cleared
+        # when an emergency-flatten path explicitly canceled all
+        # orders for the symbol. Treat broker as source of truth.
+        await self.cancel_all_for_ticker(ticker)
 
         client: TradingClient = self._gw.client
         try:
@@ -989,16 +985,11 @@ class OrderManager:
             )
             return None
 
-        if matching_active is not None:
-            for oid in (
-                matching_active.alpaca_stop_order_id,
-                matching_active.alpaca_target_order_id,
-                matching_active.alpaca_trail_order_id,
-            ):
-                if oid is not None:
-                    await self.cancel_order(oid)
-        else:
-            await self.cancel_all_for_ticker(ticker)
+        # Cancel ALL open orders for the ticker. Mirrors the change in
+        # place_exit — see that comment for rationale. Phantom stops not
+        # tracked in the local DB will otherwise hold the qty and reject
+        # this LIMIT submission with "insufficient qty available".
+        await self.cancel_all_for_ticker(ticker)
 
         # Snapshot the prior status so we can roll back if Alpaca
         # rejects the submission. Without this, a failed submit leaves

--- a/trading_bot/execution/order_manager.py
+++ b/trading_bot/execution/order_manager.py
@@ -759,8 +759,20 @@ class OrderManager:
             # Benign: order may already be filled/cancelled by the time we try.
             logger.debug("Error cancelling order %s (may already be done)", order_id, exc_info=True)
 
-    async def cancel_all_for_ticker(self, ticker: str) -> None:
-        """Cancel all open orders for a ticker."""
+    async def cancel_all_for_ticker(
+        self, ticker: str, *, side_filter: OrderSide | None = None,
+    ) -> None:
+        """Cancel open orders for a ticker.
+
+        Args:
+            ticker: Symbol to scope the cancel to.
+            side_filter: If set, only cancel orders on this side. Used by
+                strategy-exit paths to pass ``OrderSide.SELL`` so an
+                in-flight BUY entry from another strategy on the same
+                ticker isn't collaterally cancelled. Default ``None``
+                preserves the pre-existing all-orders behaviour for
+                emergency-flatten / drain paths.
+        """
         try:
             from alpaca.trading.enums import QueryOrderStatus
             request = GetOrdersRequest(
@@ -771,15 +783,37 @@ class OrderManager:
                 self._gw.client.get_orders,  # type: ignore[arg-type]
                 filter=request,
             )
+            cancelled: int = 0
             for order in orders:
+                if side_filter is not None:
+                    order_side = getattr(order, "side", None)
+                    # OrderSide enum or .value — accept both. Skip on
+                    # mismatch.
+                    order_side_value = (
+                        order_side.value
+                        if hasattr(order_side, "value")
+                        else order_side
+                    )
+                    filter_value = (
+                        side_filter.value
+                        if hasattr(side_filter, "value")
+                        else side_filter
+                    )
+                    if order_side_value != filter_value:
+                        continue
                 try:
                     await asyncio.to_thread(
                         self._gw.client.cancel_order_by_id, str(order.id),
                     )
+                    cancelled += 1
                 except Exception:
                     logger.warning("Error cancelling order for %s", ticker, exc_info=True)
-            if orders:
-                logger.info("Cancelled %d order(s) for %s", len(orders), ticker)
+            if cancelled:
+                logger.info(
+                    "Cancelled %d order(s) for %s%s",
+                    cancelled, ticker,
+                    f" (side={side_filter.value})" if side_filter else "",
+                )
         except Exception:
             logger.exception("Error cancelling orders for %s", ticker)
 
@@ -881,7 +915,14 @@ class OrderManager:
         # blocked for 3 trading days by an untracked stop, only cleared
         # when an emergency-flatten path explicitly canceled all
         # orders for the symbol. Treat broker as source of truth.
-        await self.cancel_all_for_ticker(ticker)
+        #
+        # SELL-side filter: only cancel SELL orders (existing
+        # stops/targets/trailing). If another strategy has an in-flight
+        # BUY entry on the same ticker (allowed by the multi-strategy
+        # framework once breakout/trend_following are re-enabled), we
+        # must not cancel it — only the bracket-leg sells reserve the
+        # qty that's blocking our SELL.
+        await self.cancel_all_for_ticker(ticker, side_filter=OrderSide.SELL)
 
         client: TradingClient = self._gw.client
         try:
@@ -985,11 +1026,13 @@ class OrderManager:
             )
             return None
 
-        # Cancel ALL open orders for the ticker. Mirrors the change in
-        # place_exit — see that comment for rationale. Phantom stops not
-        # tracked in the local DB will otherwise hold the qty and reject
-        # this LIMIT submission with "insufficient qty available".
-        await self.cancel_all_for_ticker(ticker)
+        # Cancel SELL-side orders only for the ticker. Mirrors the
+        # change in place_exit — see that comment for rationale.
+        # Phantom stops not tracked in the local DB will otherwise hold
+        # the qty and reject this LIMIT submission with "insufficient
+        # qty available". The SELL filter protects an in-flight BUY
+        # entry from another strategy on the same ticker.
+        await self.cancel_all_for_ticker(ticker, side_filter=OrderSide.SELL)
 
         # Snapshot the prior status so we can roll back if Alpaca
         # rejects the submission. Without this, a failed submit leaves

--- a/trading_bot/tests/test_order_manager_lifecycle.py
+++ b/trading_bot/tests/test_order_manager_lifecycle.py
@@ -692,9 +692,14 @@ class TestPlaceExit:
 
         # Alpaca reports three OPEN orders for SPY: the tracked bracket
         # legs PLUS a phantom stop the local DB doesn't know about.
-        def _mk_open(oid: str) -> Any:
+        # All on the SELL side (bracket-leg sells) so the SELL-side
+        # filter in place_exit catches them.
+        from alpaca.trading.enums import OrderSide as _OrderSide
+
+        def _mk_open(oid: str, side: str = "sell") -> Any:
             o = MagicMock()
             o.id = oid
+            o.side = _OrderSide.SELL if side == "sell" else _OrderSide.BUY
             return o
 
         om._gw.client.get_orders = MagicMock(return_value=[
@@ -732,6 +737,68 @@ class TestPlaceExit:
         assert len(submit_orders) == 1
         # New order id mapped to the original trade id
         assert om._alpaca_to_trade.get("exit-1") == 1
+
+    @pytest.mark.asyncio
+    async def test_place_exit_preserves_cross_strategy_buy_entry(
+        self, config, tmp_db_path: str, mock_notifier,
+    ):
+        """Multi-strategy: if strategy B has an in-flight BUY entry on
+        the same ticker, strategy A's place_exit must NOT cancel it.
+        Only SELL-side orders (stops/targets/trailing/etc.) are
+        candidates for cancellation, because only those reserve the
+        qty that blocks A's SELL.
+        """
+        from alpaca.trading.enums import OrderSide as _OrderSide
+
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        active = _ActiveOrder(
+            trade_id=1,
+            ticker="XLF",
+            exchange="US",
+            alpaca_entry_order_id="entry-1",
+            alpaca_stop_order_id="stop-1",
+            status=PositionStatus.STOP_AND_TARGET_ACTIVE,
+            entry_shares=10.0,
+            filled_shares=10.0,
+            entry_price=50.0,
+            stop_price=49.0,
+            target_price=52.0,
+            hold_type="intraday",
+            strategy_id="overnight_drift",
+        )
+        om._active_orders[1] = active
+
+        def _mk_open(oid: str, side: _OrderSide) -> Any:
+            o = MagicMock()
+            o.id = oid
+            o.side = side
+            return o
+
+        # Alpaca reports: our SELL stop, plus another strategy's BUY
+        # entry that just hasn't filled yet.
+        om._gw.client.get_orders = MagicMock(return_value=[
+            _mk_open("stop-1", _OrderSide.SELL),
+            _mk_open("mean-reversion-buy-entry", _OrderSide.BUY),
+        ])
+        cancel_calls: list[str] = []
+        om._gw.client.cancel_order_by_id = MagicMock(
+            side_effect=lambda oid: cancel_calls.append(oid),
+        )
+        om._gw.client.submit_order = MagicMock(
+            return_value=_alpaca_order("exit-2", status="new"),
+        )
+
+        order_id = await om.place_exit(
+            ticker="XLF", qty=10, reason="overnight_exit",
+        )
+        assert order_id == "exit-2"
+        # SELL-side stop cancelled.
+        assert "stop-1" in cancel_calls
+        # Other strategy's BUY entry preserved.
+        assert "mean-reversion-buy-entry" not in cancel_calls, (
+            "cross-strategy BUY entry must not be collaterally "
+            "cancelled — only SELL orders reserve our qty"
+        )
 
     @pytest.mark.asyncio
     async def test_place_exit_returns_none_on_broker_failure(
@@ -1331,9 +1398,12 @@ class TestPlaceLimitExit:
         )
         om._active_orders[1] = active
 
-        def _mk_open(oid: str) -> Any:
+        from alpaca.trading.enums import OrderSide as _OrderSide
+
+        def _mk_open(oid: str, side: str = "sell") -> Any:
             o = MagicMock()
             o.id = oid
+            o.side = _OrderSide.SELL if side == "sell" else _OrderSide.BUY
             return o
 
         om._gw.client.get_orders = MagicMock(return_value=[

--- a/trading_bot/tests/test_order_manager_lifecycle.py
+++ b/trading_bot/tests/test_order_manager_lifecycle.py
@@ -657,18 +657,28 @@ class TestCancelFlatten:
 
 class TestPlaceExit:
     @pytest.mark.asyncio
-    async def test_place_exit_cancels_bracket_legs_and_submits_market_sell(
+    async def test_place_exit_cancels_all_open_orders_including_phantom_stops(
         self, config, tmp_db_path: str, mock_notifier,
     ):
+        """Regression for 2026-05-11 XLK/XLF stuck-overnight bug.
+
+        ``place_exit`` must cancel ALL open orders for the ticker, not
+        just the locally-tracked bracket legs. When earlier retry paths
+        place additional stops that aren't linked back into the DB,
+        those phantom stops still hold the qty as ``held_for_orders``
+        on Alpaca and cause the subsequent SELL to be rejected
+        (Alpaca code 40310000 "insufficient qty available").
+
+        See: trading_bot/execution/order_manager.py#place_exit.
+        """
         om = _make_om(config, tmp_db_path, mock_notifier)
-        # Track an in-flight position with both bracket legs known.
         active = _ActiveOrder(
             trade_id=1,
             ticker="SPY",
             exchange="US",
             alpaca_entry_order_id="entry-1",
-            alpaca_stop_order_id="stop-1",
-            alpaca_target_order_id="target-1",
+            alpaca_stop_order_id="stop-1",  # locally tracked
+            alpaca_target_order_id="target-1",  # locally tracked
             status=PositionStatus.STOP_AND_TARGET_ACTIVE,
             entry_shares=10.0,
             filled_shares=10.0,
@@ -679,6 +689,19 @@ class TestPlaceExit:
             strategy_id="mean_reversion",
         )
         om._active_orders[1] = active
+
+        # Alpaca reports three OPEN orders for SPY: the tracked bracket
+        # legs PLUS a phantom stop the local DB doesn't know about.
+        def _mk_open(oid: str) -> Any:
+            o = MagicMock()
+            o.id = oid
+            return o
+
+        om._gw.client.get_orders = MagicMock(return_value=[
+            _mk_open("stop-1"),
+            _mk_open("target-1"),
+            _mk_open("phantom-stop-from-retry"),
+        ])
 
         cancel_calls: list[str] = []
         om._gw.client.cancel_order_by_id = MagicMock(
@@ -698,10 +721,14 @@ class TestPlaceExit:
             ticker="SPY", qty=10, reason="rsi_normalized",
         )
         assert order_id == "exit-1"
-        # Both bracket legs cancelled before the new market order
+        # All three open orders cancelled — including the phantom stop
         assert "stop-1" in cancel_calls
         assert "target-1" in cancel_calls
-        # Market sell submitted
+        assert "phantom-stop-from-retry" in cancel_calls, (
+            "phantom stop not in DB must still be cancelled — Alpaca is "
+            "the source of truth for what's holding the qty"
+        )
+        # Market sell submitted exactly once after the cancels
         assert len(submit_orders) == 1
         # New order id mapped to the original trade id
         assert om._alpaca_to_trade.get("exit-1") == 1
@@ -1275,6 +1302,61 @@ class TestPlaceLimitExit:
             ticker="SPY", qty=0, limit_price=100.0, reason="bug",
         )
         assert order_id is None
+
+    @pytest.mark.asyncio
+    async def test_place_limit_exit_cancels_phantom_stops(
+        self, config, tmp_db_path: str, mock_notifier
+    ):
+        """Mirror of place_exit phantom-stop regression. The TAKE_PROFIT
+        path is what finally cleared XLK on 2026-05-11 because the
+        emergency-flatten fallback called cancel_all_for_ticker. With
+        this fix the limit path itself cancels all open orders, so the
+        fallback shouldn't be needed.
+        """
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        active = _ActiveOrder(
+            trade_id=1,
+            ticker="SPY",
+            exchange="US",
+            alpaca_entry_order_id="entry-1",
+            alpaca_stop_order_id="stop-1",  # locally tracked
+            status=PositionStatus.STOP_AND_TARGET_ACTIVE,
+            entry_shares=10.0,
+            filled_shares=10.0,
+            entry_price=100.0,
+            stop_price=98.0,
+            target_price=104.0,
+            hold_type="intraday",
+            strategy_id="mean_reversion",
+        )
+        om._active_orders[1] = active
+
+        def _mk_open(oid: str) -> Any:
+            o = MagicMock()
+            o.id = oid
+            return o
+
+        om._gw.client.get_orders = MagicMock(return_value=[
+            _mk_open("stop-1"),
+            _mk_open("phantom-stop-from-retry"),
+        ])
+        cancel_calls: list[str] = []
+        om._gw.client.cancel_order_by_id = MagicMock(
+            side_effect=lambda oid: cancel_calls.append(oid),
+        )
+        om._gw.client.submit_order = MagicMock(
+            return_value=_alpaca_order("limit-exit-2", status="new"),
+        )
+
+        order_id = await om.place_limit_exit(
+            ticker="SPY", qty=10, limit_price=104.5, reason="take_profit",
+        )
+        assert order_id == "limit-exit-2"
+        assert "stop-1" in cancel_calls
+        assert "phantom-stop-from-retry" in cancel_calls, (
+            "limit-exit path must also cancel untracked stops so the "
+            "SELL isn't rejected with insufficient-qty"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`place_exit` and `place_limit_exit` previously cancelled only the locally tracked bracket-leg order IDs (`alpaca_stop_order_id` / `alpaca_target_order_id` / `alpaca_trail_order_id`) when a matching `_ActiveOrder` existed. Always call `cancel_all_for_ticker` instead — the broker is the source of truth for what's holding the qty.

## Why

Surfaced by today's live trading (2026-05-11). The XLK overnight_drift position entered 2026-05-07 failed its Friday-morning and Monday-morning exits with Alpaca code 40310000 (`insufficient qty available, held_for_orders: 0.8795, related_orders: [6d2250f1...]`). The stop holding the qty was placed by an earlier retry path and never linked back into `positions.alpaca_stop_order_id`. XLF #95 hits the same rejection — still long at end of day Monday with the morning exit having failed.

The position only cleared when `TAKE_PROFIT` fell back to `emergency_flatten`, which itself calls `cancel_all_for_ticker`. This PR moves that same broker-as-source-of-truth cancel into the primary exit paths.

## Test plan
- [x] `test_place_exit_cancels_all_open_orders_including_phantom_stops` — asserts a phantom stop (Alpaca-side, absent from `_ActiveOrder`) is cancelled before SELL
- [x] `test_place_limit_exit_cancels_phantom_stops` — same for the limit-exit path
- [x] Full pytest suite — 874 passed

After merge, tomorrow morning's tick should successfully exit XLF #95 (and XLK #97 once a separate orphan-attribution PR lands).