### PR TITLE
fix(backtest): track peak/MaxDD + mark-to-market at last close in run_spy_intraday

### DIFF
--- a/trading_bot/multi_strategy_backtest.py
+++ b/trading_bot/multi_strategy_backtest.py
@@ -1319,6 +1319,15 @@ class MultiStrategyBacktester:
         # ``prev_day is None`` on the very first bar prevents the read,
         # but explicit init removes the smell.
         day_start_equity: dict[str, float] = {}
+        # Last bar's close, used as the mark-to-market price for open
+        # positions when crossing a day boundary. Pre-fix this code path
+        # marked positions at ``entry_price`` (= cost basis) and never
+        # updated ``peak_equity_usd``/``max_drawdown_pct``, which made
+        # MaxDD report 0.0% on every --spy run regardless of actual
+        # equity excursions. ``run_multi_ticker_intraday`` and
+        # ``run_daily_backtest`` mark at the latest close and track DD
+        # correctly — this aligns ``run_spy_intraday`` with them.
+        last_close: float = 0.0
 
         for bar_idx in range(LOOKBACK_BARS, len(df_5min)):
             bar = df_5min.iloc[bar_idx]
@@ -1336,8 +1345,14 @@ class MultiStrategyBacktester:
             if bar_date != prev_day:
                 if prev_day is not None:
                     for sid, st in states.items():
+                        # Mark open positions at the previous day's
+                        # last close (``last_close``), not at entry
+                        # price. Without this, intraday and overnight
+                        # P&L on still-open positions never reflects
+                        # in equity, so peak/DD stay anchored at the
+                        # opening cash balance.
                         pos_value = sum(
-                            t.entry_price * t.shares for t in st.open_positions
+                            last_close * t.shares for t in st.open_positions
                         )
                         total_now = st.cash_usd + pos_value
                         total_before = day_start_equity.get(sid, total_now)
@@ -1347,6 +1362,20 @@ class MultiStrategyBacktester:
                             )
                         else:
                             st.daily_returns.append(0.0)
+                        # Update peak / max drawdown at the day boundary.
+                        # Mirrors the same block in
+                        # ``run_multi_ticker_intraday`` (~L1825) and
+                        # ``run_daily_backtest`` (~L678). Pre-fix this
+                        # block was absent and MaxDD never moved off 0.0.
+                        if total_now > st.peak_equity_usd:
+                            st.peak_equity_usd = total_now
+                        if st.peak_equity_usd > 0:
+                            dd_pct = (
+                                (st.peak_equity_usd - total_now)
+                                / st.peak_equity_usd * 100
+                            )
+                            if dd_pct > st.max_drawdown_pct:
+                                st.max_drawdown_pct = dd_pct
 
                     for st in states.values():
                         for trade in st.open_positions:
@@ -1354,8 +1383,12 @@ class MultiStrategyBacktester:
 
                 day_start_equity = {}
                 for sid, st in states.items():
+                    # Baseline for the new day's daily_returns. Use the
+                    # most recent close (= previous day's close, which
+                    # equals today's pre-open mark) to keep open
+                    # positions valued at market.
                     pos_value = sum(
-                        t.entry_price * t.shares for t in st.open_positions
+                        last_close * t.shares for t in st.open_positions
                     )
                     day_start_equity[sid] = st.cash_usd + pos_value
 
@@ -1492,6 +1525,10 @@ class MultiStrategyBacktester:
                     st.open_positions.append(trade)
                     st.cash_usd -= cost
                     st.trade_count += 1
+
+            # End-of-bar bookkeeping: remember the close so the next
+            # day-boundary block can mark-to-market and update DD.
+            last_close = bar_close
 
             # Progress logging
             if bar_idx % 10000 == 0:

--- a/trading_bot/tests/test_multi_strategy_backtest.py
+++ b/trading_bot/tests/test_multi_strategy_backtest.py
@@ -1229,3 +1229,70 @@ class TestFractionalShares:
         )
         # Integer capped: floor(3.6) = 3
         assert shares == 3.0
+
+
+# ---------------------------------------------------------------------------
+# Regression: run_spy_intraday must track MaxDD (2026-05-14)
+# ---------------------------------------------------------------------------
+
+class TestSpyIntradayDrawdownTracking:
+    """Pre-2026-05-14 ``run_spy_intraday`` had two related bugs in its
+    day-boundary block:
+
+    1. Open positions were marked at ``entry_price`` (cost basis) so
+       equity never reflected price moves on held positions.
+    2. The peak-equity / max-drawdown update block was simply missing.
+
+    Net effect: every ``--spy`` backtest reported MaxDD = 0.0%
+    regardless of actual equity excursions, while ``--multi-intraday``
+    and ``--daily`` modes were unaffected. The fix aligns
+    ``run_spy_intraday`` with the other two handlers."""
+
+    @pytest.mark.asyncio
+    async def test_max_drawdown_is_nonzero_over_a_lossy_window(
+        self, config: Config,
+    ) -> None:
+        """A 1-year SPY window includes the 2018 Q4 selloff — a
+        strategy that takes any losing trade in that window must
+        produce MaxDD > 0. Pre-fix this assertion failed (MaxDD
+        always reported as 0.0); post-fix the peak/DD tracking at
+        the day-boundary block records real equity excursions."""
+        # Skip if the real SPY dataset isn't present (CI without it
+        # would otherwise fail noisily). The integration test only
+        # makes sense against real bars — synthetic data wouldn't
+        # exercise the strategy's signal-generation path.
+        try:
+            from trading_bot.data.spy_intraday_loader import load_spy_range
+            spy_check = load_spy_range(date(2018, 1, 1), date(2018, 1, 5))
+            if spy_check.empty:
+                pytest.skip("SPY 1-min dataset not available in this env")
+        except Exception:
+            pytest.skip("SPY 1-min dataset not loadable in this env")
+
+        engine = MultiStrategyBacktester(config)
+        result = await engine.run_spy_intraday(
+            from_date=date(2018, 1, 1),
+            to_date=date(2018, 12, 31),
+            cash_per_strategy_usd=1000.0,
+            regime_filter=True,
+        )
+
+        # Find the mean_reversion strategy result. The default config
+        # always includes it.
+        mr = next(
+            (s for s in result.strategies if s.strategy_id == "mean_reversion"),
+            None,
+        )
+        assert mr is not None, "mean_reversion must be present"
+        assert mr.total_trades > 0, (
+            "regression test requires at least one trade in the 2018 "
+            "window — if this fails the strategy config has drifted "
+            "and the test no longer exercises the bug"
+        )
+        assert mr.max_drawdown_pct > 0, (
+            f"MaxDD must be > 0 over a year that includes 2018 Q4 "
+            f"selloff and {mr.losses} losing trades. Pre-fix this was "
+            f"silently 0.0 because the day-boundary block marked open "
+            f"positions at entry_price and never updated "
+            f"peak_equity_usd / max_drawdown_pct."
+        )


### PR DESCRIPTION
## Problem

Every \`--spy\` backtest reported \`MaxDD = 0.0%\` regardless of actual equity excursions. Two related bugs in \`run_spy_intraday\`'s day-boundary block:

1. **Stale mark-to-market.** Open positions were marked at \`entry_price\` (cost basis), so equity never reflected price moves on held positions. \`daily_returns\` computed from this stale equity told the same lie.
2. **Missing peak/DD tracking.** The \`if total_now > peak_equity_usd ... if dd_pct > max_drawdown_pct: max_drawdown_pct = dd_pct\` block that lives in \`run_daily_backtest\` (~L678) and \`run_multi_ticker_intraday\` (~L1825) was simply absent.

The other two handlers are fine — only \`--spy\` mode produces the bug. Existed since at least #85. Surfaced today during the post-V11 regression sweep:

\`\`\`
--spy mean_reversion 2008-2021: MaxDD=0.0% (memory baseline says -11.9%)
\`\`\`

## Fix

- Track \`last_close\` updated at the end of each bar iteration.
- In the day-boundary block, mark open positions at \`last_close\` instead of \`entry_price\`. Same mark seeds \`day_start_equity\` for the new day.
- Add the missing peak/DD tracking block immediately after \`total_now\` is computed, mirroring \`run_multi_ticker_intraday\`.

## Post-fix verification

SPY 13yr mean_reversion baseline:

| Metric | Pre-fix | Post-fix | Memory baseline |
|---|---:|---:|---:|
| Trades | 93 | 93 | 102 |
| Win rate | 62.4% | 62.4% | 60.8% |
| Profit factor | 1.60 | 1.60 | 1.54 |
| Return | +77.48% | +77.48% | +76.09% |
| **MaxDD** | **0.0%** | **11.10%** | **−11.9%** |
| Sharpe | 0.60 | 0.62 | — |

PF/WR/return are unchanged — those depend on closed trades, not the equity curve. MaxDD now lines up with the memory baseline (the small delta is normal across code revisions; what matters is it's the right order of magnitude).

## Test plan

- [x] New \`TestSpyIntradayDrawdownTracking::test_max_drawdown_is_nonzero_over_a_lossy_window\` — 1-year SPY slice over the 2018 Q4 selloff, asserts \`MaxDD > 0\`. Pre-fix this would have failed (silently 0.0); post-fix it passes.
- [x] Full suite: 911 passed, 1 skipped (was 908+3 skipped — symlinks unblocked 2 previously-skipped tests, plus 1 new)
- [x] ruff clean across both touched files
- [x] Live SPY 13yr re-run: MaxDD 0.0% → 11.10%, all trade-level metrics unchanged