### PR TITLE
fix(recovery): heal orphan strategy attribution from ENTRY_FAILED rows

### DIFF
--- a/trading_bot/gateway/recovery.py
+++ b/trading_bot/gateway/recovery.py
@@ -51,6 +51,9 @@ class RecoveryResult:
     stops_placed: list[str] = field(default_factory=list)
     stale_orders_cancelled: list[str] = field(default_factory=list)
     eod_flatten_orders: list[str] = field(default_factory=list)
+    # Pairs of orphan→canonical position IDs merged by
+    # _heal_unknown_orphans. Format: "TICKER #orphan→#canonical (strategy)".
+    orphans_healed: list[str] = field(default_factory=list)
 
     account_equity: float = 0.0
     settled_cash: float = 0.0
@@ -64,6 +67,7 @@ class RecoveryResult:
             or self.quantities_updated
             or self.stale_orders_cancelled
             or self.eod_flatten_orders
+            or self.orphans_healed
         )
 
     def summary(self) -> str:
@@ -95,6 +99,10 @@ class RecoveryResult:
             lines.append(
                 f"EOD flatten — closing intraday positions: "
                 f"{', '.join(self.eod_flatten_orders)}"
+            )
+        if self.orphans_healed:
+            lines.append(
+                f"Healed orphan attribution: {', '.join(self.orphans_healed)}"
             )
         if not self.has_discrepancies:
             lines.append("No discrepancies found - state is clean.")
@@ -138,27 +146,35 @@ class StateRecovery:
         result.settled_cash = _safe_float(account.get("SettledCash", "0"))
         result.buying_power = _safe_float(account.get("BuyingPower", "0"))
 
-        # 4. Load SQLite open positions
+        # 4. Heal stale orphan attribution. If a previous tick captured
+        #    an Alpaca position as a strategy_id='unknown' orphan AND a
+        #    matching ENTRY_FAILED row exists, merge them so the
+        #    strategy's exit logic sees the position. See
+        #    _heal_unknown_orphans for the match rules.
+        self._heal_unknown_orphans(result)
+
+        # 5. Load SQLite open positions (post-healing so the reconciler
+        #    sees the corrected attribution).
         db_positions: list[dict[str, Any]] = self._load_db_open_positions()
         result.db_open_positions = len(db_positions)
 
-        # 5. Reconcile
+        # 6. Reconcile
         self._reconcile(alpaca_positions, db_positions, result)
 
-        # 6. Verify stop orders
+        # 7. Verify stop orders
         await self._verify_stop_orders(alpaca_positions, alpaca_orders, result)
 
-        # 7. Cancel stale entry orders. Fresh order list because step 6 may
+        # 8. Cancel stale entry orders. Fresh order list because step 7 may
         #    have placed new stops, but those are GTC and not stale.
         await self._cancel_stale_entry_orders(alpaca_orders, result)
 
-        # 8. EOD intraday flatten. Closes intraday-tagged DB positions if the
+        # 9. EOD intraday flatten. Closes intraday-tagged DB positions if the
         #    cron tick lands after the configured cutoff (default 15:55 ET).
         #    Pass open orders for idempotency (skip tickers with a pending
         #    SELL already on the broker).
         await self._eod_intraday_flatten(alpaca_positions, alpaca_orders, result)
 
-        # 9. Log and alert
+        # 10. Log and alert
         logger.info("State recovery complete:\n%s", result.summary())
         if result.has_discrepancies:
             await self._notifier.gateway_alert(
@@ -529,6 +545,164 @@ class StateRecovery:
         finally:
             conn.close()
 
+    # Window for matching an Alpaca-discovered position against a recent
+    # ENTRY_FAILED row. Long enough to absorb the 5-min entry-pending
+    # sweep + reconciliation tick cadence, short enough that we don't
+    # accidentally merge across distinct entries for the same ticker.
+    _ORPHAN_REATTRIBUTION_WINDOW_MIN: int = 30
+    # Wider window for healing already-created 'unknown' orphans on
+    # subsequent ticks — covers overnight gaps when the orphan was
+    # created at the close and the matching ENTRY_FAILED row from a
+    # different strategy is up to a few sessions old.
+    _ORPHAN_HEAL_WINDOW_HOURS: int = 48
+    # Tolerance for entry-price match when reattributing. Limit orders
+    # fill at our exact limit price in normal conditions; allow 1¢ of
+    # rounding/quote-tick drift.
+    _ORPHAN_REATTRIBUTION_PRICE_TOL: float = 0.01
+
+    def _heal_unknown_orphans(self, result: RecoveryResult) -> None:
+        """Reattribute existing ``strategy_id='unknown'`` POSITION_OPEN rows.
+
+        When a previous tick created an orphan from an Alpaca position
+        because the matching local entry had already flipped to
+        ENTRY_FAILED, we can heal the attribution on the next tick by
+        merging the two rows. The ENTRY_FAILED row is the canonical one
+        (it carries the original ``alpaca_order_id`` and the correct
+        strategy_id); we promote it to POSITION_OPEN and close out the
+        unknown orphan with ``exit_reason='reattributed'``.
+
+        Idempotent: safe to call on every tick. If no orphan/ENTRY_FAILED
+        pair matches, this is a no-op.
+        """
+        cutoff: str = (
+            datetime.now(tz=ET) - timedelta(hours=self._ORPHAN_HEAL_WINDOW_HOURS)
+        ).isoformat()
+        conn: sqlite3.Connection = sqlite3.connect(self._db_path)
+        conn.row_factory = sqlite3.Row
+        try:
+            # Pull every active orphan in the heal window.
+            orphans = conn.execute(
+                "SELECT id, ticker, quantity, entry_price, entry_time "
+                "FROM positions "
+                "WHERE status = 'POSITION_OPEN' AND strategy_id = 'unknown' "
+                "AND entry_time >= ?",
+                (cutoff,),
+            ).fetchall()
+            if not orphans:
+                return
+            healed: list[str] = []
+            now: str = datetime.now(tz=ET).isoformat()
+            for orphan in orphans:
+                match = conn.execute(
+                    "SELECT id, strategy_id FROM positions "
+                    "WHERE status = 'ENTRY_FAILED' AND ticker = ? "
+                    "AND ABS(quantity - ?) < 1e-6 "
+                    "AND ABS(entry_price - ?) <= ? "
+                    "AND entry_time >= ? "
+                    "AND strategy_id IS NOT NULL AND strategy_id != 'unknown' "
+                    "ORDER BY entry_time DESC LIMIT 1",
+                    (
+                        orphan["ticker"],
+                        float(orphan["quantity"]),
+                        float(orphan["entry_price"]),
+                        self._ORPHAN_REATTRIBUTION_PRICE_TOL,
+                        cutoff,
+                    ),
+                ).fetchone()
+                if match is None:
+                    continue
+                canonical_id: int = int(match["id"])
+                orphan_id: int = int(orphan["id"])
+                strategy_id: str = str(match["strategy_id"])
+                # Promote ENTRY_FAILED → POSITION_OPEN, close the orphan.
+                # Single transaction so we don't end up with two open
+                # rows or two failed rows for the same broker holding.
+                with conn:
+                    conn.execute(
+                        "UPDATE positions SET status = 'POSITION_OPEN', "
+                        "updated_at = ? WHERE id = ?",
+                        (now, canonical_id),
+                    )
+                    conn.execute(
+                        "UPDATE positions SET status = 'CLOSED', "
+                        "updated_at = ? WHERE id = ?",
+                        (now, orphan_id),
+                    )
+                healed.append(
+                    f"{orphan['ticker']} #{orphan_id}→#{canonical_id} ({strategy_id})"
+                )
+                logger.warning(
+                    "Healed orphan attribution: %s qty=%.6f price=%.4f "
+                    "— merged unknown #%d into ENTRY_FAILED #%d (strategy=%s).",
+                    orphan["ticker"], float(orphan["quantity"]),
+                    float(orphan["entry_price"]),
+                    orphan_id, canonical_id, strategy_id,
+                )
+            result.orphans_healed.extend(healed)
+        except sqlite3.OperationalError:
+            logger.warning("Could not heal unknown orphans (DB unavailable)")
+        finally:
+            conn.close()
+
+    def _try_reattribute_entry_failed(
+        self,
+        conn: sqlite3.Connection,
+        ticker: str,
+        qty: float,
+        avg_cost: float,
+        now_iso: str,
+    ) -> bool:
+        """Attempt to merge an Alpaca-discovered position into a recent
+        ENTRY_FAILED row instead of creating a new ``strategy_id='unknown'``
+        orphan.
+
+        Returns True if a matching row was reattributed. False otherwise.
+
+        Match criteria (all must hold):
+        - status = 'ENTRY_FAILED'
+        - ticker matches
+        - quantity within 1e-6 (Alpaca fractional precision)
+        - entry_price within ``_ORPHAN_REATTRIBUTION_PRICE_TOL``
+        - row created within ``_ORPHAN_REATTRIBUTION_WINDOW_MIN``
+
+        Rationale: 2026-05-11 XLK fill in 169 ms, but the local 5-min
+        entry-pending sweep timed out anyway and flipped the row to
+        ENTRY_FAILED. The next reconciliation tick then saw the
+        unattached Alpaca position and created a duplicate row with
+        ``strategy_id='unknown'``, silently breaking the overnight_drift
+        exit logic. Treat the ENTRY_FAILED row as the canonical record
+        whenever the Alpaca position is clearly the same entry.
+        """
+        cutoff: str = (
+            datetime.now(tz=ET) - timedelta(minutes=self._ORPHAN_REATTRIBUTION_WINDOW_MIN)
+        ).isoformat()
+        row = conn.execute(
+            "SELECT id, strategy_id, quantity, entry_price FROM positions "
+            "WHERE ticker = ? AND status = 'ENTRY_FAILED' "
+            "AND ABS(quantity - ?) < 1e-6 "
+            "AND ABS(entry_price - ?) <= ? "
+            "AND entry_time >= ? "
+            "ORDER BY entry_time DESC LIMIT 1",
+            (ticker, qty, avg_cost, self._ORPHAN_REATTRIBUTION_PRICE_TOL, cutoff),
+        ).fetchone()
+        if row is None:
+            return False
+        row_id: int = int(row[0])
+        strategy_id: str = str(row[1]) if row[1] is not None else "unknown"
+        conn.execute(
+            "UPDATE positions SET status = 'POSITION_OPEN', updated_at = ? "
+            "WHERE id = ?",
+            (now_iso, row_id),
+        )
+        conn.commit()
+        logger.warning(
+            "Reattributed Alpaca position %s (qty=%.6f, price=%.4f) to "
+            "ENTRY_FAILED row #%d (strategy=%s) — entry filled at broker "
+            "but local marker timed out. See feedback_per_strategy_vs_broker_truth.",
+            ticker, qty, avg_cost, row_id, strategy_id,
+        )
+        return True
+
     def _create_db_position(self, ticker: str, pos: AlpacaPosition) -> None:
         now: str = datetime.now(tz=ET).isoformat()
         avg_cost: float = float(pos.avg_entry_price or 0)
@@ -539,6 +713,13 @@ class StateRecovery:
 
         conn: sqlite3.Connection = sqlite3.connect(self._db_path)
         try:
+            # Prefer reattributing a recent ENTRY_FAILED row over creating
+            # a fresh strategy_id='unknown' orphan. Same broker fill,
+            # known strategy attribution.
+            if self._try_reattribute_entry_failed(
+                conn, ticker, qty, avg_cost, now,
+            ):
+                return
             conn.execute(
                 """INSERT INTO positions
                    (ticker, exchange, currency, quantity, entry_price,

--- a/trading_bot/gateway/recovery.py
+++ b/trading_bot/gateway/recovery.py
@@ -593,36 +593,86 @@ class StateRecovery:
             healed: list[str] = []
             now: str = datetime.now(tz=ET).isoformat()
             for orphan in orphans:
-                match = conn.execute(
-                    "SELECT id, strategy_id FROM positions "
-                    "WHERE status = 'ENTRY_FAILED' AND ticker = ? "
-                    "AND ABS(quantity - ?) < 1e-6 "
-                    "AND ABS(entry_price - ?) <= ? "
-                    "AND entry_time >= ? "
-                    "AND strategy_id IS NOT NULL AND strategy_id != 'unknown' "
-                    "ORDER BY entry_time DESC LIMIT 1",
-                    (
-                        orphan["ticker"],
-                        float(orphan["quantity"]),
-                        float(orphan["entry_price"]),
-                        self._ORPHAN_REATTRIBUTION_PRICE_TOL,
-                        cutoff,
-                    ),
-                ).fetchone()
-                if match is None:
-                    continue
-                canonical_id: int = int(match["id"])
                 orphan_id: int = int(orphan["id"])
-                strategy_id: str = str(match["strategy_id"])
-                # Promote ENTRY_FAILED → POSITION_OPEN, close the orphan.
-                # Single transaction so we don't end up with two open
-                # rows or two failed rows for the same broker holding.
+                # Atomic claim: promote a matching ENTRY_FAILED row to
+                # POSITION_OPEN in a single UPDATE that selects on the
+                # match predicates. If another tick has already claimed
+                # the same ENTRY_FAILED row (status no longer matches),
+                # rowcount = 0 and we skip without producing a duplicate
+                # heal. Without this, the SELECT-then-UPDATE pattern had
+                # a race window where two ticks could both observe the
+                # ENTRY_FAILED row and both attempt to promote it /
+                # close the orphan, inflating the heal count.
                 with conn:
-                    conn.execute(
-                        "UPDATE positions SET status = 'POSITION_OPEN', "
-                        "updated_at = ? WHERE id = ?",
-                        (now, canonical_id),
+                    cur = conn.execute(
+                        "UPDATE positions "
+                        "SET status = 'POSITION_OPEN', updated_at = ? "
+                        "WHERE status = 'ENTRY_FAILED' AND ticker = ? "
+                        "AND ABS(quantity - ?) < 1e-6 "
+                        "AND ABS(entry_price - ?) <= ? "
+                        "AND entry_time >= ? "
+                        "AND strategy_id IS NOT NULL AND strategy_id != 'unknown' "
+                        "AND id = ("
+                        "    SELECT id FROM positions "
+                        "    WHERE status = 'ENTRY_FAILED' AND ticker = ? "
+                        "    AND ABS(quantity - ?) < 1e-6 "
+                        "    AND ABS(entry_price - ?) <= ? "
+                        "    AND entry_time >= ? "
+                        "    AND strategy_id IS NOT NULL AND strategy_id != 'unknown' "
+                        "    ORDER BY entry_time DESC LIMIT 1"
+                        ")",
+                        (
+                            now,
+                            orphan["ticker"],
+                            float(orphan["quantity"]),
+                            float(orphan["entry_price"]),
+                            self._ORPHAN_REATTRIBUTION_PRICE_TOL,
+                            cutoff,
+                            orphan["ticker"],
+                            float(orphan["quantity"]),
+                            float(orphan["entry_price"]),
+                            self._ORPHAN_REATTRIBUTION_PRICE_TOL,
+                            cutoff,
+                        ),
                     )
+                    if cur.rowcount == 0:
+                        # No matching ENTRY_FAILED row (or another tick
+                        # claimed it first). Leave the orphan alone.
+                        continue
+                    # Look up the row we just promoted so we can record
+                    # the canonical id + strategy in the heal summary.
+                    promoted = conn.execute(
+                        "SELECT id, strategy_id FROM positions "
+                        "WHERE ticker = ? AND status = 'POSITION_OPEN' "
+                        "AND ABS(quantity - ?) < 1e-6 "
+                        "AND ABS(entry_price - ?) <= ? "
+                        "AND id != ? "
+                        "AND updated_at = ? "
+                        "ORDER BY id DESC LIMIT 1",
+                        (
+                            orphan["ticker"],
+                            float(orphan["quantity"]),
+                            float(orphan["entry_price"]),
+                            self._ORPHAN_REATTRIBUTION_PRICE_TOL,
+                            orphan_id,
+                            now,
+                        ),
+                    ).fetchone()
+                    if promoted is None:
+                        # Promotion happened but lookup didn't find it
+                        # (extremely unlikely — would indicate concurrent
+                        # mutation). Log and bail without closing the
+                        # orphan, to avoid leaving an open Alpaca holding
+                        # with no DB row.
+                        logger.error(
+                            "Healed orphan attribution: %s promoted but "
+                            "canonical row lookup failed; not closing "
+                            "orphan #%d.",
+                            orphan["ticker"], orphan_id,
+                        )
+                        continue
+                    canonical_id = int(promoted["id"])
+                    strategy_id = str(promoted["strategy_id"])
                     conn.execute(
                         "UPDATE positions SET status = 'CLOSED', "
                         "updated_at = ? WHERE id = ?",
@@ -676,25 +726,54 @@ class StateRecovery:
         cutoff: str = (
             datetime.now(tz=ET) - timedelta(minutes=self._ORPHAN_REATTRIBUTION_WINDOW_MIN)
         ).isoformat()
+        # Atomic claim: single UPDATE filtered on the match predicates,
+        # with rowcount = 0 signalling "nothing to merge". This collapses
+        # the previous SELECT-then-UPDATE pair into a single statement
+        # so two concurrent ticks can't both observe the ENTRY_FAILED
+        # row and both promote it (the second tick's UPDATE would see
+        # status no longer matching 'ENTRY_FAILED' and report 0 rows).
+        with conn:
+            cur = conn.execute(
+                "UPDATE positions "
+                "SET status = 'POSITION_OPEN', updated_at = ? "
+                "WHERE ticker = ? AND status = 'ENTRY_FAILED' "
+                "AND ABS(quantity - ?) < 1e-6 "
+                "AND ABS(entry_price - ?) <= ? "
+                "AND entry_time >= ? "
+                "AND id = ("
+                "    SELECT id FROM positions "
+                "    WHERE ticker = ? AND status = 'ENTRY_FAILED' "
+                "    AND ABS(quantity - ?) < 1e-6 "
+                "    AND ABS(entry_price - ?) <= ? "
+                "    AND entry_time >= ? "
+                "    ORDER BY entry_time DESC LIMIT 1"
+                ")",
+                (
+                    now_iso,
+                    ticker, qty, avg_cost,
+                    self._ORPHAN_REATTRIBUTION_PRICE_TOL, cutoff,
+                    ticker, qty, avg_cost,
+                    self._ORPHAN_REATTRIBUTION_PRICE_TOL, cutoff,
+                ),
+            )
+            if cur.rowcount == 0:
+                return False
+        # Best-effort strategy_id lookup for the log line. The match
+        # criteria are tight enough that the row we just promoted is the
+        # only one fitting the description with updated_at = now_iso.
         row = conn.execute(
-            "SELECT id, strategy_id, quantity, entry_price FROM positions "
-            "WHERE ticker = ? AND status = 'ENTRY_FAILED' "
+            "SELECT id, strategy_id FROM positions "
+            "WHERE ticker = ? AND status = 'POSITION_OPEN' "
             "AND ABS(quantity - ?) < 1e-6 "
             "AND ABS(entry_price - ?) <= ? "
-            "AND entry_time >= ? "
-            "ORDER BY entry_time DESC LIMIT 1",
-            (ticker, qty, avg_cost, self._ORPHAN_REATTRIBUTION_PRICE_TOL, cutoff),
+            "AND updated_at = ? "
+            "ORDER BY id DESC LIMIT 1",
+            (ticker, qty, avg_cost, self._ORPHAN_REATTRIBUTION_PRICE_TOL, now_iso),
         ).fetchone()
-        if row is None:
-            return False
-        row_id: int = int(row[0])
-        strategy_id: str = str(row[1]) if row[1] is not None else "unknown"
-        conn.execute(
-            "UPDATE positions SET status = 'POSITION_OPEN', updated_at = ? "
-            "WHERE id = ?",
-            (now_iso, row_id),
+        row_id: int = int(row[0]) if row is not None else -1
+        strategy_id: str = (
+            str(row[1]) if row is not None and row[1] is not None else "unknown"
         )
-        conn.commit()
         logger.warning(
             "Reattributed Alpaca position %s (qty=%.6f, price=%.4f) to "
             "ENTRY_FAILED row #%d (strategy=%s) — entry filled at broker "

--- a/trading_bot/tests/test_state_recovery.py
+++ b/trading_bot/tests/test_state_recovery.py
@@ -497,3 +497,284 @@ class TestStateRecovery:
         assert "PLTR" not in result.eod_flatten_orders
         # No new submit_order — only pre-existing orders observed.
         assert gw.client.submit_order.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Orphan-attribution recovery (2026-05-11 XLK regression)
+# ---------------------------------------------------------------------------
+
+
+def _insert_entry_failed(
+    conn: sqlite3.Connection,
+    ticker: str,
+    qty: float,
+    entry_price: float,
+    strategy_id: str = "overnight_drift",
+    minutes_ago: int = 5,
+) -> int:
+    entry_time = (datetime.now(ET) - timedelta(minutes=minutes_ago)).isoformat()
+    cur = conn.execute(
+        """INSERT INTO positions
+           (ticker, exchange, currency, quantity, entry_price, entry_time,
+            status, hold_type, phase, strategy_id, alpaca_order_id)
+           VALUES (?,?,?,?,?,?,?,?,?,?,?)""",
+        (
+            ticker, "US", "USD", qty, entry_price, entry_time,
+            "ENTRY_FAILED", "swing", 3, strategy_id, "entry-order-abc",
+        ),
+    )
+    conn.commit()
+    return cur.lastrowid  # type: ignore[return-value]
+
+
+def _insert_unknown_orphan(
+    conn: sqlite3.Connection,
+    ticker: str,
+    qty: float,
+    entry_price: float,
+    minutes_ago: int = 0,
+) -> int:
+    entry_time = (datetime.now(ET) - timedelta(minutes=minutes_ago)).isoformat()
+    cur = conn.execute(
+        """INSERT INTO positions
+           (ticker, exchange, currency, quantity, entry_price, entry_time,
+            status, hold_type, phase, strategy_id)
+           VALUES (?,?,?,?,?,?,?,?,?,?)""",
+        (
+            ticker, "AssetExchange.ARCA", "USD", qty, entry_price, entry_time,
+            "POSITION_OPEN", "swing", 1, "unknown",
+        ),
+    )
+    conn.commit()
+    return cur.lastrowid  # type: ignore[return-value]
+
+
+class TestOrphanAttributionRecovery:
+    """Regression suite for the 2026-05-11 XLK orphan-attribution bug.
+
+    Symptom: 169 ms Alpaca fill on a fractional overnight_drift entry,
+    5-min local entry-pending sweep flipped the row to ENTRY_FAILED
+    before the fill was observed, then the next reconcile tick saw the
+    unattached Alpaca position and created a duplicate row with
+    strategy_id='unknown'. Overnight_drift's exit logic then refused to
+    fire on the orphan, leaving the position long indefinitely.
+    """
+
+    def _make_gateway(self, positions: list | None = None) -> MagicMock:
+        gw = MagicMock()
+        gw.account_id = "TEST_ACCOUNT"
+        gw.client = MagicMock()
+        gw.get_positions = AsyncMock(return_value=positions or [])
+        gw.get_open_orders = AsyncMock(return_value=[])
+        gw.get_account_summary = AsyncMock(
+            return_value={
+                "NetLiquidation": "100000.0",
+                "SettledCash": "99000.0",
+                "BuyingPower": "99000.0",
+            }
+        )
+        return gw
+
+    @pytest.mark.asyncio
+    async def test_create_db_position_reattributes_to_matching_entry_failed(
+        self, tmp_db_path: str, mock_notifier
+    ):
+        """When Alpaca exposes a position not in the open DB rows but
+        matching a recent ENTRY_FAILED row, _create_db_position must
+        promote the ENTRY_FAILED row instead of inserting a new orphan
+        with strategy_id='unknown'.
+        """
+        conn = sqlite3.connect(tmp_db_path)
+        failed_id = _insert_entry_failed(
+            conn, "XLK", qty=0.3927, entry_price=177.438,
+            strategy_id="overnight_drift", minutes_ago=5,
+        )
+        conn.close()
+
+        pos = _alpaca_position("XLK", qty=0.3927, avg_entry_price=177.438)
+        gw = self._make_gateway(positions=[pos])
+        recovery = _make_recovery(gw, tmp_db_path, mock_notifier)
+        await recovery.recover()
+
+        conn = sqlite3.connect(tmp_db_path)
+        try:
+            rows = conn.execute(
+                "SELECT id, status, strategy_id FROM positions "
+                "WHERE ticker = 'XLK' ORDER BY id"
+            ).fetchall()
+        finally:
+            conn.close()
+        # Only ONE XLK row — the ENTRY_FAILED row got promoted, no
+        # new orphan was created.
+        assert len(rows) == 1, (
+            f"expected single reattributed row, got {len(rows)} rows: {rows}"
+        )
+        assert rows[0][0] == failed_id
+        assert rows[0][1] == "POSITION_OPEN"
+        assert rows[0][2] == "overnight_drift", (
+            "strategy attribution must be preserved from the original "
+            "ENTRY_FAILED row, not collapsed to 'unknown'"
+        )
+
+    @pytest.mark.asyncio
+    async def test_create_db_position_no_match_still_creates_unknown_orphan(
+        self, tmp_db_path: str, mock_notifier
+    ):
+        """Negative case: when no ENTRY_FAILED row matches, fall back to
+        the legacy strategy_id='unknown' insert so the position is at
+        least tracked (some other recovery path may attribute it later).
+        """
+        pos = _alpaca_position("XLB", qty=10.0, avg_entry_price=50.0)
+        gw = self._make_gateway(positions=[pos])
+        recovery = _make_recovery(gw, tmp_db_path, mock_notifier)
+        await recovery.recover()
+
+        conn = sqlite3.connect(tmp_db_path)
+        try:
+            row = conn.execute(
+                "SELECT status, strategy_id FROM positions WHERE ticker = 'XLB'"
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row is not None
+        assert row[0] == "POSITION_OPEN"
+        assert row[1] == "unknown"
+
+    @pytest.mark.asyncio
+    async def test_create_db_position_quantity_mismatch_does_not_merge(
+        self, tmp_db_path: str, mock_notifier
+    ):
+        """Quantity mismatch (e.g. partial fill) must NOT merge — that
+        would attribute the wrong size to the original strategy. Falls
+        through to the unknown-orphan path.
+        """
+        conn = sqlite3.connect(tmp_db_path)
+        _insert_entry_failed(
+            conn, "XLK", qty=0.3927, entry_price=177.438,
+            strategy_id="overnight_drift", minutes_ago=5,
+        )
+        conn.close()
+        # Half-share off — clearly a different fill.
+        pos = _alpaca_position("XLK", qty=0.5, avg_entry_price=177.438)
+        gw = self._make_gateway(positions=[pos])
+        recovery = _make_recovery(gw, tmp_db_path, mock_notifier)
+        await recovery.recover()
+
+        conn = sqlite3.connect(tmp_db_path)
+        try:
+            statuses = {
+                row[0]: row[1] for row in conn.execute(
+                    "SELECT status, strategy_id FROM positions "
+                    "WHERE ticker = 'XLK'"
+                ).fetchall()
+            }
+        finally:
+            conn.close()
+        # ENTRY_FAILED still ENTRY_FAILED, plus a new POSITION_OPEN orphan.
+        assert statuses.get("ENTRY_FAILED") == "overnight_drift"
+        assert statuses.get("POSITION_OPEN") == "unknown"
+
+    @pytest.mark.asyncio
+    async def test_create_db_position_stale_entry_failed_does_not_merge(
+        self, tmp_db_path: str, mock_notifier
+    ):
+        """ENTRY_FAILED rows older than the reattribution window must NOT
+        merge — they were genuinely failed entries, not late fills.
+        """
+        conn = sqlite3.connect(tmp_db_path)
+        _insert_entry_failed(
+            conn, "XLK", qty=0.3927, entry_price=177.438,
+            strategy_id="overnight_drift", minutes_ago=120,  # 2h old
+        )
+        conn.close()
+        pos = _alpaca_position("XLK", qty=0.3927, avg_entry_price=177.438)
+        gw = self._make_gateway(positions=[pos])
+        recovery = _make_recovery(gw, tmp_db_path, mock_notifier)
+        await recovery.recover()
+
+        conn = sqlite3.connect(tmp_db_path)
+        try:
+            rows = conn.execute(
+                "SELECT status, strategy_id FROM positions "
+                "WHERE ticker = 'XLK'"
+            ).fetchall()
+        finally:
+            conn.close()
+        # Two rows: stale ENTRY_FAILED unchanged + new unknown orphan
+        assert len(rows) == 2
+        statuses = {r[0] for r in rows}
+        assert "ENTRY_FAILED" in statuses
+        assert "POSITION_OPEN" in statuses
+
+    @pytest.mark.asyncio
+    async def test_heal_unknown_orphans_merges_existing_pair(
+        self, tmp_db_path: str, mock_notifier
+    ):
+        """Live-incident-specific case: position #97 already exists in
+        the DB as a strategy_id='unknown' POSITION_OPEN orphan, and
+        position #96 is the matching ENTRY_FAILED row from the prior
+        tick. _heal_unknown_orphans must merge them.
+        """
+        conn = sqlite3.connect(tmp_db_path)
+        failed_id = _insert_entry_failed(
+            conn, "XLK", qty=0.3927, entry_price=177.438,
+            strategy_id="overnight_drift", minutes_ago=15,
+        )
+        orphan_id = _insert_unknown_orphan(
+            conn, "XLK", qty=0.3927, entry_price=177.438, minutes_ago=10,
+        )
+        conn.close()
+
+        # Alpaca still reports the position so the reconciler treats
+        # the now-promoted ENTRY_FAILED row as the canonical match.
+        pos = _alpaca_position("XLK", qty=0.3927, avg_entry_price=177.438)
+        gw = self._make_gateway(positions=[pos])
+        recovery = _make_recovery(gw, tmp_db_path, mock_notifier)
+        result = await recovery.recover()
+
+        assert any("XLK" in s for s in result.orphans_healed), (
+            f"expected orphan heal in result, got {result.orphans_healed}"
+        )
+
+        conn = sqlite3.connect(tmp_db_path)
+        try:
+            failed_status = conn.execute(
+                "SELECT status, strategy_id FROM positions WHERE id = ?",
+                (failed_id,),
+            ).fetchone()
+            orphan_status = conn.execute(
+                "SELECT status FROM positions WHERE id = ?", (orphan_id,),
+            ).fetchone()
+        finally:
+            conn.close()
+        # ENTRY_FAILED promoted to POSITION_OPEN with original strategy
+        assert failed_status[0] == "POSITION_OPEN"
+        assert failed_status[1] == "overnight_drift"
+        # Orphan row closed out so it doesn't double-count
+        assert orphan_status[0] == "CLOSED"
+
+    @pytest.mark.asyncio
+    async def test_heal_unknown_orphans_idempotent(
+        self, tmp_db_path: str, mock_notifier
+    ):
+        """Running recovery twice must not double-merge or thrash state."""
+        conn = sqlite3.connect(tmp_db_path)
+        _insert_entry_failed(
+            conn, "XLK", qty=0.3927, entry_price=177.438,
+            strategy_id="overnight_drift", minutes_ago=15,
+        )
+        _insert_unknown_orphan(
+            conn, "XLK", qty=0.3927, entry_price=177.438, minutes_ago=10,
+        )
+        conn.close()
+
+        pos = _alpaca_position("XLK", qty=0.3927, avg_entry_price=177.438)
+        gw = self._make_gateway(positions=[pos])
+        recovery = _make_recovery(gw, tmp_db_path, mock_notifier)
+        first = await recovery.recover()
+        second = await recovery.recover()
+
+        assert first.orphans_healed
+        # Second pass: no new healing work to do — the original orphan
+        # is now CLOSED and there's no remaining unknown POSITION_OPEN.
+        assert second.orphans_healed == []

--- a/trading_bot/tests/test_state_recovery.py
+++ b/trading_bot/tests/test_state_recovery.py
@@ -778,3 +778,77 @@ class TestOrphanAttributionRecovery:
         # Second pass: no new healing work to do — the original orphan
         # is now CLOSED and there's no remaining unknown POSITION_OPEN.
         assert second.orphans_healed == []
+
+    @pytest.mark.asyncio
+    async def test_heal_unknown_orphans_atomic_under_double_claim(
+        self, tmp_db_path: str, mock_notifier
+    ):
+        """Regression for SELECT-then-UPDATE race in _heal_unknown_orphans.
+
+        The earlier implementation used a SELECT to find an orphan/
+        ENTRY_FAILED pair then a separate UPDATE inside `with conn:`.
+        Two concurrent ticks could both observe the same pair and both
+        attempt the merge, inflating the heal count and (worse) producing
+        a second POSITION_OPEN row from the same broker holding if the
+        ENTRY_FAILED row was already promoted.
+
+        With the atomic single-UPDATE-with-rowcount-check, the second
+        attempt must report no healing and the DB must reflect exactly
+        ONE POSITION_OPEN row for the ticker.
+        """
+        conn = sqlite3.connect(tmp_db_path)
+        failed_id = _insert_entry_failed(
+            conn, "XLK", qty=0.3927, entry_price=177.438,
+            strategy_id="overnight_drift", minutes_ago=15,
+        )
+        orphan_id = _insert_unknown_orphan(
+            conn, "XLK", qty=0.3927, entry_price=177.438, minutes_ago=10,
+        )
+        conn.close()
+
+        pos = _alpaca_position("XLK", qty=0.3927, avg_entry_price=177.438)
+        gw = self._make_gateway(positions=[pos])
+
+        # Simulate two ticks racing against the same state by building
+        # two recovery instances against the same DB path and calling
+        # _heal_unknown_orphans directly twice in sequence. The atomic
+        # UPDATE in the second call must observe status != ENTRY_FAILED
+        # and report no heal.
+        from trading_bot.gateway.recovery import RecoveryResult
+        recovery_a = _make_recovery(gw, tmp_db_path, mock_notifier)
+        recovery_b = _make_recovery(gw, tmp_db_path, mock_notifier)
+
+        result_a = RecoveryResult()
+        result_b = RecoveryResult()
+        recovery_a._heal_unknown_orphans(result_a)
+        recovery_b._heal_unknown_orphans(result_b)
+
+        # First call did the work; second saw a clean DB.
+        assert len(result_a.orphans_healed) == 1
+        assert result_b.orphans_healed == []
+
+        # End-state must have exactly ONE POSITION_OPEN row for XLK —
+        # the promoted ENTRY_FAILED row — and the original orphan must
+        # be CLOSED. No duplicate POSITION_OPEN.
+        conn = sqlite3.connect(tmp_db_path)
+        try:
+            rows = conn.execute(
+                "SELECT id, status, strategy_id FROM positions "
+                "WHERE ticker = 'XLK' ORDER BY id"
+            ).fetchall()
+        finally:
+            conn.close()
+        open_rows = [r for r in rows if r[1] == "POSITION_OPEN"]
+        assert len(open_rows) == 1, (
+            f"expected exactly 1 POSITION_OPEN after double-heal, "
+            f"got {len(open_rows)} rows: {rows}"
+        )
+        assert open_rows[0][0] == failed_id
+        assert open_rows[0][2] == "overnight_drift"
+        # Original orphan must be CLOSED.
+        closed_orphan = [
+            r for r in rows if r[0] == orphan_id and r[1] == "CLOSED"
+        ]
+        assert closed_orphan, (
+            f"orphan #{orphan_id} must be CLOSED after heal, got {rows}"
+        )


### PR DESCRIPTION
## Summary

When an entry order fills on Alpaca but the local 5-min entry-pending sweep flips the row to `ENTRY_FAILED` before the fill is observed, the next reconciliation tick sees the unattached Alpaca position and creates a duplicate row with `strategy_id='unknown'`. The strategy's exit logic then refuses to fire on the orphan, leaving the position held indefinitely.

Observed live 2026-05-11: 169 ms Alpaca fill for XLK overnight_drift entry, 5-min local timeout, orphan created with wrong attribution. Monday-morning exit didn't fire on it.

## Two paths reattribute

1. **`_create_db_position`** (orphan-creation site in `StateRecovery`): Before inserting a fresh `'unknown'` row, look for a matching `ENTRY_FAILED` row within 30 min by ticker + quantity (1e-6 tol) + entry_price (1¢ tol). If found, promote in place keeping its original `strategy_id`.

2. **`_heal_unknown_orphans`** (new step in `recover()`): Scan existing `strategy_id='unknown'` POSITION_OPEN rows from the last 48 h and pair them with matching `ENTRY_FAILED` rows. Promote the `ENTRY_FAILED` row (it carries the correct `alpaca_order_id` and strategy); close the orphan as `CLOSED`. Idempotent.

## Test plan
- [x] `test_create_db_position_reattributes_to_matching_entry_failed`
- [x] `test_create_db_position_no_match_still_creates_unknown_orphan`
- [x] `test_create_db_position_quantity_mismatch_does_not_merge`
- [x] `test_create_db_position_stale_entry_failed_does_not_merge`
- [x] `test_heal_unknown_orphans_merges_existing_pair`
- [x] `test_heal_unknown_orphans_idempotent`
- [x] Full suite — 880 passed

After merge, tomorrow morning's first tick will auto-heal today's XLK position #97 (`strategy='unknown'`) by merging it into #96 (`ENTRY_FAILED`, `overnight_drift`), and overnight_drift's morning exit will fire correctly.

Pairs with [#98](https://github.com/alex5imon/ai-broker/pull/98) — together they unblock XLF #95 and XLK #97 from tomorrow's open.