### PR TITLE
chore(repair): one-shot pnl repair for pre-#108 int(qty) truncation

### DIFF
--- a/.github/workflows/repair-pnl-truncation.yml
+++ b/.github/workflows/repair-pnl-truncation.yml
@@ -1,0 +1,84 @@
+name: repair-pnl-truncation
+
+# One-shot repair for trades rows whose pnl_usd was computed with the
+# pre-#108 int(quantity) truncation. The fix in #108 stops new rows
+# from being affected but does not heal existing ones: the
+# backfill:position:N marker on trades.notes makes load_candidates skip
+# them permanently. positions.quantity retained the correct fractional
+# value, so this workflow recomputes pnl_usd as
+#   (exit_price - entry_price) * positions.quantity
+# for every affected row, then regenerates daily_summaries.
+#
+# Manual trigger only. After it runs successfully, this workflow and
+# the scripts/repair_pnl_truncation.py file should be removed in a
+# follow-up PR.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run (log changes without writing)"
+        type: boolean
+        default: true
+
+# Own concurrency group so a scheduled bot.yml tick (which sets
+# cancel-in-progress=true on the bot-run group) cannot send a cancel
+# signal mid-write. The repair re-restores the most recent bot-db-*
+# cache via restore-keys and writes back under the same prefix, so
+# the next bot tick picks our changes up.
+concurrency:
+  group: repair-run
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  repair:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install deps
+        run: pip install -r requirements.txt
+
+      - name: Restore SQLite DB
+        uses: actions/cache@v5
+        with:
+          path: trading_bot/data/trading_bot.db*
+          key: bot-db-${{ github.run_id }}
+          restore-keys: |
+            bot-db-
+
+      - name: Run repair (dry_run=${{ inputs.dry_run }})
+        env:
+          BOT_LOG_DIR: logs
+        run: |
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            python scripts/repair_pnl_truncation.py
+          else
+            python scripts/repair_pnl_truncation.py --apply
+          fi
+
+      - name: Recompute daily_summaries
+        # Idempotent (INSERT OR REPLACE). Only meaningful if we wrote
+        # changes — but harmless on dry-run, just reaffirms current state.
+        if: inputs.dry_run == false
+        env:
+          BOT_LOG_DIR: logs
+        run: python -m trading_bot.self_improve.recompute_daily_summaries --days 30
+
+      - name: Upload SQLite DB artifact
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: repair-db-${{ github.run_id }}
+          path: trading_bot/data/trading_bot.db*
+          retention-days: 30

--- a/scripts/repair_pnl_truncation.py
+++ b/scripts/repair_pnl_truncation.py
@@ -1,0 +1,159 @@
+"""One-shot repair: recompute pnl for trades affected by int(qty) truncation.
+
+Context — fixed in ai-broker#108 forward-only:
+
+  Pre-#108 ``alpaca_backfill.py`` loaded ``positions.quantity`` via
+  ``int(row[5])``, truncating fractional shares (e.g. 0.3927 → 0). The
+  backfilled ``trades`` rows received ``quantity = int(...)`` and
+  ``pnl_usd = (exit - entry) * int(qty)`` — so any sub-1-share position
+  recorded pnl as $0.00, and 1<x<2 share positions recorded pnl scaled
+  by 1 instead of the real fractional quantity.
+
+  #108 stopped new rows from being affected but did not heal existing
+  rows: the ``backfill:position:N`` marker on ``trades.notes`` makes
+  ``load_candidates`` skip them permanently. ``positions.quantity``
+  retained the correct fractional value, so we can recover the real
+  quantity by joining on the marker.
+
+Scope:
+
+  - Only rows where ``trades.notes LIKE 'backfill:position:%'`` (touched
+    by the backfill code path) AND ``trades.side = 'BUY'`` (long-only
+    repair; the few historical short rows compute pnl correctly under
+    ``(entry - exit) * qty`` and need a separate code path).
+  - Only rows where ``exit_price IS NOT NULL`` (closed trades only).
+  - Only rows where the math disagrees by more than $0.01 (epsilon
+    avoids touching rows that are already correct, e.g. integer-qty
+    rows from the older bot era).
+
+Idempotent: re-running with no affected rows prints "no rows to repair"
+and exits 0. The recomputed ``pnl_usd`` matches what the post-#108
+backfill would have written, so future re-runs will find no delta.
+
+After repairing trades, ``daily_summaries`` is regenerated via
+``trading_bot.self_improve.recompute_daily_summaries`` so the per-day
+reports reflect the corrected pnl.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sqlite3
+import sys
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Tolerance for "pnl already correct". $0.01 = one cent; smaller than
+# any single-share price change we'd care about, larger than IEEE-754
+# rounding noise on multiply.
+EPSILON_USD: float = 0.01
+
+
+def find_affected_rows(conn: sqlite3.Connection) -> list[tuple]:
+    """Rows where (exit - entry) * positions.quantity differs from
+    trades.pnl_usd by > EPSILON_USD. Returns the join already done so
+    the caller can both audit and repair in one pass."""
+    cur = conn.execute(
+        """
+        SELECT
+            t.id, t.ticker, t.entry_time, t.exit_time,
+            t.quantity AS old_qty,
+            p.quantity AS real_qty,
+            t.entry_price, t.exit_price,
+            t.pnl_usd AS old_pnl,
+            (t.exit_price - t.entry_price) * p.quantity AS real_pnl
+        FROM trades t
+        JOIN positions p
+          ON ('backfill:position:' || p.id) = t.notes
+        WHERE t.side = 'BUY'
+          AND t.exit_price IS NOT NULL
+          AND ABS(t.pnl_usd - (t.exit_price - t.entry_price) * p.quantity)
+              > ?
+        ORDER BY t.id
+        """,
+        (EPSILON_USD,),
+    )
+    return cur.fetchall()
+
+
+def repair_row(conn: sqlite3.Connection, trade_id: int,
+               real_qty: float, real_pnl: float) -> None:
+    """Update one trades row in-place with corrected qty + pnl."""
+    conn.execute(
+        """
+        UPDATE trades
+           SET quantity = ?,
+               gross_pnl = ?,
+               net_pnl = ?,
+               pnl_usd = ?
+         WHERE id = ?
+        """,
+        (real_qty, real_pnl, real_pnl, real_pnl, trade_id),
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--db",
+        default="trading_bot/data/trading_bot.db",
+        help="Path to the SQLite DB (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Commit the repair. Without this flag, runs as a dry-run "
+             "and prints what would change.",
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+    )
+
+    db_path = Path(args.db)
+    if not db_path.exists():
+        logger.error("DB not found: %s", db_path)
+        return 2
+
+    conn = sqlite3.connect(db_path)
+    try:
+        rows = find_affected_rows(conn)
+        if not rows:
+            logger.info("No rows to repair — all backfilled trades match "
+                        "(exit - entry) * positions.quantity within $%.2f.",
+                        EPSILON_USD)
+            return 0
+
+        logger.info("Found %d row(s) with truncated pnl:", len(rows))
+        total_delta = 0.0
+        for (tid, ticker, et, xt, old_qty, real_qty,
+             ep, xp, old_pnl, real_pnl) in rows:
+            delta = real_pnl - old_pnl
+            total_delta += delta
+            logger.info(
+                "  id=%-4d %-5s qty %s→%-7.4f  pnl %+9.4f → %+9.4f  delta %+8.4f",
+                tid, ticker, f"{old_qty:.4f}", real_qty,
+                old_pnl, real_pnl, delta,
+            )
+        logger.info("Total pnl delta: $%+.4f", total_delta)
+
+        if not args.apply:
+            logger.info("Dry-run — pass --apply to commit. Exiting without "
+                        "changes.")
+            return 0
+
+        for (tid, _, _, _, _, real_qty, _, _, _, real_pnl) in rows:
+            repair_row(conn, tid, real_qty, real_pnl)
+        conn.commit()
+        logger.info("Repair committed: %d row(s) updated.", len(rows))
+        return 0
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/trading_bot/tests/test_repair_pnl_truncation.py
+++ b/trading_bot/tests/test_repair_pnl_truncation.py
@@ -1,0 +1,157 @@
+"""Smoke tests for the one-shot scripts/repair_pnl_truncation.py.
+
+These cover the three behaviours that matter for the live run:
+
+1. ``find_affected_rows`` joins on positions.id correctly and excludes
+   rows where the math is already within tolerance.
+2. ``repair_row`` overwrites quantity + pnl in place.
+3. ``main`` is idempotent — re-running with no truncated rows reports
+   "no rows to repair" and exits 0 without writing.
+
+The script will be deleted in a follow-up PR after the live run.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+# Load the script under test by path so we don't need to mark the
+# top-level ``scripts/`` directory as a package.
+_SPEC = importlib.util.spec_from_file_location(
+    "repair_pnl_truncation",
+    Path(__file__).resolve().parents[2] / "scripts" / "repair_pnl_truncation.py",
+)
+assert _SPEC is not None and _SPEC.loader is not None
+_MODULE = importlib.util.module_from_spec(_SPEC)
+sys.modules["repair_pnl_truncation"] = _MODULE
+_SPEC.loader.exec_module(_MODULE)
+
+find_affected_rows = _MODULE.find_affected_rows
+main = _MODULE.main
+repair_row = _MODULE.repair_row
+
+
+def _seed(conn: sqlite3.Connection, *,
+          position_id: int, real_qty: float,
+          trade_id: int, trade_qty: float,
+          entry: float, exit_: float, pnl: float) -> None:
+    conn.execute(
+        """
+        INSERT INTO positions (
+            id, ticker, exchange, currency, quantity, entry_price,
+            entry_time, status, hold_type, phase, strategy_id
+        ) VALUES (?, 'SPY', 'NYSE', 'USD', ?, ?,
+                  '2026-04-01T15:45:00-04:00', 'CLOSED',
+                  'swing', 1, 'overnight_drift')
+        """,
+        (position_id, real_qty, entry),
+    )
+    conn.execute(
+        """
+        INSERT INTO trades (
+            id, ticker, exchange, currency, side,
+            entry_time, entry_price, quantity,
+            exit_time, exit_price, exit_reason,
+            gross_pnl, net_pnl, pnl_usd,
+            hold_type, phase, strategy_id, notes
+        ) VALUES (?, 'SPY', 'NYSE', 'USD', 'BUY',
+                  '2026-04-01T15:45:00-04:00', ?, ?,
+                  '2026-04-02T09:31:00-04:00', ?, 'manual',
+                  ?, ?, ?,
+                  'swing', 1, 'overnight_drift', ?)
+        """,
+        (trade_id, entry, trade_qty, exit_, pnl, pnl, pnl,
+         f"backfill:position:{position_id}"),
+    )
+    conn.commit()
+
+
+@pytest.mark.unit
+def test_find_affected_rows_flags_truncated_pnl(tmp_db):
+    # positions stores 0.3927 (real qty); trades was written with
+    # int(0.3927)=0 and pnl=0. Real pnl = (98 - 100) * 0.3927 = -0.7854.
+    _seed(tmp_db,
+          position_id=1, real_qty=0.3927,
+          trade_id=10, trade_qty=0, entry=100.0, exit_=98.0, pnl=0.0)
+    rows = find_affected_rows(tmp_db)
+    assert len(rows) == 1
+    # Schema: id, ticker, entry_time, exit_time, old_qty, real_qty,
+    # entry_price, exit_price, old_pnl, real_pnl
+    assert rows[0][0] == 10
+    assert rows[0][5] == pytest.approx(0.3927)
+    assert rows[0][9] == pytest.approx((98.0 - 100.0) * 0.3927)
+
+
+@pytest.mark.unit
+def test_find_affected_rows_skips_already_correct(tmp_db):
+    # Real qty = trade qty = 5, pnl = (98-100)*5 = -10. Match.
+    _seed(tmp_db,
+          position_id=1, real_qty=5.0,
+          trade_id=10, trade_qty=5.0, entry=100.0, exit_=98.0, pnl=-10.0)
+    assert find_affected_rows(tmp_db) == []
+
+
+@pytest.mark.unit
+def test_main_dry_run_writes_nothing(tmp_db, tmp_path):
+    _seed(tmp_db,
+          position_id=1, real_qty=0.3927,
+          trade_id=10, trade_qty=0, entry=100.0, exit_=98.0, pnl=0.0)
+    # main() opens its own connection — close ours and write to the
+    # same file so the script can find it.
+    db_path = tmp_path / "smoke.db"
+    backup = sqlite3.connect(db_path)
+    tmp_db.backup(backup)
+    backup.close()
+
+    exit_code = main(["--db", str(db_path)])
+    assert exit_code == 0
+
+    # Re-open and confirm row is untouched.
+    conn = sqlite3.connect(db_path)
+    row = conn.execute(
+        "SELECT quantity, pnl_usd FROM trades WHERE id = 10"
+    ).fetchone()
+    conn.close()
+    assert row == (0, 0.0), "dry-run must not modify rows"
+
+
+@pytest.mark.unit
+def test_main_apply_repairs_and_is_idempotent(tmp_db, tmp_path):
+    _seed(tmp_db,
+          position_id=1, real_qty=0.3927,
+          trade_id=10, trade_qty=0, entry=100.0, exit_=98.0, pnl=0.0)
+    db_path = tmp_path / "apply.db"
+    backup = sqlite3.connect(db_path)
+    tmp_db.backup(backup)
+    backup.close()
+
+    # First run: writes.
+    assert main(["--db", str(db_path), "--apply"]) == 0
+
+    conn = sqlite3.connect(db_path)
+    row = conn.execute(
+        "SELECT quantity, pnl_usd FROM trades WHERE id = 10"
+    ).fetchone()
+    expected_pnl = (98.0 - 100.0) * 0.3927
+    assert row[0] == pytest.approx(0.3927)
+    assert row[1] == pytest.approx(expected_pnl)
+
+    # Second run: idempotent — nothing to repair.
+    assert main(["--db", str(db_path), "--apply"]) == 0
+    # Row still matches.
+    row = conn.execute(
+        "SELECT quantity, pnl_usd FROM trades WHERE id = 10"
+    ).fetchone()
+    conn.close()
+    assert row[0] == pytest.approx(0.3927)
+    assert row[1] == pytest.approx(expected_pnl)
+
+
+@pytest.mark.unit
+def test_main_missing_db_returns_2(tmp_path):
+    assert main(["--db", str(tmp_path / "does-not-exist.db")]) == 2


### PR DESCRIPTION
## Summary

Heals the trades rows that were written with truncated pnl before #108 landed. Investigation today found 19 affected rows totalling **+\$46.99 of masked realized P&L**, including +\$39.26 hidden on 2026-05-07 and +\$7.47 on 2026-05-11. Daily summaries on those dates currently report \$0.00 net.

The bug class is documented in [memory/floor_masks_truncations](memory/floor_masks_truncations.md). The earlier follow-on lesson from this session: the backfill marker (\`trades.notes = 'backfill:position:N'\`) is one-way idempotent — \`load_candidates\` permanently skips marked rows, so bug-fix PRs to backfill code do not retroactively heal already-marked data.

\`positions.quantity\` retained the correct fractional values throughout, so the repair recovers them via JOIN.

## Affected dates (verified on 2026-05-13 bot DB snapshot)

| Date | Before | After | Delta |
|---|---:|---:|---:|
| 2026-04-30 | +\$6.58  | +\$9.98  | +\$3.40 |
| 2026-05-04 | -\$25.83 | -\$26.38 | -\$0.55 |
| 2026-05-07 | \$0.00   | +\$39.26 | +\$39.26 |
| 2026-05-11 | \$0.00   | +\$7.47  | +\$7.47 |
| 2026-05-12 | -\$0.46  | -\$3.05  | -\$2.59 |
| **Total** | | | **+\$46.99** |

## What's in this PR

- \`scripts/repair_pnl_truncation.py\` — dry-run by default, \`--apply\` commits. Joins \`trades\` on \`positions.id\` via the notes marker; recomputes pnl as \`(exit - entry) * positions.quantity\` for every \`side='BUY'\` row where the recorded pnl differs by > \$0.01. Skips SELL rows (their math is correct for shorts). Idempotent — re-running with no truncated rows logs \"no rows to repair\" and exits 0.
- \`.github/workflows/repair-pnl-truncation.yml\` — \`workflow_dispatch\` only, restores cache, runs repair, recomputes daily_summaries when applying, saves back to cache for the next bot tick. Modeled on the existing \`repair-orphans\` workflow.
- \`trading_bot/tests/test_repair_pnl_truncation.py\` — 5 unit tests covering find/repair/main paths and idempotency.

## Test plan

- [x] \`pytest trading_bot/tests/test_repair_pnl_truncation.py\` — 5 passed
- [x] Full suite (skipping hypothesis files) — 901 passed
- [x] Dry-run against a copy of 2026-05-13 bot DB shows the 19-row delta
- [x] Apply against the copy then re-run reports \"no rows to repair\"
- [ ] After merge: dispatch with \`dry_run=false\`, verify artifact DB, check that next bot tick's daily_summaries reflect corrected dates
- [ ] Follow-up PR will remove the script + workflow once the live run lands cleanly