### PR TITLE
fix(execution): broker-position fallback + always-notify on exit failure

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -341,7 +341,16 @@ entry:
   spread_max_us_pct: 0.0005       # 0.05%
   spread_wait_seconds: 120        # Wait up to 2 min for spread to narrow
   spread_recheck_seconds: 15      # Recheck spread every 15 sec
-  entry_timeout_seconds: 300      # Cancel unfilled entry after 5 min
+  # 2026-05-11: extended 300 → 600. Alpaca's get_order_by_id can lag
+  # behind the matching engine by 100s of ms to seconds — a 5-min poll
+  # at boundary can return status='new'/filled_qty=0 for an order that
+  # already filled, causing _maybe_timeout_entry to mark ENTRY_FAILED
+  # and orphan the position. The 10-min window gives Alpaca enough time
+  # to propagate the fill across REST endpoints. Combined with the
+  # _consistency_check_alpaca_position fallback in order_manager, the
+  # bot will also catch any remaining races by treating the Alpaca
+  # position list as the source of truth.
+  entry_timeout_seconds: 600      # Cancel unfilled entry after 10 min
   # Maximum slop above ask (buys) or below bid (sells) for entry limit
   # orders. Prevents thin-spread / pre-market chasing where a strategy's
   # current_price reference may already sit at ask. 0.002 = 0.2%.

--- a/trading_bot/execution/order_manager.py
+++ b/trading_bot/execution/order_manager.py
@@ -57,6 +57,28 @@ logger: logging.Logger = logging.getLogger(__name__)
 ET: ZoneInfo = TZ_EASTERN
 
 
+def _coerce_broker_qty(value: Any) -> float | None:
+    """Coerce an Alpaca position field to float, or return None.
+
+    Alpaca returns qty/avg_entry_price as strings ("0.3927", "177.438").
+    A defensive coercion: only accept str/int/float so the call site
+    is immune to test gateways that auto-mock attributes with
+    MagicMock objects (which would otherwise yield ``float(MagicMock)
+    == 1.0`` and trick the consistency check into reporting a held
+    position that doesn't exist).
+    """
+    if value is None:
+        return None
+    if not isinstance(value, (str, int, float)):
+        return None
+    if isinstance(value, str) and not value.strip():
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
 # Callback fired when a strategy-driven exit order (place_exit /
 # place_limit_exit) actually FILLS at the broker. Args:
 # (strategy_id, ticker, filled_qty, realized_pnl). The pnl is computed
@@ -673,6 +695,31 @@ class OrderManager:
             await self.cancel_order(alpaca_order_id)
             await self._transition_to_open(trade_id, active.filled_shares)
         else:
+            # Belt-and-suspenders: before declaring ENTRY_FAILED, ask the
+            # broker directly whether we actually hold the position. The
+            # order-status endpoint can lag the fill by seconds (observed
+            # 2026-05-11: 169 ms fill, 5-min poll still showed
+            # filled_qty=0), which would otherwise orphan a real
+            # position. If the position exists at the broker, treat the
+            # order as filled and transition to POSITION_OPEN with the
+            # actual broker qty + avg cost.
+            broker_qty: float | None = await self._broker_held_qty(active.ticker)
+            if broker_qty is not None and broker_qty > 0:
+                broker_avg: float = await self._broker_avg_entry_price(
+                    active.ticker,
+                ) or active.entry_price
+                logger.warning(
+                    "Entry timeout: order-status lag for %s — broker holds "
+                    "%.6f sh @ $%.4f despite filled_qty=0 on order. "
+                    "Promoting to POSITION_OPEN (trade_id=%d, age=%.0fs).",
+                    active.ticker, broker_qty, broker_avg, trade_id,
+                    age.total_seconds(),
+                )
+                active.filled_shares = broker_qty
+                active.entry_price = broker_avg
+                await self._transition_to_open(trade_id, broker_qty)
+                return
+
             logger.info(
                 "Entry timeout: cancelling %s (filled %.4f/%.4f, age=%.0fs, trade_id=%d)",
                 active.ticker, active.filled_shares, active.entry_shares,
@@ -699,6 +746,34 @@ class OrderManager:
                        f"{active.entry_shares:.4f} after {age.total_seconds():.0f}s",
             )
             del self._active_orders[trade_id]
+
+    async def _broker_held_qty(self, ticker: str) -> float | None:
+        """Return Alpaca-side held qty for ``ticker``, or None on lookup
+        failure / no position. Used by ``_maybe_timeout_entry`` to avoid
+        marking a position ENTRY_FAILED when the broker has actually
+        filled the order but order-status hasn't propagated yet.
+        """
+        try:
+            pos = await asyncio.to_thread(
+                self._gw.client.get_open_position, ticker,  # type: ignore[arg-type]
+            )
+        except Exception:
+            # No open position OR transient error — fall through to the
+            # legacy ENTRY_FAILED path. Don't try to distinguish; the
+            # consistency check is best-effort and should never break
+            # the timeout path.
+            return None
+        return _coerce_broker_qty(getattr(pos, "qty", None))
+
+    async def _broker_avg_entry_price(self, ticker: str) -> float | None:
+        """Mirror of _broker_held_qty for the broker's avg entry price."""
+        try:
+            pos = await asyncio.to_thread(
+                self._gw.client.get_open_position, ticker,  # type: ignore[arg-type]
+            )
+        except Exception:
+            return None
+        return _coerce_broker_qty(getattr(pos, "avg_entry_price", None))
 
     # ------------------------------------------------------------------
     # Stop / Target / Trailing
@@ -920,18 +995,28 @@ class OrderManager:
                     matching_trade_id, PositionStatus.CLOSING,
                 )
             return order_id
-        except Exception:
+        except Exception as exc:
             logger.exception(
                 "CRITICAL: Failed to place strategy exit for %s (qty=%s, reason=%s)",
                 ticker, qty, reason,
             )
-            if is_emergency:
-                await self._notifier.send(
-                    "Strategy Exit Failed",
-                    f"Failed to exit {qty} {ticker} (reason={reason}). Manual review required.",
-                    priority=4,
-                    tags=["warning"],
-                )
+            # Always notify — every place_exit caller intends to actually
+            # close a real position, so a failure means the position is
+            # stuck. Today's silent failure mode (2026-05-08 → 2026-05-11
+            # daily "insufficient qty" rejections, no alert ever fired)
+            # showed that the prior is_emergency-only path was too
+            # restrictive. is_emergency now only escalates priority.
+            priority: int = 5 if is_emergency else 4
+            await self._notifier.send(
+                "Strategy Exit Failed",
+                (
+                    f"Failed to exit {qty} {ticker} (reason={reason}). "
+                    f"Position remains long at the broker. Manual review "
+                    f"required. Error: {type(exc).__name__}: {exc}"
+                ),
+                priority=priority,
+                tags=["warning"],
+            )
             return None
 
     async def place_limit_exit(

--- a/trading_bot/execution/order_manager.py
+++ b/trading_bot/execution/order_manager.py
@@ -60,14 +60,34 @@ ET: ZoneInfo = TZ_EASTERN
 def _coerce_broker_qty(value: Any) -> float | None:
     """Coerce an Alpaca position field to float, or return None.
 
-    Alpaca returns qty/avg_entry_price as strings ("0.3927", "177.438").
-    A defensive coercion: only accept str/int/float so the call site
-    is immune to test gateways that auto-mock attributes with
-    MagicMock objects (which would otherwise yield ``float(MagicMock)
-    == 1.0`` and trick the consistency check into reporting a held
-    position that doesn't exist).
+    Alpaca returns ``qty`` / ``avg_entry_price`` as strings
+    ("0.3927", "177.438") via Pydantic-defined ``Optional[str]``
+    fields. A defensive coercion: only accept ``str``/``int``/``float``
+    so the call site is immune to:
+
+    1. **MagicMock auto-attrs in tests.** ``float(MagicMock())`` returns
+       1.0, which would otherwise trick the timeout-fallback consistency
+       check in ``_maybe_timeout_entry`` into reporting a held position
+       that doesn't exist. The strict isinstance check forces tests to
+       set string values explicitly (matching production SDK behavior).
+    2. **``bool``-as-``int`` aliasing.** ``isinstance(True, int)`` is
+       True in Python, so a stray ``True`` would pass and
+       ``float(True) == 1.0`` — wrong for a position quantity. Listing
+       the types explicitly and excluding bool via a guard isn't done
+       directly here, but the SDK contract guarantees str, not bool, so
+       the isinstance check is sufficient — IF the SDK ever changed to
+       return bool we'd want to know rather than silently coerce.
+
+    ``decimal.Decimal`` is rejected because alpaca-py's release-pinned
+    Pydantic model defines these fields as ``str`` and never produces
+    Decimal. If that changes we want a None return + explicit log over
+    silent type-coercion that could lose precision.
     """
     if value is None:
+        return None
+    # `bool` is a subclass of `int`; reject explicitly because
+    # `float(True) == 1.0` would silently look like a 1-share position.
+    if isinstance(value, bool):
         return None
     if not isinstance(value, (str, int, float)):
         return None

--- a/trading_bot/tests/test_order_manager_lifecycle.py
+++ b/trading_bot/tests/test_order_manager_lifecycle.py
@@ -323,6 +323,92 @@ class TestEntryTimeout:
         assert trade_id not in om._active_orders
 
     @pytest.mark.asyncio
+    async def test_timeout_with_broker_position_promotes_to_open(
+        self, config, tmp_db_path: str, mock_notifier
+    ):
+        """Regression for 2026-05-11 XLK order-status lag bug.
+
+        Alpaca filled the order in 169 ms but the bot's 5-min poll
+        returned filled_qty=0 (stale endpoint). _maybe_timeout_entry
+        was about to mark the row ENTRY_FAILED, which then orphaned the
+        real broker-held position. The fix: before declaring failure,
+        consult ``get_open_position`` — if the broker actually holds
+        the qty, promote the row to POSITION_OPEN with the real fill
+        data.
+        """
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        entry_alpaca = _alpaca_order("entry-1", "new")
+        om._gw.client.submit_order = MagicMock(return_value=entry_alpaca)
+        # Use integer-share entry so the _entry helper's int() doesn't
+        # truncate to 0. The broker-side qty/price the consistency check
+        # observes is what matters for the assertion.
+        trade_id = await om.place_entry(_entry(shares=100, price=10.0))
+
+        # Stale order status: still 'new', 0 filled, 10 min old (≥ default
+        # entry_timeout). The broker, however, holds the position.
+        old_submitted = datetime.now(tz=ET) - timedelta(seconds=600)
+        stale_status = _alpaca_order(
+            "entry-1", "new",
+            filled_qty=0.0, filled_avg_price=0.0,
+            submitted_at=old_submitted,
+        )
+        om._gw.client.get_order_by_id = MagicMock(return_value=stale_status)
+        om._gw.client.cancel_order_by_id = MagicMock()
+        om._gw.client.submit_order = MagicMock(
+            return_value=_alpaca_order("stop-1", "new"),
+        )
+
+        # Alpaca position list: position exists at the broker.
+        broker_pos = MagicMock()
+        broker_pos.qty = "100"  # str — matches alpaca-py serialization
+        broker_pos.avg_entry_price = "10.00"
+        om._gw.client.get_open_position = MagicMock(return_value=broker_pos)
+
+        await om._check_order_statuses()
+
+        active = om._active_orders[trade_id]
+        # Promoted to POSITION_OPEN with the broker's qty + avg cost,
+        # not ENTRY_FAILED — order-status lag must not orphan a real fill.
+        assert active.status != PositionStatus.ENTRY_FAILED, (
+            "broker holds the position; row must NOT be marked ENTRY_FAILED"
+        )
+        assert active.filled_shares == pytest.approx(100.0, abs=1e-6)
+        assert active.entry_price == pytest.approx(10.0, abs=0.01)
+
+    @pytest.mark.asyncio
+    async def test_timeout_with_no_broker_position_marks_entry_failed(
+        self, config, tmp_db_path: str, mock_notifier
+    ):
+        """Negative case: timeout fires, order-status is stale, AND the
+        broker has no position — legitimate ENTRY_FAILED path.
+        """
+        from alpaca.common.exceptions import APIError
+
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        entry_alpaca = _alpaca_order("entry-1", "new")
+        om._gw.client.submit_order = MagicMock(return_value=entry_alpaca)
+        trade_id = await om.place_entry(_entry(shares=10, price=100.0))
+
+        old_submitted = datetime.now(tz=ET) - timedelta(seconds=600)
+        stale = _alpaca_order(
+            "entry-1", "new",
+            filled_qty=0.0, filled_avg_price=0.0,
+            submitted_at=old_submitted,
+        )
+        om._gw.client.get_order_by_id = MagicMock(return_value=stale)
+        om._gw.client.cancel_order_by_id = MagicMock()
+        # Production Alpaca raises APIError when no position exists.
+        om._gw.client.get_open_position = MagicMock(
+            side_effect=APIError({"message": "position not found"}),
+        )
+
+        await om._check_order_statuses()
+
+        assert trade_id not in om._active_orders, (
+            "no broker position — legacy ENTRY_FAILED path must fire"
+        )
+
+    @pytest.mark.asyncio
     async def test_recent_pending_order_not_timed_out(
         self, config, tmp_db_path: str, mock_notifier
     ):
@@ -721,6 +807,31 @@ class TestPlaceExit:
         assert order_id is None
         # Emergency exits should fire a notification on failure
         mock_notifier.send.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_place_exit_notifies_on_non_emergency_failure(
+        self, config, tmp_db_path: str, mock_notifier,
+    ):
+        """Regression for 2026-05-08 → 2026-05-11 silent-failure mode.
+
+        overnight_drift's morning exit failed daily with Alpaca's
+        "insufficient qty available" rejection, but the alert path was
+        gated on ``is_emergency=True`` — strategy callers pass False,
+        so nothing ever fired. The position survived multiple sessions
+        with zero operator visibility.
+        """
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        om._gw.client.submit_order = MagicMock(side_effect=RuntimeError("rejected"))
+        om._gw.client.get_orders = MagicMock(return_value=[])
+
+        order_id = await om.place_exit(
+            ticker="XLF", qty=1.989, reason="overnight_exit",
+            is_emergency=False,
+        )
+        assert order_id is None
+        mock_notifier.send.assert_awaited(), (
+            "non-emergency exit failures must still notify — position is stuck"
+        )
 
     @pytest.mark.asyncio
     async def test_place_exit_rejects_non_positive_qty(

--- a/trading_bot/tests/test_order_manager_lifecycle.py
+++ b/trading_bot/tests/test_order_manager_lifecycle.py
@@ -1641,3 +1641,56 @@ class TestStrategyExitFillCallback:
         assert sid == "mean_reversion"
         assert qty == 10.0
         assert pnl == pytest.approx(-6.0, rel=1e-6)  # (99.40 - 100) * 10
+
+
+# ---------------------------------------------------------------------------
+# _coerce_broker_qty — defensive coercion helper for the timeout fallback
+# ---------------------------------------------------------------------------
+
+
+class TestCoerceBrokerQty:
+    """Locks in the strict-type contract for the broker-position fallback.
+
+    The helper is the gatekeeper between Alpaca position fields and the
+    promote-to-open path in _maybe_timeout_entry. Loose coercion here
+    would cause silent miscategorisation of a held position vs no
+    position, which directly affects whether a row becomes
+    POSITION_OPEN or ENTRY_FAILED.
+    """
+
+    def test_accepts_alpaca_string_qty(self) -> None:
+        from trading_bot.execution.order_manager import _coerce_broker_qty
+        assert _coerce_broker_qty("0.3927") == pytest.approx(0.3927)
+        assert _coerce_broker_qty("100") == 100.0
+
+    def test_accepts_int_and_float(self) -> None:
+        from trading_bot.execution.order_manager import _coerce_broker_qty
+        assert _coerce_broker_qty(10) == 10.0
+        assert _coerce_broker_qty(3.5) == 3.5
+
+    def test_rejects_none(self) -> None:
+        from trading_bot.execution.order_manager import _coerce_broker_qty
+        assert _coerce_broker_qty(None) is None
+
+    def test_rejects_bool(self) -> None:
+        """bool is a subclass of int — explicit reject so float(True)==1.0
+        can't silently look like a 1-share position."""
+        from trading_bot.execution.order_manager import _coerce_broker_qty
+        assert _coerce_broker_qty(True) is None
+        assert _coerce_broker_qty(False) is None
+
+    def test_rejects_magicmock(self) -> None:
+        """Defends against test gateways that auto-mock the qty attribute.
+        Without this guard, float(MagicMock()) returns 1.0 and the
+        timeout-fallback path would falsely report a held position."""
+        from trading_bot.execution.order_manager import _coerce_broker_qty
+        assert _coerce_broker_qty(MagicMock()) is None
+
+    def test_rejects_empty_string(self) -> None:
+        from trading_bot.execution.order_manager import _coerce_broker_qty
+        assert _coerce_broker_qty("") is None
+        assert _coerce_broker_qty("   ") is None
+
+    def test_rejects_garbage_string(self) -> None:
+        from trading_bot.execution.order_manager import _coerce_broker_qty
+        assert _coerce_broker_qty("not-a-number") is None


### PR DESCRIPTION
## Summary

Three related fixes from the 2026-05-11 live-trading post-mortem.

### 1. Broker-position fallback in `_maybe_timeout_entry`

Alpaca's `get_order_by_id` can lag the matching engine by seconds. The 2026-05-11 XLK entry filled in **169 ms** but the 5-min poll still reported `filled_qty=0`, causing `_maybe_timeout_entry` to mark the row ENTRY_FAILED. The next reconcile tick then orphaned the real broker position with `strategy_id='unknown'`.

Before declaring ENTRY_FAILED, the bot now consults `get_open_position(ticker)`. If the broker holds the qty, the row is promoted to POSITION_OPEN with the broker's reported qty and avg cost. Treat broker as source of truth.

Includes a defensive `_coerce_broker_qty` helper that only accepts str/int/float so test gateways auto-mocking attributes can't spoof a held position.

### 2. `entry_timeout_seconds`: 300 → 600

Even with the fallback, a 10-min window gives Alpaca more time to propagate fills before any sweep fires.

### 3. Always notify on `place_exit` failure

The prior code only sent an ntfy alert when `is_emergency=True`. Strategy callers pass False, so today's 3-day silent-failure mode (XLK + XLF "insufficient qty available" rejections) generated zero alerts. `is_emergency` now only escalates priority (4 → 5).

## Test plan
- [x] `test_timeout_with_broker_position_promotes_to_open`
- [x] `test_timeout_with_no_broker_position_marks_entry_failed`
- [x] `test_place_exit_notifies_on_non_emergency_failure`
- [x] Full suite — 882 passed

Pairs with [#98](https://github.com/alex5imon/ai-broker/pull/98) (phantom-stop cancel-all) and [#99](https://github.com/alex5imon/ai-broker/pull/99) (orphan-attribution heal).