### PR TITLE
feat(execution): persist alpaca_exit_order_id across stateless ticks (V11)

### DIFF
--- a/trading_bot/constants.py
+++ b/trading_bot/constants.py
@@ -196,4 +196,4 @@ def ticker_market(ticker: str) -> Market:
 # Schema version — must match the DB migration target
 # ---------------------------------------------------------------------------
 
-SCHEMA_VERSION: int = 10
+SCHEMA_VERSION: int = 11

--- a/trading_bot/db/migrations.py
+++ b/trading_bot/db/migrations.py
@@ -365,6 +365,42 @@ def _migration_v10(conn: sqlite3.Connection) -> None:
     logger.info("Applied migration V10: USD-only column rename")
 
 
+def _migration_v11(conn: sqlite3.Connection) -> None:
+    """V11: add ``positions.alpaca_exit_order_id`` for cross-tick exit tracking.
+
+    Pre-V11 the strategy-driven exit order id lived only in
+    ``OrderManager._ActiveOrder.alpaca_exit_order_id`` — in-memory
+    state that vaporizes when the stateless tick exits. Every
+    overnight_drift exit straddles a process boundary (entry at 15:45
+    ET, exit fires at 09:30 ET next day), so the pending order id is
+    lost between ticks. The next tick re-evaluated the exit signal and
+    tried to re-submit, relying on Alpaca's ``held_for_orders`` to
+    reject the duplicate and on StateRecovery + nightly backfill to
+    reconcile. See memory/overnight_drift_exit_orphans.md.
+
+    This migration adds a nullable TEXT column so OrderManager can
+    persist the order id on ``place_exit`` success and rehydrate it on
+    the next tick start. Backfilled rows stay NULL — they have no
+    pending exit by definition.
+
+    Idempotent: skipped if the column already exists (fresh installs
+    via _SCHEMA_SQL get the column directly from V11-onwards
+    schema.py).
+    """
+    rows = conn.execute("PRAGMA table_info(positions)").fetchall()
+    if not any(r[1] == "alpaca_exit_order_id" for r in rows):
+        conn.execute(
+            "ALTER TABLE positions ADD COLUMN alpaca_exit_order_id TEXT"
+        )
+
+    conn.execute(
+        "INSERT OR REPLACE INTO schema_version (version, description) "
+        "VALUES (11, "
+        "'V11 schema - positions.alpaca_exit_order_id for cross-tick exit tracking')"
+    )
+    logger.info("Applied migration V11: positions.alpaca_exit_order_id")
+
+
 _MIGRATIONS: list[tuple[int, str, MigrationFn]] = [
     (4, "V4 schema - multi-market adaptive trading bot", _migration_v4),
     (5, "V5 schema - multi-strategy Alpaca trading bot", _migration_v5),
@@ -373,6 +409,8 @@ _MIGRATIONS: list[tuple[int, str, MigrationFn]] = [
     (8, "V8 schema - ENTRY_FAILED terminal status (data-only)", _migration_v8),
     (9, "V9 schema - settlements table removed", _migration_v9),
     (10, "V10 schema - USD-only column rename", _migration_v10),
+    (11, "V11 schema - positions.alpaca_exit_order_id for cross-tick exit tracking",
+     _migration_v11),
 ]
 
 

--- a/trading_bot/db/schema.py
+++ b/trading_bot/db/schema.py
@@ -69,6 +69,12 @@ CREATE TABLE IF NOT EXISTS positions (
     alpaca_stop_order_id TEXT,
     alpaca_target_order_id TEXT,
     alpaca_trail_order_id TEXT,
+    -- Strategy-driven exit (place_exit / place_limit_exit). Populated
+    -- when the position transitions to CLOSING; cleared on FILLED or
+    -- on canceled/expired/rejected rollback. Persisted so the next
+    -- stateless tick can rehydrate the pending exit instead of
+    -- re-evaluating and double-submitting. Added in V11.
+    alpaca_exit_order_id TEXT,
     highest_price   REAL,
     strategy_id     TEXT NOT NULL,
     updated_at      TEXT NOT NULL DEFAULT (datetime('now'))

--- a/trading_bot/execution/order_manager.py
+++ b/trading_bot/execution/order_manager.py
@@ -158,8 +158,11 @@ class _ActiveOrder:
     # when the position transitions to CLOSING; polled by
     # _check_order_statuses to advance CLOSING -> CLOSED with the real
     # exit_reason instead of leaving the row for state-recovery to
-    # tag as 'reconciliation_mismatch' next tick. In-memory only —
-    # process restarts fall back to the recovery path.
+    # tag as 'reconciliation_mismatch' next tick. Persisted to
+    # positions.alpaca_exit_order_id (V11+) so a stateless-tick restart
+    # rehydrates the pending order and avoids re-submitting the same
+    # exit. Pre-V11 this was in-memory only and every overnight_drift
+    # exit fell through to the recovery path.
     alpaca_exit_order_id: str | None = None
     exit_reason: str | None = None
     status: PositionStatus = PositionStatus.ENTRY_PENDING
@@ -268,6 +271,17 @@ class OrderManager:
                 logger.debug("Skipping row with unknown status %s", status_str)
                 continue
 
+            # alpaca_exit_order_id added in V11. Existing DBs may have
+            # this column NULL on every row until a place_exit fires;
+            # the `[idx] if "alpaca_exit_order_id" in row.keys()` check
+            # tolerates older schema views during the migration window.
+            row_keys = set(row.keys())
+            exit_oid: str | None = (
+                row["alpaca_exit_order_id"]
+                if "alpaca_exit_order_id" in row_keys
+                else None
+            )
+
             active = _ActiveOrder(
                 trade_id=trade_id,
                 ticker=str(row["ticker"]),
@@ -276,6 +290,7 @@ class OrderManager:
                 alpaca_stop_order_id=row["alpaca_stop_order_id"],
                 alpaca_target_order_id=row["alpaca_target_order_id"],
                 alpaca_trail_order_id=row["alpaca_trail_order_id"],
+                alpaca_exit_order_id=exit_oid,
                 status=status,
                 entry_shares=float(row["quantity"] or 0),
                 filled_shares=float(row["quantity"] or 0)
@@ -296,6 +311,7 @@ class OrderManager:
                 active.alpaca_stop_order_id,
                 active.alpaca_target_order_id,
                 active.alpaca_trail_order_id,
+                active.alpaca_exit_order_id,
             ):
                 if oid is not None:
                     self._alpaca_to_trade[str(oid)] = trade_id
@@ -572,6 +588,13 @@ class OrderManager:
                         active.alpaca_exit_order_id = None
                         active.exit_reason = None
                         active.status = PositionStatus.STOP_AND_TARGET_ACTIVE
+                        # V11+: clear the persisted exit order_id too,
+                        # so the next tick re-evaluates the exit
+                        # condition cleanly instead of seeing a stale
+                        # alpaca_exit_order_id and refusing to act.
+                        self._update_position_field(
+                            trade_id, "alpaca_exit_order_id", None,
+                        )
                         self._update_position_status(
                             trade_id, PositionStatus.STOP_AND_TARGET_ACTIVE,
                         )
@@ -1060,6 +1083,14 @@ class OrderManager:
                     matching_active.status = PositionStatus.CLOSING
                     matching_active.alpaca_exit_order_id = order_id
                     matching_active.exit_reason = reason
+                # Persist the exit order_id BEFORE flipping status to
+                # CLOSING — a crash between the two writes leaves the
+                # row still STOP_AND_TARGET_ACTIVE with the order id
+                # set, which the next tick's rehydration handles
+                # gracefully. V11+: column lives on positions table.
+                self._update_position_field(
+                    matching_trade_id, "alpaca_exit_order_id", order_id,
+                )
                 self._update_position_status(
                     matching_trade_id, PositionStatus.CLOSING,
                 )
@@ -1191,6 +1222,11 @@ class OrderManager:
                     matching_active.status = PositionStatus.CLOSING
                     matching_active.alpaca_exit_order_id = order_id
                     matching_active.exit_reason = reason
+                # V11+: persist exit order_id before status flip so a
+                # crash between the two writes is recoverable from DB.
+                self._update_position_field(
+                    matching_trade_id, "alpaca_exit_order_id", order_id,
+                )
                 self._update_position_status(
                     matching_trade_id, PositionStatus.CLOSING,
                 )
@@ -1572,6 +1608,7 @@ class OrderManager:
             active.alpaca_stop_order_id,
             active.alpaca_target_order_id,
             active.alpaca_trail_order_id,
+            active.alpaca_exit_order_id,
         ):
             if oid is not None:
                 self._alpaca_to_trade.pop(oid, None)
@@ -1722,7 +1759,8 @@ class OrderManager:
         col: f"UPDATE positions SET {col} = ?, updated_at = ? WHERE id = ?"  # nosec B608
         for col in (
             "status", "alpaca_order_id", "alpaca_stop_order_id",
-            "alpaca_target_order_id", "alpaca_trail_order_id", "oca_group",
+            "alpaca_target_order_id", "alpaca_trail_order_id",
+            "alpaca_exit_order_id", "oca_group",
             "quantity", "entry_price", "stop_price", "target_price",
             "trailing_active", "trailing_distance", "highest_price",
         )

--- a/trading_bot/strategy/strategy_manager.py
+++ b/trading_bot/strategy/strategy_manager.py
@@ -407,6 +407,18 @@ class StrategyManager:
             positions: list[dict[str, Any]] = portfolio.get_open_positions()
             for position in positions:
                 ticker: str = position["ticker"]
+                # V11+: skip positions with a persisted pending exit.
+                # An earlier tick already submitted the exit order; the
+                # OrderManager will detect the fill (or rollback on
+                # cancel/expire/reject) via _check_order_statuses
+                # polling. Re-evaluating the exit signal here would
+                # only trigger a duplicate-submit that Alpaca rejects
+                # with `held_for_orders=qty, available=0` — the
+                # symptom pattern that motivated this gate.
+                # `position.get(...)` tolerates older DB rows where
+                # the column doesn't exist or is NULL.
+                if position.get("alpaca_exit_order_id") is not None:
+                    continue
                 # Stale-data gate — same protection scan_for_entries uses.
                 # A stale price that fires a false exit signal would
                 # otherwise cascade into a phantom market sell, broken

--- a/trading_bot/tests/test_exit_persistence_v11.py
+++ b/trading_bot/tests/test_exit_persistence_v11.py
@@ -1,0 +1,253 @@
+"""V11 cross-tick exit persistence — end-to-end behaviour tests.
+
+Covers the four properties that make the persistence useful:
+
+1. ``place_exit`` persists ``alpaca_exit_order_id`` on the positions
+   row in addition to the existing in-memory ``_ActiveOrder`` write.
+2. ``_hydrate_active_orders`` reads the persisted column back and
+   populates ``_ActiveOrder.alpaca_exit_order_id`` — a "new tick"
+   simulation by tearing down + rebuilding the OM against the same DB.
+3. On cancel/expire/reject of the exit order, the column is cleared in
+   the DB so the next tick re-evaluates the exit cleanly.
+4. The reverse-index ``_alpaca_to_trade`` includes the exit order id
+   after hydration (so the fill poll can look the trade up).
+
+Plus one StrategyManager-level test:
+
+5. ``check_exits`` skips positions where ``alpaca_exit_order_id`` is
+   non-NULL — the early-return that prevents the duplicate-submit
+   pattern observed before V11.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from trading_bot.constants import PositionStatus, TZ_EASTERN
+from trading_bot.execution.order_manager import (
+    EntryDecision,
+    OrderManager,
+    _ActiveOrder,
+)
+
+pytestmark = pytest.mark.critical
+
+ET = TZ_EASTERN
+
+
+def _make_om(config, db_path: str, notifier) -> OrderManager:
+    gw = MagicMock()
+    gw.client = MagicMock()
+    return OrderManager(gw, config, notifier, db_path)
+
+
+def _entry(ticker: str = "SPY") -> EntryDecision:
+    return EntryDecision(
+        ticker=ticker,
+        exchange="US",
+        side="BUY",
+        shares=10,
+        limit_price=100.0,
+        stop_price=98.0,
+        target_price=104.0,
+        hold_type="intraday",
+        sector="Information Technology",
+        phase=1,
+        sentiment_score=0.2,
+        signals="test",
+        currency="USD",
+        strategy_id="overnight_drift",
+        trail_pct=None,
+        trail_activation_price=None,
+    )
+
+
+def _seed_open_position(
+    om: OrderManager, ticker: str = "SPY"
+) -> int:
+    """Helper: seed a STOP_AND_TARGET_ACTIVE position (entry already
+    filled) ready for place_exit to act on."""
+    trade_id = om._create_position_record(_entry(ticker))
+    # Wire the in-memory _ActiveOrder so place_exit can find it.
+    om._active_orders[trade_id] = _ActiveOrder(
+        trade_id=trade_id,
+        ticker=ticker,
+        exchange="US",
+        alpaca_entry_order_id="entry-1",
+        alpaca_stop_order_id="stop-1",
+        alpaca_target_order_id="target-1",
+        status=PositionStatus.STOP_AND_TARGET_ACTIVE,
+        entry_shares=10.0,
+        filled_shares=10.0,
+        entry_price=100.0,
+        stop_price=98.0,
+        target_price=104.0,
+        hold_type="intraday",
+        strategy_id="overnight_drift",
+    )
+    om._update_position_status(
+        trade_id, PositionStatus.STOP_AND_TARGET_ACTIVE,
+    )
+    return trade_id
+
+
+def _stub_alpaca_exit_submit(om: OrderManager, exit_id: str = "exit-1") -> None:
+    """Wire client.get_orders + cancel + submit so place_exit succeeds."""
+    om._gw.client.get_orders = MagicMock(return_value=[])
+    om._gw.client.cancel_order_by_id = MagicMock()
+    submitted = MagicMock()
+    submitted.id = exit_id
+    om._gw.client.submit_order = MagicMock(return_value=submitted)
+
+
+@pytest.mark.asyncio
+async def test_place_exit_persists_alpaca_exit_order_id(
+    config, tmp_db_path: str, mock_notifier,
+):
+    """After successful place_exit, positions.alpaca_exit_order_id
+    holds the Alpaca order id — not just the in-memory _ActiveOrder.
+    This is the invariant that survives a process restart."""
+    om = _make_om(config, tmp_db_path, mock_notifier)
+    trade_id = _seed_open_position(om)
+    _stub_alpaca_exit_submit(om, exit_id="alp-exit-42")
+
+    order_id = await om.place_exit(
+        ticker="SPY", qty=10, reason="overnight_exit",
+    )
+    assert order_id == "alp-exit-42"
+
+    # In-memory write (pre-existing behaviour).
+    assert om._active_orders[trade_id].alpaca_exit_order_id == "alp-exit-42"
+
+    # NEW: DB write — the cross-tick invariant.
+    conn = sqlite3.connect(tmp_db_path)
+    try:
+        row = conn.execute(
+            "SELECT alpaca_exit_order_id, status FROM positions WHERE id = ?",
+            (trade_id,),
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row[0] == "alp-exit-42"
+    assert row[1] == "CLOSING"
+
+
+@pytest.mark.asyncio
+async def test_hydrate_recovers_pending_exit_after_restart(
+    config, tmp_db_path: str, mock_notifier,
+):
+    """Simulate a tick boundary: place_exit on OM_a, then tear it down
+    and build OM_b against the same DB. Hydration must restore
+    _ActiveOrder.alpaca_exit_order_id from positions row + register
+    the reverse index entry so a fill poll can resolve the order to a
+    trade."""
+    om_a = _make_om(config, tmp_db_path, mock_notifier)
+    trade_id = _seed_open_position(om_a)
+    _stub_alpaca_exit_submit(om_a, exit_id="alp-exit-rehydrate")
+    await om_a.place_exit(ticker="SPY", qty=10, reason="overnight_exit")
+
+    # New tick — completely fresh OM.
+    om_b = _make_om(config, tmp_db_path, mock_notifier)
+    assert om_b._active_orders == {}, "fresh OM starts empty"
+    om_b._hydrate_active_orders()
+
+    active = om_b._active_orders[trade_id]
+    assert active.alpaca_exit_order_id == "alp-exit-rehydrate"
+    assert active.status == PositionStatus.CLOSING
+    # Reverse index lets _check_order_statuses resolve order_id back
+    # to the position when polling the exit.
+    assert om_b._alpaca_to_trade["alp-exit-rehydrate"] == trade_id
+
+
+@pytest.mark.asyncio
+async def test_cancel_rollback_clears_persisted_exit_order_id(
+    config, tmp_db_path: str, mock_notifier,
+):
+    """If a limit exit is canceled/expired/rejected, the OM rolls back
+    the position to STOP_AND_TARGET_ACTIVE. The persisted exit_order_id
+    must also be cleared in the DB so the next tick re-evaluates the
+    exit fresh and doesn't see a stale order id pointing at a dead
+    Alpaca order."""
+    om = _make_om(config, tmp_db_path, mock_notifier)
+    trade_id = _seed_open_position(om)
+    _stub_alpaca_exit_submit(om, exit_id="alp-exit-to-cancel")
+    await om.place_exit(ticker="SPY", qty=10, reason="overnight_exit")
+
+    # Sanity: column populated before the rollback.
+    conn = sqlite3.connect(tmp_db_path)
+    try:
+        assert conn.execute(
+            "SELECT alpaca_exit_order_id FROM positions WHERE id = ?",
+            (trade_id,),
+        ).fetchone()[0] == "alp-exit-to-cancel"
+    finally:
+        conn.close()
+
+    # Drive the cancel/expire/reject branch of _check_order_statuses by
+    # making the polled exit order report a terminal non-fill status.
+    canceled = MagicMock()
+    canceled.id = "alp-exit-to-cancel"
+    canceled.status = MagicMock()
+    canceled.status.value = "canceled"
+    canceled.filled_qty = 0
+    canceled.filled_avg_price = 0
+    om._gw.client.get_order_by_id = MagicMock(return_value=canceled)
+    om._gw.client.get_orders = MagicMock(return_value=[])
+
+    await om._check_order_statuses()
+
+    # In-memory and DB both cleared; status rolled back.
+    assert om._active_orders[trade_id].alpaca_exit_order_id is None
+    assert (
+        om._active_orders[trade_id].status
+        == PositionStatus.STOP_AND_TARGET_ACTIVE
+    )
+    conn = sqlite3.connect(tmp_db_path)
+    try:
+        row = conn.execute(
+            "SELECT alpaca_exit_order_id, status FROM positions WHERE id = ?",
+            (trade_id,),
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row[0] is None, "DB column must be cleared on rollback"
+    assert row[1] == "STOP_AND_TARGET_ACTIVE"
+
+
+@pytest.mark.asyncio
+async def test_get_open_positions_exposes_exit_order_id_for_skip(
+    config, tmp_db_path: str, mock_notifier,
+):
+    """VirtualPortfolio.get_open_positions does SELECT * — so a
+    place_exit success makes the column visible to StrategyManager.
+    check_exits without further plumbing. This is the data dependency
+    that the V11+ skip-gate in StrategyManager relies on."""
+    om = _make_om(config, tmp_db_path, mock_notifier)
+    trade_id = _seed_open_position(om, ticker="XLF")
+    _stub_alpaca_exit_submit(om, exit_id="alp-exit-skip")
+    await om.place_exit(ticker="XLF", qty=10, reason="overnight_exit")
+
+    # Read the way VirtualPortfolio.get_open_positions does — SELECT *
+    # filtered by strategy + open statuses.
+    conn = sqlite3.connect(tmp_db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute(
+            "SELECT * FROM positions WHERE strategy_id = ? "
+            "AND status NOT IN ('CLOSED', 'ENTRY_FAILED')",
+            ("overnight_drift",),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    assert len(rows) == 1
+    pos: dict[str, Any] = dict(rows[0])
+    assert pos["id"] == trade_id
+    assert pos.get("alpaca_exit_order_id") == "alp-exit-skip", (
+        "the column must materialize from SELECT * so the StrategyManager "
+        "skip-gate can read position.get('alpaca_exit_order_id')"
+    )

--- a/trading_bot/tests/test_migration_v11_alpaca_exit_order_id.py
+++ b/trading_bot/tests/test_migration_v11_alpaca_exit_order_id.py
@@ -1,0 +1,159 @@
+"""Tests for V11: add ``positions.alpaca_exit_order_id`` column.
+
+Pre-V11 the strategy-driven exit order id lived only in
+``OrderManager._ActiveOrder.alpaca_exit_order_id`` (in-memory). Every
+overnight_drift exit straddled a process boundary, so the next tick
+re-fired the same exit and relied on Alpaca's ``held_for_orders``
+guard plus StateRecovery to reconcile. See
+memory/overnight_drift_exit_orphans.md.
+
+V11 adds a nullable TEXT column so the order id survives across ticks.
+These tests pin:
+
+1. Fresh DB at SCHEMA_VERSION has the column.
+2. Pre-V11 DB upgraded by ``run_migrations`` ends up with the column,
+   existing rows backfilled to NULL.
+3. The migration is idempotent — running V11 twice is a no-op the
+   second time.
+4. The column is part of ``positions.SELECT *`` so VirtualPortfolio
+   and OrderManager hydration see it without further code changes.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from trading_bot.constants import SCHEMA_VERSION
+from trading_bot.db.migrations import _migration_v11, run_migrations
+
+
+def _column_names(conn: sqlite3.Connection, table: str) -> set[str]:
+    return {row[1] for row in conn.execute(f"PRAGMA table_info({table})")}
+
+
+@pytest.fixture
+def db_at_v10(tmp_path: Path) -> Path:
+    """Build a SQLite DB at V10 so we can drive _migration_v11 directly."""
+    db = tmp_path / "v10.db"
+    # Apply all migrations then rewind the version pointer to 10. The
+    # full schema already includes the V11 column when SCHEMA_VERSION=11,
+    # so to simulate "DB last migrated at V10" we both rewind the
+    # schema_version row AND drop the column.
+    run_migrations(str(db))
+    conn = sqlite3.connect(str(db))
+    try:
+        conn.execute("DELETE FROM schema_version WHERE version >= 11")
+        # Drop the V11 column to mirror a real V10-era schema.
+        if "alpaca_exit_order_id" in _column_names(conn, "positions"):
+            conn.execute("ALTER TABLE positions DROP COLUMN alpaca_exit_order_id")
+        conn.commit()
+    finally:
+        conn.close()
+    return db
+
+
+@pytest.mark.unit
+def test_fresh_db_at_target_version_has_column(tmp_path: Path) -> None:
+    """A clean run_migrations on an empty DB lands at SCHEMA_VERSION
+    with the column already present (via _SCHEMA_SQL on V4)."""
+    db = tmp_path / "fresh.db"
+    run_migrations(str(db))
+    conn = sqlite3.connect(str(db))
+    try:
+        cols = _column_names(conn, "positions")
+        version = conn.execute(
+            "SELECT MAX(version) FROM schema_version"
+        ).fetchone()[0]
+    finally:
+        conn.close()
+    assert "alpaca_exit_order_id" in cols
+    assert version == SCHEMA_VERSION
+
+
+@pytest.mark.unit
+def test_v11_adds_column_on_existing_db(db_at_v10: Path) -> None:
+    """V10 → V11 adds the new column; existing rows survive intact."""
+    conn = sqlite3.connect(str(db_at_v10))
+    try:
+        # Seed an existing position row to prove backfill is non-destructive.
+        conn.execute(
+            "INSERT INTO positions (ticker, exchange, currency, quantity, "
+            "entry_price, entry_time, status, hold_type, phase, strategy_id) "
+            "VALUES ('SPY','NYSE','USD',10,100.0,'2026-05-01T10:00:00-04:00',"
+            "'POSITION_OPEN','intraday',1,'mean_reversion')"
+        )
+        conn.commit()
+        assert "alpaca_exit_order_id" not in _column_names(conn, "positions")
+
+        _migration_v11(conn)
+        conn.commit()
+
+        cols = _column_names(conn, "positions")
+        assert "alpaca_exit_order_id" in cols, "V11 must add the column"
+
+        row = conn.execute(
+            "SELECT ticker, alpaca_exit_order_id FROM positions"
+        ).fetchone()
+        assert row == ("SPY", None), "backfilled rows must default to NULL"
+
+        version = conn.execute(
+            "SELECT MAX(version) FROM schema_version"
+        ).fetchone()[0]
+        assert version == 11
+    finally:
+        conn.close()
+
+
+@pytest.mark.unit
+def test_v11_is_idempotent(db_at_v10: Path) -> None:
+    """Running V11 twice must be safe — fresh installs get the column
+    from _SCHEMA_SQL on V4, then the V11 migration runs against an
+    already-correct schema and must not error."""
+    conn = sqlite3.connect(str(db_at_v10))
+    try:
+        _migration_v11(conn)
+        conn.commit()
+        # Second run should not raise (and the column should still be
+        # there, not duplicated).
+        _migration_v11(conn)
+        conn.commit()
+
+        rows = conn.execute(
+            "PRAGMA table_info(positions)"
+        ).fetchall()
+        exit_oid_cols = [r for r in rows if r[1] == "alpaca_exit_order_id"]
+        assert len(exit_oid_cols) == 1, (
+            f"expected exactly one alpaca_exit_order_id column, got "
+            f"{len(exit_oid_cols)}"
+        )
+    finally:
+        conn.close()
+
+
+@pytest.mark.unit
+def test_column_appears_in_select_star(tmp_path: Path) -> None:
+    """VirtualPortfolio.get_open_positions and OrderManager hydration
+    both rely on SELECT * — so the column must materialize without
+    explicit query changes."""
+    db = tmp_path / "fresh.db"
+    run_migrations(str(db))
+    conn = sqlite3.connect(str(db))
+    conn.row_factory = sqlite3.Row
+    try:
+        conn.execute(
+            "INSERT INTO positions (ticker, exchange, currency, quantity, "
+            "entry_price, entry_time, status, hold_type, phase, strategy_id, "
+            "alpaca_exit_order_id) "
+            "VALUES ('QQQ','NASDAQ','USD',5,200.0,'2026-05-01T10:00:00-04:00',"
+            "'CLOSING','swing',1,'overnight_drift','alp-exit-123')"
+        )
+        conn.commit()
+
+        row = conn.execute("SELECT * FROM positions WHERE ticker='QQQ'").fetchone()
+        assert "alpaca_exit_order_id" in row.keys()
+        assert row["alpaca_exit_order_id"] == "alp-exit-123"
+    finally:
+        conn.close()

--- a/trading_bot/tests/test_strategy_manager.py
+++ b/trading_bot/tests/test_strategy_manager.py
@@ -2206,6 +2206,73 @@ class TestCheckExits:
         assert n == 0
         assert strategy.evaluate_exit_calls == []
 
+    @pytest.mark.asyncio
+    async def test_pending_exit_skips_evaluate(
+        self,
+        base_market_data,
+        base_risk_manager,
+        base_earnings,
+        base_sentiment,
+        base_order_manager,
+        base_portfolio_manager,
+        base_config,
+        tmp_db_path,
+    ):
+        """V11+: a position with a persisted alpaca_exit_order_id has
+        a pending exit order from an earlier tick. check_exits must
+        skip it entirely — no evaluate_exit call, no place_exit. The
+        OrderManager's poll handles fill detection (or rollback on
+        cancel/expire/reject). Without this gate, the bot would
+        re-submit and Alpaca would reject with
+        ``held_for_orders=qty`` — the 2026-05-12/13 pattern that
+        motivated the V11 work."""
+        sm, strategy, portfolio = self._setup(
+            base_market_data, base_portfolio_manager, base_order_manager, base_config,
+            base_risk_manager, base_sentiment, base_earnings, tmp_db_path,
+            positions=[{
+                "ticker": "SPY", "entry_price": 100.0, "quantity": 5,
+                "alpaca_exit_order_id": "alp-exit-pending",
+            }],
+            exit_signal=ExitSignal(should_exit=True, reason="overnight_exit"),
+        )
+        n = await sm.check_exits()
+        assert n == 0, "must not double-submit when an exit is already pending"
+        assert strategy.evaluate_exit_calls == [], (
+            "evaluate_exit must be short-circuited for positions with "
+            "a persisted alpaca_exit_order_id — the gate runs before "
+            "the strategy is consulted"
+        )
+        portfolio.record_exit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_null_exit_order_id_does_not_skip(
+        self,
+        base_market_data,
+        base_risk_manager,
+        base_earnings,
+        base_sentiment,
+        base_order_manager,
+        base_portfolio_manager,
+        base_config,
+        tmp_db_path,
+    ):
+        """Sanity: an explicit NULL in the position dict (the common
+        case — no pending exit) must NOT short-circuit. Catches a
+        regression where someone accidentally writes ``if "key" in
+        position`` instead of ``if position.get(...) is not None``."""
+        sm, strategy, _ = self._setup(
+            base_market_data, base_portfolio_manager, base_order_manager, base_config,
+            base_risk_manager, base_sentiment, base_earnings, tmp_db_path,
+            positions=[{
+                "ticker": "SPY", "entry_price": 100.0, "quantity": 5,
+                "alpaca_exit_order_id": None,
+            }],
+            exit_signal=ExitSignal(should_exit=True, reason="take_profit"),
+        )
+        n = await sm.check_exits()
+        assert n == 1
+        assert len(strategy.evaluate_exit_calls) == 1
+
 
 def test_get_comparison_report(
     base_market_data,


### PR DESCRIPTION
Closes the overnight_drift orphan-exit gap from [memory/overnight_drift_exit_orphans.md](memory/overnight_drift_exit_orphans.md).

## Problem

Pre-V11 the strategy-driven exit order id lived only in \`OrderManager._ActiveOrder.alpaca_exit_order_id\` — in-memory state that vaporizes when the stateless tick exits. Every overnight_drift exit straddles a process boundary (entered at 15:45 ET, exit fires at 09:30 ET next day), so the pending order id is invisible to the second tick. The next tick re-evaluates the same overnight_exit signal and submits a duplicate SELL, relying on Alpaca's \`held_for_orders=qty, available=0\` guard to reject it. StateRecovery + the nightly backfill then reconcile.

**Cost of the pre-V11 path:**
- 100% of overnight_drift exits go through the recovery path
- \`exit_reason\` is lost — stamped 'manual' or 'reconciliation_mismatch' instead of 'overnight_exit'
- daily_summaries for the close date is blank until the 22:40 UTC backfill
- Spurious CRITICAL log lines on every duplicate-submit rejection

## Fix — the four points

1. **\`positions.alpaca_exit_order_id\` column** (V11 migration, idempotent, backfilled NULL).
2. **\`OrderManager._hydrate_active_orders\`** reads the column → populates \`_ActiveOrder.alpaca_exit_order_id\` and the \`_alpaca_to_trade\` reverse index, so the next tick's poll resolves the order to a trade.
3. **\`StrategyManager.check_exits\`** skips positions where \`position.get('alpaca_exit_order_id') is not None\` — the early return that prevents the duplicate-submit. Uses \`.get(...) is not None\` so older DB rows (column NULL or absent) flow through unchanged.
4. **\`_check_order_statuses\`** clears both the in-memory field and the DB column on cancel/expire/reject rollback. \`_close_position\` cleans up the reverse-index entry on FILL.

\`place_exit\` and \`place_limit_exit\` both persist the column BEFORE flipping status to CLOSING, so a crash between the two writes leaves the row recoverable on the next tick's hydration.

## Files

| File | Change |
|---|---|
| \`trading_bot/constants.py\` | \`SCHEMA_VERSION: 10 → 11\` |
| \`trading_bot/db/schema.py\` | New column in positions CREATE |
| \`trading_bot/db/migrations.py\` | \`_migration_v11\` (idempotent ALTER) |
| \`trading_bot/execution/order_manager.py\` | Hydration + persist + clear + reverse-index |
| \`trading_bot/strategy/strategy_manager.py\` | Skip-gate in \`check_exits\` |
| \`trading_bot/tests/test_migration_v11_alpaca_exit_order_id.py\` | NEW — 4 migration tests |
| \`trading_bot/tests/test_exit_persistence_v11.py\` | NEW — 4 OM behaviour tests |
| \`trading_bot/tests/test_strategy_manager.py\` | +2 TestCheckExits cases |

## Test plan

- [x] 4 migration tests pin the V11 ALTER, idempotency, fresh-install via \`_SCHEMA_SQL\`, and SELECT * visibility
- [x] 4 OM persistence tests: \`place_exit\` writes the column; fresh-OM hydration round-trips; cancel/expire/reject rolls back in both memory + DB; SELECT * surfaces the column for the skip-gate
- [x] 2 TestCheckExits cases: pending-exit short-circuits \`evaluate_exit\`; NULL exit_order_id falls through to evaluate normally
- [x] Full suite: 908 passed, 3 skipped (was 898 + 10 new)
- [x] ruff clean across all touched files
- [ ] After merge: confirm the next overnight_drift exit lands with \`exit_reason='overnight_exit'\` not \`reconciliation_mismatch\`, and daily_summaries reflects the close pnl on the same trading day (not waiting for 22:40 UTC backfill)