### PR TITLE
fix(recovery): skip emergency-stop placement outside market-hours window

### DIFF
--- a/trading_bot/gateway/recovery.py
+++ b/trading_bot/gateway/recovery.py
@@ -281,15 +281,52 @@ class StateRecovery:
     # Skip placing emergency stops once we're inside the close window;
     # the next session's first tick (09:30 ET) will re-attach a fresh
     # stop in a window where Alpaca submits it immediately.
-    _STOP_VERIFY_CUTOFF_HHMM: int = 15 * 60 + 55  # 15:55 ET
+    _STOP_VERIFY_CUTOFF_HHMM: int = 15 * 60 + 55  # 15:55 ET, used by fallback
+    # Minimum seconds before next close required for a DAY stop to make
+    # it onto the book before Alpaca defers it to the next session.
+    _STOP_VERIFY_CLOSE_BUFFER_SEC: int = 300  # 5 minutes
 
-    def _inside_stop_placement_window(self) -> bool:
+    async def _inside_stop_placement_window(self) -> bool:
         """Return True when emergency-stop placement is safe.
 
-        Safe = inside NYSE regular hours with at least ~5 min of buffer
-        before the close. Outside that window we defer to the next
-        session — see _STOP_VERIFY_CUTOFF_HHMM rationale.
+        Primary: consult Alpaca's clock (`is_open` + `next_close`). This
+        handles early-close days (Thanksgiving Friday 13:00 ET, Christmas
+        Eve 13:00 ET, July 3 etc.) correctly — the fixed 15:55 cutoff
+        would happily place a stop at 13:30 on an early-close day, which
+        Alpaca would then defer to the next session and produce the same
+        phantom-stop bug this gate exists to prevent.
+
+        Fallback: fixed ET time gate (09:30 ≤ now_et < 15:55). Used only
+        when the clock call fails or returns an unrecognised shape — keeps
+        the safety net functional even if Alpaca's /v2/clock endpoint
+        flakes briefly.
         """
+        # Primary path: Alpaca clock.
+        try:
+            clock = await asyncio.to_thread(self._gw.client.get_clock)
+            is_open = getattr(clock, "is_open", None)
+            # Strict bool check defends against test gateways whose
+            # `get_clock` auto-mocks attributes to MagicMock objects —
+            # would otherwise read as truthy and let placement proceed.
+            if isinstance(is_open, bool):
+                if not is_open:
+                    return False
+                next_close = getattr(clock, "next_close", None)
+                if isinstance(next_close, datetime):
+                    if next_close.tzinfo is None:
+                        next_close = next_close.replace(tzinfo=ET)
+                    seconds_to_close = (
+                        next_close - self._now_fn()
+                    ).total_seconds()
+                    if seconds_to_close < self._STOP_VERIFY_CLOSE_BUFFER_SEC:
+                        return False
+                return True
+        except Exception:
+            logger.debug(
+                "AlpacaClock unavailable; falling back to fixed time gate",
+                exc_info=True,
+            )
+        # Fallback path: fixed time gate.
         now_et: datetime = self._now_fn()
         hhmm: int = now_et.hour * 60 + now_et.minute
         return 9 * 60 + 30 <= hhmm < self._STOP_VERIFY_CUTOFF_HHMM
@@ -301,7 +338,7 @@ class StateRecovery:
         result: RecoveryResult,
     ) -> None:
         """Ensure every open position has an active stop-loss order."""
-        if not self._inside_stop_placement_window():
+        if not await self._inside_stop_placement_window():
             # Outside the safe window — defer. Don't even iterate, so
             # the run summary doesn't report "would have placed X stops".
             return

--- a/trading_bot/gateway/recovery.py
+++ b/trading_bot/gateway/recovery.py
@@ -269,6 +269,31 @@ class StateRecovery:
             self._close_db_position(db_row["id"], "reconciliation_mismatch")
             result.positions_closed_mismatch.append(ticker)
 
+    # NYSE close = 16:00 ET. DAY stop orders expire at the bell, which
+    # means the close-of-day bot tick (cron fires at 20:00 UTC = 16:00 ET)
+    # sees an empty open-orders list for those tickers and would replace
+    # every fractional position's stop. Alpaca then defers the
+    # post-close-submitted stop to the next trading session's pre-market
+    # open (~04:00 ET), where it becomes a phantom that holds the qty
+    # and blocks the next morning's strategy exit (observed 2026-05-08
+    # XLF/XLC, 2026-05-11 09:30 ET overnight_drift exit rejections).
+    #
+    # Skip placing emergency stops once we're inside the close window;
+    # the next session's first tick (09:30 ET) will re-attach a fresh
+    # stop in a window where Alpaca submits it immediately.
+    _STOP_VERIFY_CUTOFF_HHMM: int = 15 * 60 + 55  # 15:55 ET
+
+    def _inside_stop_placement_window(self) -> bool:
+        """Return True when emergency-stop placement is safe.
+
+        Safe = inside NYSE regular hours with at least ~5 min of buffer
+        before the close. Outside that window we defer to the next
+        session — see _STOP_VERIFY_CUTOFF_HHMM rationale.
+        """
+        now_et: datetime = self._now_fn()
+        hhmm: int = now_et.hour * 60 + now_et.minute
+        return 9 * 60 + 30 <= hhmm < self._STOP_VERIFY_CUTOFF_HHMM
+
     async def _verify_stop_orders(
         self,
         alpaca_positions: list[AlpacaPosition],
@@ -276,6 +301,11 @@ class StateRecovery:
         result: RecoveryResult,
     ) -> None:
         """Ensure every open position has an active stop-loss order."""
+        if not self._inside_stop_placement_window():
+            # Outside the safe window — defer. Don't even iterate, so
+            # the run summary doesn't report "would have placed X stops".
+            return
+
         tickers_with_stops: set[str] = set()
         for order in alpaca_orders:
             if order.type and order.type.value in ("stop", "trailing_stop"):

--- a/trading_bot/tests/test_state_recovery.py
+++ b/trading_bot/tests/test_state_recovery.py
@@ -268,7 +268,10 @@ class TestStateRecovery:
         pos = _alpaca_position("PLTR", qty=100, avg_entry_price=10.0)
         gw = self._make_gateway(positions=[pos], orders=[])
 
-        recovery = _make_recovery(gw, tmp_db_path, mock_notifier)
+        # Pin the clock to mid-session (11:00 ET) so the new
+        # close-window gate doesn't skip placement.
+        mid_session = datetime(2026, 5, 11, 11, 0, tzinfo=ET)
+        recovery = _make_recovery(gw, tmp_db_path, mock_notifier, now=mid_session)
         result = await recovery.recover()
 
         assert "PLTR" in result.stops_placed
@@ -284,11 +287,90 @@ class TestStateRecovery:
         pos = _alpaca_position("PLTR", qty=100, avg_entry_price=0.0)
         gw = self._make_gateway(positions=[pos], orders=[])
 
-        recovery = _make_recovery(gw, tmp_db_path, mock_notifier)
+        mid_session = datetime(2026, 5, 11, 11, 0, tzinfo=ET)
+        recovery = _make_recovery(gw, tmp_db_path, mock_notifier, now=mid_session)
         await recovery.recover()
 
         # Stop should NOT be submitted when avg_cost is 0
         gw.client.submit_order.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_stop_verify_skipped_at_close_of_day_tick(
+        self, tmp_db_path: str, mock_notifier
+    ) -> None:
+        """Regression for 2026-05-08 phantom-stop bug.
+
+        At the 16:00 ET (= 20:00 UTC) close-of-day tick, the existing
+        DAY stops have JUST expired at the bell. _verify_stop_orders
+        would see them missing and submit fresh stops — which Alpaca
+        defers to the next session's pre-market open, where they hold
+        the qty and block the morning exit.
+
+        The gate must skip _place_emergency_stop in the close window.
+        Next morning's first tick will re-attach a fresh stop in a
+        window where Alpaca submits it immediately.
+        """
+        pos = _alpaca_position("XLF", qty=1.989, avg_entry_price=51.28)
+        gw = self._make_gateway(positions=[pos], orders=[])
+
+        # 16:00 ET exactly — the cron tick that caused the regression.
+        close_tick = datetime(2026, 5, 8, 16, 0, tzinfo=ET)
+        recovery = _make_recovery(gw, tmp_db_path, mock_notifier, now=close_tick)
+        result = await recovery.recover()
+
+        gw.client.submit_order.assert_not_called(), (
+            "no stop must be submitted at the close-of-day tick — "
+            "Alpaca defers post-close DAY orders to next session, "
+            "creating phantom stops that block morning exits"
+        )
+        assert "XLF" not in result.stops_placed
+
+    @pytest.mark.asyncio
+    async def test_stop_verify_skipped_just_before_close(
+        self, tmp_db_path: str, mock_notifier
+    ) -> None:
+        """15:55 ET is the cutoff — at or after, defer to next session."""
+        pos = _alpaca_position("XLF", qty=1.989, avg_entry_price=51.28)
+        gw = self._make_gateway(positions=[pos], orders=[])
+
+        just_before_close = datetime(2026, 5, 8, 15, 55, tzinfo=ET)
+        recovery = _make_recovery(
+            gw, tmp_db_path, mock_notifier, now=just_before_close,
+        )
+        await recovery.recover()
+        gw.client.submit_order.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_stop_verify_skipped_pre_market(
+        self, tmp_db_path: str, mock_notifier
+    ) -> None:
+        """Pre-market (e.g., 08:00 ET) is also outside the safe window.
+        DAY stops placed pre-market would still be queued before the
+        regular session starts.
+        """
+        pos = _alpaca_position("XLF", qty=1.989, avg_entry_price=51.28)
+        gw = self._make_gateway(positions=[pos], orders=[])
+        pre_market = datetime(2026, 5, 8, 8, 0, tzinfo=ET)
+        recovery = _make_recovery(gw, tmp_db_path, mock_notifier, now=pre_market)
+        await recovery.recover()
+        gw.client.submit_order.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_stop_verify_active_at_market_open(
+        self, tmp_db_path: str, mock_notifier
+    ) -> None:
+        """09:30 ET is the open — the first valid window for stop placement.
+        This is the morning tick that re-attaches the stop the close-of-day
+        skipper deferred.
+        """
+        pos = _alpaca_position("XLF", qty=1.989, avg_entry_price=51.28)
+        gw = self._make_gateway(positions=[pos], orders=[])
+        market_open = datetime(2026, 5, 8, 9, 30, tzinfo=ET)
+        recovery = _make_recovery(gw, tmp_db_path, mock_notifier, now=market_open)
+        result = await recovery.recover()
+
+        assert "XLF" in result.stops_placed
+        gw.client.submit_order.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_no_discrepancy_clean_state(

--- a/trading_bot/tests/test_state_recovery.py
+++ b/trading_bot/tests/test_state_recovery.py
@@ -373,6 +373,105 @@ class TestStateRecovery:
         gw.client.submit_order.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_stop_verify_uses_alpaca_clock_when_closed(
+        self, tmp_db_path: str, mock_notifier
+    ) -> None:
+        """When Alpaca's clock reports is_open=False, defer regardless of
+        wall-clock time. Closes the early-close-day gap that the fixed
+        15:55 ET cutoff couldn't see (Thanksgiving Friday closes 13:00 ET,
+        the bot's 14:00 tick would otherwise place a stop that Alpaca
+        queues until the next session).
+        """
+        pos = _alpaca_position("XLF", qty=1.989, avg_entry_price=51.28)
+        gw = self._make_gateway(positions=[pos], orders=[])
+
+        # Wall clock says 14:00 ET — inside the fixed time gate's safe
+        # window. But Alpaca's clock says the market is closed (e.g.,
+        # early-close day post-13:00).
+        clock = MagicMock()
+        clock.is_open = False
+        clock.next_close = None
+        gw.client.get_clock = MagicMock(return_value=clock)
+
+        wall_clock = datetime(2026, 11, 28, 14, 0, tzinfo=ET)  # Thxgv Fri
+        recovery = _make_recovery(gw, tmp_db_path, mock_notifier, now=wall_clock)
+        await recovery.recover()
+
+        gw.client.submit_order.assert_not_called(), (
+            "AlpacaClock.is_open=False must override the fixed time gate "
+            "— early-close days would otherwise reproduce the phantom-stop bug"
+        )
+
+    @pytest.mark.asyncio
+    async def test_stop_verify_uses_alpaca_clock_near_close(
+        self, tmp_db_path: str, mock_notifier
+    ) -> None:
+        """When market is open but ``next_close`` is within the 5-min
+        buffer, defer. Catches the boundary case where Alpaca would still
+        queue a DAY order rather than submit it before close.
+        """
+        pos = _alpaca_position("XLF", qty=1.989, avg_entry_price=51.28)
+        gw = self._make_gateway(positions=[pos], orders=[])
+
+        wall_clock = datetime(2026, 5, 8, 15, 57, tzinfo=ET)
+        # Clock says open, but next_close is 3 min away — below the 5-min
+        # safety buffer.
+        clock = MagicMock()
+        clock.is_open = True
+        clock.next_close = datetime(2026, 5, 8, 16, 0, tzinfo=ET)
+        gw.client.get_clock = MagicMock(return_value=clock)
+
+        recovery = _make_recovery(gw, tmp_db_path, mock_notifier, now=wall_clock)
+        await recovery.recover()
+
+        gw.client.submit_order.assert_not_called(), (
+            "within 5 min of close — DAY stop would be queued for next "
+            "session, must defer"
+        )
+
+    @pytest.mark.asyncio
+    async def test_stop_verify_active_when_clock_open_and_buffer_safe(
+        self, tmp_db_path: str, mock_notifier
+    ) -> None:
+        """Clock says open + plenty of time before close → place the stop."""
+        pos = _alpaca_position("XLF", qty=1.989, avg_entry_price=51.28)
+        gw = self._make_gateway(positions=[pos], orders=[])
+
+        wall_clock = datetime(2026, 5, 8, 11, 0, tzinfo=ET)
+        clock = MagicMock()
+        clock.is_open = True
+        clock.next_close = datetime(2026, 5, 8, 16, 0, tzinfo=ET)
+        gw.client.get_clock = MagicMock(return_value=clock)
+
+        recovery = _make_recovery(gw, tmp_db_path, mock_notifier, now=wall_clock)
+        result = await recovery.recover()
+
+        assert "XLF" in result.stops_placed
+        gw.client.submit_order.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_stop_verify_falls_back_when_clock_unavailable(
+        self, tmp_db_path: str, mock_notifier
+    ) -> None:
+        """If Alpaca's clock endpoint flakes, fall back to the fixed time
+        gate so the safety net still works (and we don't accidentally
+        gate-everything when the clock call errors).
+        """
+        pos = _alpaca_position("XLF", qty=1.989, avg_entry_price=51.28)
+        gw = self._make_gateway(positions=[pos], orders=[])
+
+        # Clock call raises.
+        gw.client.get_clock = MagicMock(side_effect=RuntimeError("clock 503"))
+
+        # Wall clock at 11:00 ET — inside the fallback safe window.
+        wall_clock = datetime(2026, 5, 8, 11, 0, tzinfo=ET)
+        recovery = _make_recovery(gw, tmp_db_path, mock_notifier, now=wall_clock)
+        result = await recovery.recover()
+
+        assert "XLF" in result.stops_placed
+        gw.client.submit_order.assert_called_once()
+
+    @pytest.mark.asyncio
     async def test_no_discrepancy_clean_state(
         self, tmp_db_path: str, mock_notifier
     ) -> None:


### PR DESCRIPTION
## Summary

Root cause of the 2026-05-08 → 2026-05-11 phantom-stop saga.

At the 16:00 ET (= 20:00 UTC) close-of-day cron tick, DAY stops for fractional positions have JUST expired at the bell. `_verify_stop_orders` sees the now-empty open-orders list, treats every fractional position as unprotected, and submits fresh stops. Alpaca rejects post-close submissions and defers them to the next session's pre-market open (~04:00 ET), where they become phantom orders that hold the qty through the morning and block the strategy's open exit.

## Evidence (2026-05-08 close tick)

| Order | Symbol | Created | Submitted | Stop $ | Status |
|---|---|---|---|---|---|
| `a736eb95` | XLF 1.989 | 2026-05-08 20:00:35 UTC | **2026-05-11 08:00:48 UTC** | 50.25 | expired |
| `bd5ab489` | XLC 1.9245 | 2026-05-08 20:00:35 UTC | **2026-05-11 08:00:48 UTC** | 113.15 | expired |
| `2d2c6887` (the canonical stop) | XLF 1.989 | 2026-05-08 19:50:35 UTC | 2026-05-08 19:50:35 UTC | 50.25 | expired at bell |

`a736eb95` and `2d2c6887` are exact duplicates created 10 minutes apart by two different ticks of the same bot. The 19:50 stop expired at the bell; the 20:00 stop got queued and reactivated Monday pre-market.

## Fix

Gate `_verify_stop_orders` to inside NYSE regular hours with a ~5 min buffer before the close:

```python
09:30 ≤ now_et < 15:55 ET
```

Outside that window, defer — the next morning's first tick will re-attach a fresh stop in a window where Alpaca submits it immediately. The rest of recovery (reconcile, orphan heal, EOD flatten, stale-entry cancel) still runs.

## Test plan
- [x] `test_stop_verify_skipped_at_close_of_day_tick` (16:00 ET, regression case)
- [x] `test_stop_verify_skipped_just_before_close` (15:55 ET, cutoff inclusive)
- [x] `test_stop_verify_skipped_pre_market` (08:00 ET)
- [x] `test_stop_verify_active_at_market_open` (09:30 ET re-attach)
- [x] Existing `test_stop_order_placed_if_missing` and `test_emergency_stop_skipped_when_avg_cost_zero` pinned to 11:00 ET so CI clock doesn't trip them
- [x] Full suite — 877 passed

Companion to [#98](https://github.com/alex5imon/ai-broker/pull/98), [#99](https://github.com/alex5imon/ai-broker/pull/99), [#100](https://github.com/alex5imon/ai-broker/pull/100). Together these four fully close the 2026-05-11 incident class.