### PR TITLE
fix(execution): mypy union-attr in cancel_all_for_ticker side_filter

### DIFF
--- a/trading_bot/execution/order_manager.py
+++ b/trading_bot/execution/order_manager.py
@@ -879,21 +879,28 @@ class OrderManager:
                 filter=request,
             )
             cancelled: int = 0
+            filter_value: str | None = (
+                side_filter.value if side_filter is not None else None
+            )
             for order in orders:
-                if side_filter is not None:
-                    order_side = getattr(order, "side", None)
-                    # OrderSide enum or .value — accept both. Skip on
-                    # mismatch.
-                    order_side_value = (
-                        order_side.value
-                        if hasattr(order_side, "value")
-                        else order_side
-                    )
-                    filter_value = (
-                        side_filter.value
-                        if hasattr(side_filter, "value")
-                        else side_filter
-                    )
+                if filter_value is not None:
+                    order_side: Any = getattr(order, "side", None)
+                    if order_side is None:
+                        # No side metadata — can't filter, skip safely.
+                        # Treat as not-our-side rather than nuke an
+                        # order we can't classify.
+                        continue
+                    # Accept both OrderSide enum (has .value) and raw
+                    # string side. Narrow via isinstance to keep mypy
+                    # happy without `cast`.
+                    order_side_value: str
+                    if isinstance(order_side, str):
+                        order_side_value = order_side
+                    else:
+                        side_value_attr = getattr(order_side, "value", None)
+                        if not isinstance(side_value_attr, str):
+                            continue
+                        order_side_value = side_value_attr
                     if order_side_value != filter_value:
                         continue
                 try:
@@ -907,7 +914,7 @@ class OrderManager:
                 logger.info(
                     "Cancelled %d order(s) for %s%s",
                     cancelled, ticker,
-                    f" (side={side_filter.value})" if side_filter else "",
+                    f" (side={filter_value})" if filter_value else "",
                 )
         except Exception:
             logger.exception("Error cancelling orders for %s", ticker)


### PR DESCRIPTION
## Summary

Hotfix for the `static-checks` failure on `main` after [#98](https://github.com/alex5imon/ai-broker/pull/98) landed. mypy 1.20.2 flagged:

\`\`\`
trading_bot/execution/order_manager.py:888: error: Item "None" of "Any | None" has no attribute "value"  [union-attr]
\`\`\`

The original implementation read \`order_side.value\` after a \`hasattr(order_side, "value")\` guard. Runtime-safe but mypy can't narrow through hasattr. Replace with an explicit isinstance chain: None → skip, str → use directly, OrderSide-like → use \`.value\` if str-typed, else skip.

Also normalise the log line to use the pre-computed \`filter_value\` string so we don't re-read \`.value\` off the enum (same union-attr risk).

## Test plan
- [x] \`mypy --ignore-missing-imports\` against the same 17 critical-path files static-checks uses → no issues
- [x] Full pytest — 898 passed, 2 skipped
- Once merged the next static-checks run on main should turn green