### PR TITLE
docs(claude.md): document main branch protection + auto-merge pattern

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,24 @@ close (via `.github/workflows/daily-review.yml`, 21:30 UTC weekdays). It:
 
 - `ALPACA_ENV` — defaults to `paper`. Set to `live` to flip to live trading. The workflow selects the matching key pair automatically.
 
+## Merge protocol
+
+`main` is protected by a ruleset (`name: master`) that enforces:
+
+- All changes via PR — no direct pushes
+- `static-checks` AND `coverage` must report `success` before the merge button enables
+- No force-pushes, no branch deletion
+
+**Always queue PRs for auto-merge rather than waiting on CI manually:**
+
+```bash
+gh pr merge <N> --auto --squash --delete-branch
+```
+
+GitHub will merge the PR the moment both checks turn green. Fire-and-forget — no risk of merging before CI completes (which broke `static-checks` once on 2026-05-11 with PR #98 — see [memory: phantom_stop_close_of_day_2026_05_11](memory/phantom_stop_close_of_day_2026_05_11.md)).
+
+If a check fails after auto-merge is queued, the auto-merge stays queued and merges as soon as a follow-up push goes green. Cancel with `gh pr merge --disable-auto <N>`.
+
 ## Testing
 
 ```bash


### PR DESCRIPTION
Document the merge protocol so future sessions don't repeat today's pre-merge-CI race (the PR #98 → static-checks regression).

- Branch protection ruleset on `main`: PR-only, `static-checks` + `coverage` required
- Always queue with \`gh pr merge --auto --squash --delete-branch\` instead of merging immediately