### PR TITLE
fix(mean_reversion): default fractional_shares=True (ai-broker#39 follow-up)

### DIFF
--- a/trading_bot/docs/self_improve_followups.md
+++ b/trading_bot/docs/self_improve_followups.md
@@ -12,6 +12,24 @@ says "exercise extreme care with all order logic."
   `StopOrderRequest` on fill; take-profit is managed by the tick-loop's
   `check_exits` polling against `target_price`. The PR #38 whole-share floor
   has been removed — fractional shares pass through end-to-end.
+
+  **Accepted tradeoff — 5-min take-profit polling gap (decision 2026-05-14, ai-broker#39 re-audit).**
+  Issue #39 flagged "tick-cadence gap on take-profit" as needing an explicit
+  decision. PR #53 shipped tick-loop polling against `target_price` in place
+  of a broker-side take-profit limb because Alpaca rejects fractional+bracket
+  combos with code 42210000. The polling cadence is the bot's main-loop tick
+  (5 min during NYSE hours on GHA cron), so a fast print past the target
+  between ticks can exit at a worse price than a broker-side limit would have.
+  We accept this for the $1k live account: (a) PR #53's backtest A/B is
+  byte-identical at the strategy level — the cost is realized fill quality,
+  not signal selection; (b) fractional entries on $1k are small enough that
+  worst-case slippage on a 5-min window is bounded by the strategy's own
+  stop distance; (c) the alternative (broker-side TP for whole-qty + polled
+  TP for fractional) doubles the entry-path code surface for a single live
+  sleeve (mean_reversion, ~60 trades/year), which is a worse foot-gun than
+  the slippage it avoids. **Revisit only if** (i) live equity rises far
+  enough that whole-share entries become the norm, or (ii) postmortems
+  surface a pattern of take-profit slippage beyond the stop-distance bound.
 - **#40 — `PerformanceCalculator` not surfacing closed trades.** Two pre-existing
   test failures reproduce the same pattern as the live `daily_summaries` showing
   0/0/0 wins/losses despite closed entries. Probably the load-bearing reason

--- a/trading_bot/strategy/strategies/mean_reversion.py
+++ b/trading_bot/strategy/strategies/mean_reversion.py
@@ -47,7 +47,14 @@ class MeanReversionStrategy(StrategyBase):
         self._atr_activation_mult: float = float(config.get("atr_activation_mult", 2.5))
         self._risk_per_trade_pct: float = float(config.get("risk_per_trade_pct", 0.02))
         self._max_position_pct: float = float(config.get("max_position_pct", 0.40))
-        self._fractional_shares: bool = bool(config.get("fractional_shares", False))
+        # Default True for consistency with overnight_drift / ORB and to
+        # match the ai-broker#39 plain-limit + standalone-stop entry path,
+        # which is the path the $1k live account *must* take. Whole shares
+        # at $1k with SPY/QQQ/XLK >$400 floors to 0, dropping ~50% of
+        # mean_reversion signals — see PR #38 / issue ai-broker#39. Live
+        # config.yaml sets this explicitly to True; the default exists so
+        # a forgotten override does not silently regress to the floor.
+        self._fractional_shares: bool = bool(config.get("fractional_shares", True))
         # Let winners run past the target. When true, the ATR-derived target
         # is used as the trailing-stop activation price (not a hard exit).
         # Exits become: stop loss, trailing stop after activation, or RSI exit.

--- a/trading_bot/tests/test_strategies.py
+++ b/trading_bot/tests/test_strategies.py
@@ -165,6 +165,18 @@ class TestMeanReversion:
         result = strategy.evaluate_entry("PLTR", "US", df, df, 10.5, 250.0)
         assert result is None
 
+    def test_fractional_shares_default_is_true(self) -> None:
+        """Regression: mean_reversion must default fractional_shares=True.
+
+        The $1k live account requires fractional shares — whole-share rounding
+        at SPY/QQQ/XLK >$400 floors to 0 and drops ~50% of mean_reversion
+        signals (see ai-broker#39). If a config ever omits the explicit
+        ``fractional_shares: true`` override, this default keeps the sleeve
+        from silently regressing to whole-share sizing.
+        """
+        strategy = MeanReversionStrategy(config=_mr_config())
+        assert strategy._fractional_shares is True
+
     def test_entry_on_rsi_recovery(self) -> None:
         strategy = MeanReversionStrategy(config=_mr_config())
         df = _make_oversold_bars(60)


### PR DESCRIPTION
Follow-up from re-audit of issue #39.

## Summary

- Flip the in-code default of `fractional_shares` on `MeanReversionStrategy` from `False` to `True` so the sleeve matches `overnight_drift` and `opening_range_breakout`. Live `config.yaml` already overrides both sleeves to `true` — this prevents a silent regression to the whole-share floor if a future config edit drops the explicit override.
- Add a regression test asserting the default.
- Record the accepted-tradeoff note for the 5-min take-profit polling gap in `self_improve_followups.md`. Issue #39's body called this out as "needs explicit decision" and PR #53 shipped the polling path without writing the decision down.

## Why this is worth a PR on its own

Issue #39 itself is functionally done (PR #53 shipped the plain-limit + standalone-stop entry path on 2026-05-03). The re-audit found two small follow-ups: this default mismatch, and the missing decision note. Both are bounded, no live-order-logic risk, and they remove future foot-guns before the live flip.

## Behaviour change

None in current production — `config.yaml` line 629 already sets `fractional_shares: true` for mean_reversion.

## Test plan

- [x] `pytest trading_bot/tests/` — 923 passed (1 new regression test added)
- [x] New test `TestMeanReversion::test_fractional_shares_default_is_true` exercises the default path
- [x] Existing 8 fractional/stop-attach tests in `test_order_manager_lifecycle.py` still pass