### PR TITLE
fix(backfill): preserve fractional share quantities

### DIFF
--- a/trading_bot/self_improve/alpaca_backfill.py
+++ b/trading_bot/self_improve/alpaca_backfill.py
@@ -55,7 +55,7 @@ class ClosedPositionRow:
     exchange: str
     currency: str
     strategy_id: str
-    quantity: int
+    quantity: float
     entry_price: float
     entry_time: datetime
     hold_type: str
@@ -138,7 +138,10 @@ def load_candidates(conn: sqlite3.Connection) -> list[ClosedPositionRow]:
                 exchange=row[2],
                 currency=row[3],
                 strategy_id=row[4],
-                quantity=int(row[5]),
+                # positions.quantity is INTEGER affinity but the live writer
+                # stores fractional shares (e.g. 0.3927). int() truncates
+                # those to 0, masking pnl on any sub-1-share position.
+                quantity=float(row[5]),
                 entry_price=float(row[6]),
                 entry_time=entry_dt,
                 hold_type=row[8],
@@ -357,7 +360,7 @@ async def backfill(
         gross_pnl = (exit_fill.filled_avg_price - c.entry_price) * c.quantity
         exit_reason = _infer_exit_reason(exit_fill.order_id, c)
         logger.info(
-            "Position %d %s qty=%d entry=%.4f exit=%.4f pnl=%+.2f reason=%s%s",
+            "Position %d %s qty=%.4f entry=%.4f exit=%.4f pnl=%+.2f reason=%s%s",
             c.position_id, c.ticker, c.quantity,
             c.entry_price, exit_fill.filled_avg_price, gross_pnl, exit_reason,
             " (dry-run)" if dry_run else "",

--- a/trading_bot/tests/test_self_improve_alpaca_backfill.py
+++ b/trading_bot/tests/test_self_improve_alpaca_backfill.py
@@ -30,7 +30,7 @@ def _insert_position(
     ticker: str = "SPY",
     strategy_id: str = "overnight_drift",
     status: str = "CLOSED",
-    quantity: int = 10,
+    quantity: float = 10,
     entry_price: float = 100.0,
     entry_time: datetime,
     alpaca_order_id: str = "alp-entry-001",
@@ -260,6 +260,59 @@ def test_backfill_inserts_when_no_reconciliation_row_present(tmp_db):
     assert len(rows) == 1
     assert rows[0][0] == pytest.approx(98.0)
     assert rows[0][1] == f"{BACKFILL_MARKER_PREFIX}1"
+
+
+@pytest.mark.asyncio
+async def test_backfill_preserves_fractional_quantity(tmp_db):
+    """Live bug 2026-05-12: ``ClosedPositionRow.quantity`` was typed
+    ``int`` and ``load_candidates`` cast ``int(row[5])``, truncating
+    fractional shares to 0/1. A 0.3927-share XLK position recorded
+    pnl=$0.00 instead of the real -$1.29 — masking realized losses on
+    every sub-1-share fractional close.
+
+    The fix preserves float precision through the candidate row and into
+    the ``gross_pnl = (exit - entry) * quantity`` calculation.
+    """
+    entry_time = datetime(2026, 5, 12, 15, 45, tzinfo=TZ_EASTERN)
+    tmp_db.execute(
+        """
+        INSERT INTO positions (
+            id, ticker, exchange, currency, quantity,
+            entry_price, entry_time, status, hold_type, phase,
+            alpaca_order_id, strategy_id
+        ) VALUES (1, 'XLK', 'NYSE', 'USD', 0.3927,
+                  177.438, ?, 'CLOSED', 'swing', 1,
+                  'alp-entry-xlk', 'overnight_drift')
+        """,
+        (entry_time.isoformat(),),
+    )
+    tmp_db.commit()
+
+    candidates = load_candidates(tmp_db)
+    assert len(candidates) == 1
+    assert candidates[0].quantity == pytest.approx(0.3927), (
+        "fractional quantity must round-trip from the positions row — "
+        "int() truncation drops sub-share precision"
+    )
+
+    async def stub_finder(client, position):
+        return ExitFill(
+            order_id="alp-exit-xlk",
+            filled_at=entry_time + timedelta(hours=18),
+            filled_avg_price=174.154,
+            filled_qty=0.3927,
+        )
+
+    report = await backfill(tmp_db, client=None, fill_finder=stub_finder)
+    assert report.inserted == 1
+
+    row = tmp_db.execute(
+        "SELECT quantity, gross_pnl, pnl_usd FROM trades WHERE ticker='XLK'"
+    ).fetchone()
+    expected_pnl = (174.154 - 177.438) * 0.3927
+    assert row[0] == pytest.approx(0.3927)
+    assert row[1] == pytest.approx(expected_pnl)
+    assert row[2] == pytest.approx(expected_pnl)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

`ClosedPositionRow.quantity` was typed `int` and `load_candidates` cast `int(row[5])`, truncating fractional positions to 0 or 1. This masks realized P&L on every sub-1-share close.

Confirmed on yesterday's (2026-05-12) backfill — all 4 inserted rows had wrong qty/pnl:

| Position | Real qty | Backfill qty | Real pnl | Backfill pnl |
|---|---:|---:|---:|---:|
| XLC | 1.9245 | 1 | -\$0.44 | -\$0.23 |
| XLF | 1.989  | 1 | -\$0.46 | -\$0.23 |
| XLK | 0.3927 | 0 | -\$1.29 | -\$0.00 |
| XLK | 0.3127 | 0 | -\$0.86 | -\$0.00 |

Total real loss ~−\$3.05 (matches the equity move of −\$3.01); backfill recorded only ~−\$0.46. Sub-1-share positions silently contribute \$0.00 to \`daily_summaries\`. The bot trades fractionals down to 1/1000000 per CLAUDE.md, so this affects every overnight_drift close at the current ~\$1k notional sizing target.

Same class of bug as #38 → #53 (floor masks downstream truncations). Only non-test occurrence in the repo.

## Changes

- \`quantity: int\` → \`quantity: float\` on \`ClosedPositionRow\`
- \`int(row[5])\` → \`float(row[5])\` in \`load_candidates\`
- log format \`qty=%d\` → \`qty=%.4f\`
- new test \`test_backfill_preserves_fractional_quantity\` round-trips a 0.3927-share XLK position through \`load_candidates\` + \`backfill\` and asserts pnl equals \`(exit - entry) * 0.3927\`. Without the fix, qty rounds to 0 and pnl asserts as 0.

## Test plan

- [x] \`pytest trading_bot/tests/test_self_improve_alpaca_backfill.py\` — 14 passed (was 13)
- [x] Full suite (skipping hypothesis-dependent files that need optional local deps) — 900 passed
- [ ] Tonight's daily-review backfill should record pnl in line with equity changes for any fractional closes