### PR TITLE
fix(execution): standalone-stop lifecycle gaps leaving fractional positions naked (ai-broker#117)

### DIFF
--- a/trading_bot/execution/order_manager.py
+++ b/trading_bot/execution/order_manager.py
@@ -501,11 +501,55 @@ class OrderManager:
                                 hold_time="", exit_reason=exit_reason.value,
                             )
                             break
+                        if order.status.value in ("canceled", "expired", "rejected"):
+                            # Issue #117 failure mode A: a stop/target/trail
+                            # cancelled at the broker (DAY expiry, external
+                            # cancel, EOD wind-down) leaves the row pinned to
+                            # STOP_AND_TARGET_ACTIVE with a dead order_id —
+                            # subsequent ticks never re-attach because no
+                            # branch handles that state. Clear the dead id
+                            # and, for the protective stop specifically,
+                            # demote to POSITION_OPEN so the recovery branch
+                            # below re-attaches a fresh stop this tick.
+                            logger.warning(
+                                "Exit order %s for %s is %s — clearing dead id "
+                                "(trade_id=%d, leg=%s)",
+                                order_id, active.ticker, order.status.value,
+                                trade_id, order_id_attr,
+                            )
+                            setattr(active, order_id_attr, None)
+                            self._update_position_field(
+                                trade_id, order_id_attr, None,
+                            )
+                            self._alpaca_to_trade.pop(order_id, None)
+                            if order_id_attr == "alpaca_stop_order_id":
+                                active.status = PositionStatus.POSITION_OPEN
+                                self._update_position_status(
+                                    trade_id, PositionStatus.POSITION_OPEN,
+                                )
                     except Exception:
                         logger.warning(
                             "Error checking exit order for %s", active.ticker,
                             exc_info=True,
                         )
+
+            # Issue #117 failure modes B & C: a position can land in
+            # POSITION_OPEN with alpaca_stop_order_id=NULL when
+            # _transition_to_open was interrupted between the status flip
+            # (line 1281) and the stop-id write (line 1337) — a killed
+            # cron tick, an SDK hang, or a silent submit-response loss.
+            # Pre-fix the only thing that healed this was the next-market-
+            # open _verify_stop_orders sweep, leaving the position naked
+            # for up to a full overnight + weekend window. Re-attempt the
+            # stop attach during market hours so the protective stop is
+            # back on the book within one tick (≤ 5 min) of the gap.
+            if (
+                active.status == PositionStatus.POSITION_OPEN
+                and active.alpaca_stop_order_id is None
+                and active.filled_shares > 0
+                and active.stop_price > 0
+            ):
+                await self._recover_missing_stop(trade_id, active)
 
             # Strategy-driven exit (place_exit / place_limit_exit). Without
             # this branch the row stays CLOSING until the next tick's
@@ -1456,6 +1500,157 @@ class OrderManager:
                     continue
             return str(order.id)
         return None
+
+    # Minimum seconds before close required for a DAY stop to make it onto
+    # the book before Alpaca defers it to the next session. Mirrors
+    # recovery._STOP_VERIFY_CLOSE_BUFFER_SEC (PR #102) — the same phantom-
+    # stop bug applies here: a stop submitted at 15:57 ET is deferred to
+    # the next session's pre-market open where it holds the qty and
+    # blocks the morning's strategy exit.
+    _STOP_RECOVER_CLOSE_BUFFER_SEC: int = 300
+
+    async def _inside_market_hours_for_stop_attach(self) -> bool:
+        """Return True when the recovery branch may submit a fresh stop.
+
+        Primary: consult Alpaca's clock (`is_open` + `next_close`) so
+        early-close days (Thanksgiving Friday, July 3, Christmas Eve)
+        are handled correctly — a fixed 15:55 ET cutoff would happily
+        place a stop at 13:30 on an early-close day, which Alpaca would
+        defer to the next session.
+
+        Fallback: fixed time gate 09:30 ≤ now_et < 15:55 ET.
+        """
+        try:
+            clock = await asyncio.to_thread(self._gw.client.get_clock)
+            is_open = getattr(clock, "is_open", None)
+            if isinstance(is_open, bool):
+                if not is_open:
+                    return False
+                next_close = getattr(clock, "next_close", None)
+                if isinstance(next_close, datetime):
+                    if next_close.tzinfo is None:
+                        next_close = next_close.replace(tzinfo=ET)
+                    seconds_to_close: float = (
+                        next_close - datetime.now(tz=ET)
+                    ).total_seconds()
+                    if seconds_to_close < self._STOP_RECOVER_CLOSE_BUFFER_SEC:
+                        return False
+                return True
+        except Exception:
+            logger.debug(
+                "AlpacaClock unavailable for stop-recover gate; "
+                "falling back to fixed time window",
+                exc_info=True,
+            )
+        now_et: datetime = datetime.now(tz=ET)
+        hhmm: int = now_et.hour * 60 + now_et.minute
+        return 9 * 60 + 30 <= hhmm < 15 * 60 + 55
+
+    async def _recover_missing_stop(
+        self, trade_id: int, active: _ActiveOrder,
+    ) -> None:
+        """Attach a standalone stop on a POSITION_OPEN row that has none.
+
+        Called from ``_check_order_statuses`` when a row is rehydrated
+        with ``status=POSITION_OPEN`` and ``alpaca_stop_order_id=NULL``
+        — the survivor of a crashed/interrupted ``_transition_to_open``
+        (issue #117 failure modes B & C) or of a stop that was cancelled
+        at the broker without re-attachment (failure mode A, after the
+        cancellation handler in ``_check_order_statuses`` demotes the
+        row's status). Gated on market hours to avoid the phantom-stop
+        bug that PR #102 fixed for ``recovery._verify_stop_orders``.
+
+        On submit-response loss (alpaca-py occasionally raises after
+        Alpaca accepted the order) we adopt any matching open stop via
+        ``_find_existing_stop`` rather than emergency-flattening a real
+        position. On total failure the row stays POSITION_OPEN so the
+        next tick retries — and ``recovery._verify_stop_orders`` is the
+        ultimate fallback at the next market open.
+        """
+        if not await self._inside_market_hours_for_stop_attach():
+            logger.info(
+                "Stop recovery deferred for %s (trade_id=%d) — outside "
+                "safe placement window; next market-open recovery sweep "
+                "will heal.",
+                active.ticker, trade_id,
+            )
+            return
+
+        recovered: str | None = await self._find_existing_stop(
+            active.ticker, active.filled_shares, stop_price=active.stop_price,
+        )
+        if recovered is not None:
+            logger.warning(
+                "Stop recovery: adopting existing broker stop for %s "
+                "(trade_id=%d, alpaca_id=%s) — DB row was POSITION_OPEN "
+                "with no recorded stop_order_id.",
+                active.ticker, trade_id, recovered,
+            )
+            active.alpaca_stop_order_id = recovered
+            self._alpaca_to_trade[recovered] = trade_id
+            self._update_position_field(
+                trade_id, "alpaca_stop_order_id", recovered,
+            )
+            active.status = PositionStatus.STOP_AND_TARGET_ACTIVE
+            self._update_position_status(
+                trade_id, PositionStatus.STOP_AND_TARGET_ACTIVE,
+            )
+            await self._notifier.send(
+                "Stop Recovery: Adopted Existing Broker Stop",
+                (
+                    f"Adopted broker-side stop for {active.ticker} "
+                    f"(trade_id={trade_id}, alpaca_id={recovered}). "
+                    f"Position was POSITION_OPEN without a recorded "
+                    f"stop_order_id; investigate issue #117 lineage."
+                ),
+                priority=3,
+                tags=["warning"],
+            )
+            return
+
+        stop_id: str | None = await self._place_standalone_stop(
+            trade_id, active, active.filled_shares,
+        )
+        if stop_id is None:
+            logger.warning(
+                "Stop recovery: submit failed for %s (trade_id=%d, "
+                "qty=%.6f, stop=%.4f) — leaving POSITION_OPEN for next "
+                "tick retry; recovery._verify_stop_orders is the final "
+                "fallback at next market open.",
+                active.ticker, trade_id,
+                active.filled_shares, active.stop_price,
+            )
+            return
+
+        # Persist the order_id BEFORE the status flip so a crash between
+        # the two writes leaves the row POSITION_OPEN + stop_id set —
+        # the next tick's recovery treats that as already-healed.
+        active.alpaca_stop_order_id = stop_id
+        self._alpaca_to_trade[stop_id] = trade_id
+        self._update_position_field(trade_id, "alpaca_stop_order_id", stop_id)
+        active.status = PositionStatus.STOP_AND_TARGET_ACTIVE
+        self._update_position_status(
+            trade_id, PositionStatus.STOP_AND_TARGET_ACTIVE,
+        )
+        logger.warning(
+            "Stop recovery: attached fresh stop %s for %s (trade_id=%d, "
+            "qty=%.6f, stop=%.4f) — position was naked since prior tick.",
+            stop_id, active.ticker, trade_id,
+            active.filled_shares, active.stop_price,
+        )
+        await self._notifier.send(
+            "Stop Recovery: Re-attached Protective Stop",
+            (
+                f"Re-attached protective stop for {active.ticker} "
+                f"(trade_id={trade_id}, qty={active.filled_shares:.6f}, "
+                f"stop=${active.stop_price:.4f}, alpaca_id={stop_id}). "
+                f"Position was POSITION_OPEN without a stop; this is "
+                f"the issue #117 failure surface — investigate prior "
+                f"tick's logs."
+            ),
+            priority=3,
+            tags=["warning"],
+        )
 
     async def activate_trailing_stop(self, trade_id: int, trail_pct: float) -> bool:
         """Activate trailing stop, replacing the take-profit order."""

--- a/trading_bot/execution/order_manager.py
+++ b/trading_bot/execution/order_manager.py
@@ -523,10 +523,40 @@ class OrderManager:
                             )
                             self._alpaca_to_trade.pop(order_id, None)
                             if order_id_attr == "alpaca_stop_order_id":
+                                # Protective stop gone — demote so the
+                                # recovery branch below re-attaches.
                                 active.status = PositionStatus.POSITION_OPEN
                                 self._update_position_status(
                                     trade_id, PositionStatus.POSITION_OPEN,
                                 )
+                            elif (
+                                order_id_attr == "alpaca_trail_order_id"
+                                and active.status == PositionStatus.TRAILING_ACTIVE
+                            ):
+                                # Trail order gone but fixed stop
+                                # (alpaca_stop_order_id) is independent —
+                                # not nulled when activate_trailing_stop
+                                # ran, so the position is still protected.
+                                # Demote to STOP_AND_TARGET_ACTIVE so the
+                                # trail re-activation logic in
+                                # check_trail_activations can re-fire
+                                # next time price crosses the threshold;
+                                # otherwise the row sticks in
+                                # TRAILING_ACTIVE with a NULL trail id
+                                # forever.
+                                active.trail_activated = False
+                                active.status = (
+                                    PositionStatus.STOP_AND_TARGET_ACTIVE
+                                )
+                                self._update_position_status(
+                                    trade_id,
+                                    PositionStatus.STOP_AND_TARGET_ACTIVE,
+                                )
+                            # Don't continue checking remaining legs on
+                            # this iteration — the row's status has
+                            # changed and the next tick will re-evaluate
+                            # cleanly.
+                            break
                     except Exception:
                         logger.warning(
                             "Error checking exit order for %s", active.ticker,
@@ -547,9 +577,22 @@ class OrderManager:
                 active.status == PositionStatus.POSITION_OPEN
                 and active.alpaca_stop_order_id is None
                 and active.filled_shares > 0
-                and active.stop_price > 0
             ):
-                await self._recover_missing_stop(trade_id, active)
+                if active.stop_price <= 0:
+                    # Defence-in-depth: a row with status=POSITION_OPEN
+                    # but no stop_price means the strategy or persistence
+                    # layer dropped it. _place_standalone_stop refuses
+                    # to attach a non-positive stop anyway; surface the
+                    # state explicitly rather than silently skip so the
+                    # operator can spot the upstream bug.
+                    logger.warning(
+                        "Stop recovery skipped for %s (trade_id=%d): "
+                        "stop_price=%.4f is non-positive — cannot attach. "
+                        "Inspect upstream strategy/persistence path.",
+                        active.ticker, trade_id, active.stop_price,
+                    )
+                else:
+                    await self._recover_missing_stop(trade_id, active)
 
             # Strategy-driven exit (place_exit / place_limit_exit). Without
             # this branch the row stays CLOSING until the next tick's

--- a/trading_bot/execution/stop_reconciler.py
+++ b/trading_bot/execution/stop_reconciler.py
@@ -1,0 +1,225 @@
+"""Naked-position reconciliation: detect DB-open rows without an active broker-side stop.
+
+Walks ``positions`` rows that should have an active protective stop and
+verifies the recorded ``alpaca_stop_order_id`` is in an active state at
+Alpaca. Surfaces any mismatch as a HIGH-priority notification so the
+operator sees the bug class from issue #117 even when the in-tick
+recovery (see ``OrderManager._recover_missing_stop``) silently heals it.
+
+This is intended to run once per tick — it's cheap (one Alpaca query
+per recorded stop, plus the open-orders scan that the recovery layer
+already performs). It does NOT mutate state; it only reports.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sqlite3
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from alpaca.trading.models import Order as AlpacaOrder
+
+from trading_bot.constants import PositionStatus
+
+if TYPE_CHECKING:
+    from trading_bot.gateway import GatewayConnection
+    from trading_bot.notifications import Notifier
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+# Alpaca order statuses that mean the stop is still on the book and
+# protective. Anything else (canceled / expired / rejected / filled /
+# pending_cancel / suspended) means the position is naked or being
+# closed without the protective gate.
+_ACTIVE_STOP_STATUSES: frozenset[str] = frozenset(
+    {"new", "accepted", "held", "pending_new", "accepted_for_bidding"}
+)
+
+
+@dataclass
+class NakedPosition:
+    """A DB-tracked open position whose Alpaca stop isn't active."""
+
+    trade_id: int
+    ticker: str
+    status: str
+    quantity: float
+    entry_price: float
+    stop_price: float
+    alpaca_stop_order_id: str | None
+    broker_status: str  # 'missing' / 'canceled' / 'expired' / 'rejected' / 'filled' / etc.
+
+    def describe(self) -> str:
+        sid: str = self.alpaca_stop_order_id or "NULL"
+        return (
+            f"{self.ticker} (trade_id={self.trade_id}, qty={self.quantity:.6f}, "
+            f"entry=${self.entry_price:.4f}, stop=${self.stop_price:.4f}, "
+            f"stop_order_id={sid}, broker_status={self.broker_status})"
+        )
+
+
+@dataclass
+class ReconciliationResult:
+    """Output of a naked-position scan."""
+
+    rows_checked: int = 0
+    naked: list[NakedPosition] = field(default_factory=list)
+
+    @property
+    def has_naked(self) -> bool:
+        return bool(self.naked)
+
+    def summary(self) -> str:
+        if not self.naked:
+            return f"Stop reconciliation: {self.rows_checked} rows OK"
+        lines: list[str] = [
+            f"Stop reconciliation: {len(self.naked)} naked of "
+            f"{self.rows_checked} open positions",
+        ]
+        for n in self.naked:
+            lines.append(f"  - {n.describe()}")
+        return "\n".join(lines)
+
+
+# Statuses we expect to have a broker-side stop attached. POSITION_OPEN
+# is included on purpose — pre-#117 it could land in the DB without a
+# recorded stop_order_id, and the in-tick recovery only fires inside
+# the market-hours gate.
+_STATUSES_NEEDING_STOP: tuple[str, ...] = (
+    PositionStatus.POSITION_OPEN.value,
+    PositionStatus.STOP_AND_TARGET_ACTIVE.value,
+    PositionStatus.TRAILING_ACTIVE.value,
+)
+
+
+def _load_open_positions(db_path: str) -> list[sqlite3.Row]:
+    """Return positions rows that ought to have an active protective stop."""
+    try:
+        conn: sqlite3.Connection = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+        try:
+            placeholders: str = ",".join("?" * len(_STATUSES_NEEDING_STOP))
+            rows: list[sqlite3.Row] = conn.execute(
+                f"SELECT id, ticker, status, quantity, entry_price, "
+                f"stop_price, alpaca_stop_order_id "
+                f"FROM positions WHERE status IN ({placeholders})",
+                _STATUSES_NEEDING_STOP,
+            ).fetchall()
+        finally:
+            conn.close()
+    except sqlite3.OperationalError:
+        logger.warning(
+            "stop reconciler: positions table unreadable", exc_info=True,
+        )
+        return []
+    return rows
+
+
+async def _broker_status(
+    gateway: GatewayConnection, order_id: str,
+) -> str:
+    """Return the Alpaca order status for ``order_id``, or 'missing' on lookup
+    failure. Failure to fetch is treated as missing so the reconciler errs
+    on the side of surfacing potential naked positions."""
+    try:
+        order: AlpacaOrder = await asyncio.to_thread(
+            gateway.client.get_order_by_id, order_id,  # type: ignore[arg-type]
+        )
+    except Exception:
+        logger.debug(
+            "stop reconciler: get_order_by_id failed for %s",
+            order_id, exc_info=True,
+        )
+        return "missing"
+    status_obj = getattr(order, "status", None)
+    return (getattr(status_obj, "value", "") or "").lower() or "unknown"
+
+
+async def reconcile_open_position_stops(
+    db_path: str,
+    gateway: GatewayConnection,
+    notifier: Notifier | None = None,
+) -> ReconciliationResult:
+    """Scan DB-open positions and flag any without an active broker stop.
+
+    Args:
+        db_path: path to the SQLite DB.
+        gateway: connected Alpaca gateway (used for ``get_order_by_id``).
+        notifier: optional notifier — when provided, a HIGH-priority
+            notification fires for any naked position discovered.
+
+    Returns:
+        ReconciliationResult with the list of naked positions. Safe to
+        log/discard on every tick; the heavy lifting is one Alpaca
+        round-trip per recorded stop (typically ≤ 8 positions in Phase 3).
+    """
+    rows: list[sqlite3.Row] = _load_open_positions(db_path)
+    result: ReconciliationResult = ReconciliationResult(rows_checked=len(rows))
+
+    for row in rows:
+        stop_oid: str | None = row["alpaca_stop_order_id"]
+        # POSITION_OPEN-with-no-recorded-stop is itself a naked finding —
+        # the in-tick recovery may have just attached one, but if this
+        # check runs before the recovery branch (or outside the
+        # market-hours window) the row is still naked at the broker.
+        if not stop_oid:
+            naked: NakedPosition = NakedPosition(
+                trade_id=int(row["id"]),
+                ticker=str(row["ticker"]),
+                status=str(row["status"]),
+                quantity=float(row["quantity"] or 0),
+                entry_price=float(row["entry_price"] or 0),
+                stop_price=float(row["stop_price"] or 0),
+                alpaca_stop_order_id=None,
+                broker_status="missing",
+            )
+            result.naked.append(naked)
+            continue
+
+        broker_status: str = await _broker_status(gateway, stop_oid)
+        if broker_status in _ACTIVE_STOP_STATUSES:
+            continue
+        result.naked.append(
+            NakedPosition(
+                trade_id=int(row["id"]),
+                ticker=str(row["ticker"]),
+                status=str(row["status"]),
+                quantity=float(row["quantity"] or 0),
+                entry_price=float(row["entry_price"] or 0),
+                stop_price=float(row["stop_price"] or 0),
+                alpaca_stop_order_id=stop_oid,
+                broker_status=broker_status,
+            )
+        )
+
+    if result.has_naked:
+        logger.warning(
+            "stop reconciler: %d naked position(s) of %d checked",
+            len(result.naked), result.rows_checked,
+        )
+        for naked in result.naked:
+            logger.warning("  naked: %s", naked.describe())
+        if notifier is not None:
+            body: str = "\n".join(n.describe() for n in result.naked)
+            await notifier.send(
+                "Naked Position Detected",
+                (
+                    f"Found {len(result.naked)} DB-open "
+                    f"position(s) without an active broker-side stop. "
+                    f"Issue #117 surface — in-tick recovery should "
+                    f"heal during market hours; verify and "
+                    f"investigate lineage.\n\n{body}"
+                ),
+                priority=4,
+                tags=["warning"],
+            )
+    else:
+        logger.info(
+            "stop reconciler: all %d open position(s) have active stops",
+            result.rows_checked,
+        )
+
+    return result

--- a/trading_bot/execution/stop_reconciler.py
+++ b/trading_bot/execution/stop_reconciler.py
@@ -101,9 +101,13 @@ def _load_open_positions(db_path: str) -> list[sqlite3.Row]:
         conn: sqlite3.Connection = sqlite3.connect(db_path)
         conn.row_factory = sqlite3.Row
         try:
+            # The f-string composes only literal "?" placeholders from a
+            # fixed module-level tuple — no user input reaches the SQL.
+            # Bandit B608 flags any f-string in SQL; pinned `# nosec`
+            # mirrors the same pattern at order_manager.py:1954.
             placeholders: str = ",".join("?" * len(_STATUSES_NEEDING_STOP))
             rows: list[sqlite3.Row] = conn.execute(
-                f"SELECT id, ticker, status, quantity, entry_price, "
+                f"SELECT id, ticker, status, quantity, entry_price, "  # nosec B608
                 f"stop_price, alpaca_stop_order_id "
                 f"FROM positions WHERE status IN ({placeholders})",
                 _STATUSES_NEEDING_STOP,

--- a/trading_bot/main.py
+++ b/trading_bot/main.py
@@ -330,6 +330,26 @@ class TradingBot:
             except Exception:
                 logger.warning("Order status poll failed", exc_info=True)
 
+            # --- 6b. Naked-position reconciliation (issue #117) ---
+            # Walks DB-open rows and verifies each has an active broker
+            # stop. Surfaces the issue #117 failure surface even when
+            # the in-tick recovery silently heals — operator visibility
+            # is the goal (the in-tick recovery is the actual healer).
+            try:
+                from trading_bot.execution.stop_reconciler import (
+                    reconcile_open_position_stops,
+                )
+                await reconcile_open_position_stops(
+                    db_path=self._db_path,
+                    gateway=self._gateway,
+                    notifier=self._notifier,
+                )
+            except Exception:
+                logger.warning(
+                    "Naked-position reconciliation failed (non-fatal)",
+                    exc_info=True,
+                )
+
             # --- 7. Phase 0 one-time marker (Alpaca has no legacy cleanup) ---
             if not self._is_phase0_complete():
                 self._record_phase_transition(

--- a/trading_bot/main.py
+++ b/trading_bot/main.py
@@ -43,6 +43,7 @@ from trading_bot.execution.loss_cooldown import LossCooldownConfig, LossCooldown
 from trading_bot.execution.order_manager import EntryDecision as OMEntryDecision
 from trading_bot.execution.order_manager import OrderManager
 from trading_bot.execution.risk_manager import RiskManager
+from trading_bot.execution.stop_reconciler import reconcile_open_position_stops
 from trading_bot.gateway.connection import GatewayConnection
 from trading_bot.gateway.recovery import StateRecovery
 from trading_bot.notifications.notifier import Notifier
@@ -336,9 +337,6 @@ class TradingBot:
             # the in-tick recovery silently heals — operator visibility
             # is the goal (the in-tick recovery is the actual healer).
             try:
-                from trading_bot.execution.stop_reconciler import (
-                    reconcile_open_position_stops,
-                )
                 await reconcile_open_position_stops(
                     db_path=self._db_path,
                     gateway=self._gateway,

--- a/trading_bot/tests/test_standalone_stop_lifecycle_117.py
+++ b/trading_bot/tests/test_standalone_stop_lifecycle_117.py
@@ -1,0 +1,572 @@
+"""Regression tests for the issue #117 standalone-stop lifecycle gaps.
+
+Covers three failure modes that left fractional positions naked at Alpaca:
+
+A. Stop cancelled at the broker but DB still references the dead order id —
+   pre-#117 the stop-poll loop ignored ``canceled`` / ``expired`` / ``rejected``
+   statuses, so the row sat in ``STOP_AND_TARGET_ACTIVE`` forever.
+B. ``_transition_to_open`` interrupted between the status flip and the
+   stop-id write — the row landed in ``POSITION_OPEN`` with
+   ``alpaca_stop_order_id=NULL`` and no branch in ``_check_order_statuses``
+   handled it. Self-heal only happened on the next market-open
+   ``_verify_stop_orders`` sweep.
+C. Overnight_drift entries at 15:45 ET produced the same B-shaped state
+   on the next tick.
+
+The fix adds a stop-cancellation handler (A) that demotes the row to
+``POSITION_OPEN`` and a recovery branch (B/C) that re-attaches the
+standalone stop during market hours.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock
+
+import pytest
+
+from trading_bot.constants import PositionStatus, TZ_EASTERN
+from trading_bot.execution.order_manager import (
+    EntryDecision,
+    OrderManager,
+)
+from trading_bot.execution.stop_reconciler import (
+    reconcile_open_position_stops,
+)
+
+pytestmark = pytest.mark.critical
+
+ET = TZ_EASTERN
+
+
+# ---------------------------------------------------------------------------
+# Helpers (mirrors test_order_manager_lifecycle helpers, kept local to
+# avoid coupling regression coverage to refactors of that file)
+# ---------------------------------------------------------------------------
+
+
+def _make_om(config, db_path: str, notifier) -> OrderManager:
+    gw = MagicMock()
+    gw.client = MagicMock()
+    return OrderManager(gw, config, notifier, db_path)
+
+
+def _alpaca_order(
+    order_id: str = "order-1",
+    status: str = "new",
+    filled_qty: float = 0.0,
+    filled_avg_price: float = 0.0,
+):
+    o = MagicMock()
+    o.id = order_id
+    o.status = MagicMock()
+    o.status.value = status
+    o.filled_qty = filled_qty
+    o.filled_avg_price = filled_avg_price
+    return o
+
+
+def _entry(
+    ticker: str = "XLI",
+    shares: float = 0.3181,
+    price: float = 173.008,
+    strategy_id: str = "mean_reversion",
+    hold_type: str = "intraday",
+) -> EntryDecision:
+    return EntryDecision(
+        ticker=ticker,
+        exchange="US",
+        side="BUY",
+        shares=shares,
+        limit_price=price,
+        stop_price=round(price * 0.98, 2),
+        target_price=round(price * 1.02, 2),
+        hold_type=hold_type,
+        sector="Industrials",
+        phase=3,
+        sentiment_score=0.0,
+        signals="test",
+        currency="USD",
+        strategy_id=strategy_id,
+        trail_pct=None,
+        trail_activation_price=None,
+    )
+
+
+def _set_market_open(om: OrderManager) -> None:
+    """Make ``_inside_market_hours_for_stop_attach`` return True via the
+    Alpaca clock path. Uses a fixed forward-dated ``next_close`` so the
+    5-minute buffer check passes regardless of when the suite runs.
+    """
+    clock = MagicMock()
+    clock.is_open = True
+    clock.next_close = datetime.now(tz=ET) + timedelta(hours=1)
+    om._gw.client.get_clock = MagicMock(return_value=clock)
+
+
+def _set_market_closed(om: OrderManager) -> None:
+    clock = MagicMock()
+    clock.is_open = False
+    clock.next_close = None
+    om._gw.client.get_clock = MagicMock(return_value=clock)
+
+
+# ---------------------------------------------------------------------------
+# Failure mode B — POSITION_OPEN with NULL stop_order_id (mid-tick crash)
+# ---------------------------------------------------------------------------
+
+
+class TestFailureModeB_StopNeverAttached:
+    """``_transition_to_open`` interrupted mid-flow.
+
+    Reproduces XLI #99 (2026-05-12 11:45 ET): mean_reversion entry filled,
+    POSITION_OPEN landed in the DB, but ``_place_standalone_stop`` never
+    persisted an order id. Pre-fix the next tick simply hydrated this
+    state and fell through every branch, leaving the position naked.
+    """
+
+    @pytest.mark.asyncio
+    async def test_recovery_attaches_fresh_stop(
+        self, config, tmp_db_path: str, mock_notifier
+    ) -> None:
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        _set_market_open(om)
+
+        # Simulate the post-crash DB state: POSITION_OPEN, no stop id.
+        trade_id = om._create_position_record(_entry("XLI"))
+        om._update_position_status(trade_id, PositionStatus.POSITION_OPEN)
+        # Fill quantity so the recovery branch's guard passes.
+        om._update_position_field(trade_id, "quantity", 0.3181)
+        om._update_position_field(trade_id, "entry_price", 173.008)
+
+        # Alpaca has no existing matching stop, so recovery falls through
+        # to submitting a fresh one. Pre-fix path: no submit ever fires.
+        om._gw.client.get_orders = MagicMock(return_value=[])
+        captured: list = []
+
+        def _submit(order_data):
+            captured.append(order_data)
+            return _alpaca_order(f"stop-recovered-{len(captured)}", "new")
+
+        om._gw.client.submit_order = MagicMock(side_effect=_submit)
+
+        await om._check_order_statuses()
+
+        assert len(captured) == 1, (
+            "expected exactly one stop submission; pre-fix the recovery "
+            "branch did not exist so this would be zero"
+        )
+
+        # Status promoted and order id persisted.
+        active = om._active_orders[trade_id]
+        assert active.status == PositionStatus.STOP_AND_TARGET_ACTIVE
+        assert active.alpaca_stop_order_id == "stop-recovered-1"
+
+        conn = sqlite3.connect(tmp_db_path)
+        try:
+            row = conn.execute(
+                "SELECT status, alpaca_stop_order_id FROM positions "
+                "WHERE id = ?",
+                (trade_id,),
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row[0] == PositionStatus.STOP_AND_TARGET_ACTIVE.value
+        assert row[1] == "stop-recovered-1"
+
+    @pytest.mark.asyncio
+    async def test_recovery_adopts_existing_broker_stop(
+        self, config, tmp_db_path: str, mock_notifier
+    ) -> None:
+        """Submit-response loss: a prior tick's submit reached Alpaca but
+        the SDK raised during response parsing, so the DB never got the
+        order id. Recovery should adopt the live broker stop rather than
+        submitting a second one that would hold double the qty."""
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        _set_market_open(om)
+
+        trade_id = om._create_position_record(_entry("XLI"))
+        om._update_position_status(trade_id, PositionStatus.POSITION_OPEN)
+        om._update_position_field(trade_id, "quantity", 0.3181)
+        om._update_position_field(trade_id, "entry_price", 173.008)
+
+        # Live matching stop on the book — sell-side, matching qty + price.
+        live_stop = MagicMock()
+        live_stop.id = "stop-on-broker"
+        live_stop.order_type = MagicMock(value="stop")
+        live_stop.type = MagicMock(value="stop")
+        live_stop.side = MagicMock(value="sell")
+        live_stop.qty = "0.3181"
+        live_stop.stop_price = round(173.008 * 0.98, 2)
+        om._gw.client.get_orders = MagicMock(return_value=[live_stop])
+
+        # Any submit_order call would be a bug.
+        om._gw.client.submit_order = MagicMock(
+            side_effect=AssertionError("must not submit a second stop"),
+        )
+
+        await om._check_order_statuses()
+
+        active = om._active_orders[trade_id]
+        assert active.alpaca_stop_order_id == "stop-on-broker"
+        assert active.status == PositionStatus.STOP_AND_TARGET_ACTIVE
+
+
+# ---------------------------------------------------------------------------
+# Failure mode C — overnight_drift 15:45 ET entry, no stop next tick
+# ---------------------------------------------------------------------------
+
+
+class TestFailureModeC_OvernightDriftEntry:
+    """End-to-end: overnight_drift entry fills, next tick processes the
+    fill and must attach a stop. Pre-#117 there's a narrow path where
+    the post-fill stop-attach silently drops; the recovery branch is
+    the safety net for the next tick.
+    """
+
+    @pytest.mark.asyncio
+    async def test_late_session_entry_recovers_stop_next_tick(
+        self, config, tmp_db_path: str, mock_notifier
+    ) -> None:
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        _set_market_open(om)
+
+        # Simulate XLK #102 / XLF #103 (2026-05-13 15:45 ET): entry filled,
+        # row landed POSITION_OPEN without a stop id.
+        trade_id = om._create_position_record(
+            _entry("XLK", shares=0.5735, price=177.368, strategy_id="overnight_drift", hold_type="swing"),
+        )
+        om._update_position_status(trade_id, PositionStatus.POSITION_OPEN)
+        om._update_position_field(trade_id, "quantity", 0.5735)
+        om._update_position_field(trade_id, "entry_price", 177.368)
+
+        om._gw.client.get_orders = MagicMock(return_value=[])
+        submits: list = []
+
+        def _submit(order_data):
+            submits.append(order_data)
+            return _alpaca_order(f"stop-{len(submits)}", "new")
+
+        om._gw.client.submit_order = MagicMock(side_effect=_submit)
+
+        await om._check_order_statuses()
+
+        assert len(submits) == 1
+        active = om._active_orders[trade_id]
+        assert active.status == PositionStatus.STOP_AND_TARGET_ACTIVE
+        assert active.alpaca_stop_order_id == "stop-1"
+
+    @pytest.mark.asyncio
+    async def test_recovery_deferred_when_market_closed(
+        self, config, tmp_db_path: str, mock_notifier
+    ) -> None:
+        """Outside the safe placement window, the recovery defers to the
+        next-market-open ``_verify_stop_orders`` sweep — submitting a
+        DAY stop after close would be deferred to next session and held
+        as a phantom (the bug PR #102 fixed for recovery)."""
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        _set_market_closed(om)
+
+        trade_id = om._create_position_record(_entry("XLK"))
+        om._update_position_status(trade_id, PositionStatus.POSITION_OPEN)
+        om._update_position_field(trade_id, "quantity", 0.5735)
+
+        # If recovery does submit, this assertion fails the test.
+        om._gw.client.submit_order = MagicMock(
+            side_effect=AssertionError("must not submit outside window"),
+        )
+        om._gw.client.get_orders = MagicMock(return_value=[])
+
+        await om._check_order_statuses()
+
+        # Row stays POSITION_OPEN; the next market-open recovery sweep
+        # is the ultimate fallback. The submit_order side_effect would
+        # have fired if recovery tried — its absence is the assertion.
+        active = om._active_orders[trade_id]
+        assert active.status == PositionStatus.POSITION_OPEN
+        assert active.alpaca_stop_order_id is None
+
+
+# ---------------------------------------------------------------------------
+# Failure mode A — stop cancelled at broker, DB unaware
+# ---------------------------------------------------------------------------
+
+
+class TestFailureModeA_StopCancelledAtBroker:
+    """Reproduces SPY #90 / QQQ #91 (2026-05-07): stops were attached
+    correctly at entry but cancelled at 16:07 ET. Pre-#117 the stop-poll
+    loop only handled ``filled`` status; ``canceled`` was a no-op, so
+    the row sat in ``STOP_AND_TARGET_ACTIVE`` with a dead order id and
+    no protective stop on the book.
+    """
+
+    @pytest.mark.asyncio
+    async def test_cancelled_stop_demotes_to_position_open(
+        self, config, tmp_db_path: str, mock_notifier
+    ) -> None:
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        _set_market_open(om)
+
+        trade_id = om._create_position_record(_entry("SPY", shares=0.1681, price=732.976))
+        om._update_position_status(trade_id, PositionStatus.STOP_AND_TARGET_ACTIVE)
+        om._update_position_field(trade_id, "quantity", 0.1681)
+        om._update_position_field(trade_id, "entry_price", 732.976)
+        om._update_position_field(trade_id, "alpaca_stop_order_id", "stop-dead")
+
+        # Stop-poll: stop returns canceled. Recovery branch then runs and
+        # finds no existing broker stop, so it submits a fresh one.
+        submits: list = []
+
+        def _submit(order_data):
+            submits.append(order_data)
+            return _alpaca_order(f"stop-fresh-{len(submits)}", "new")
+
+        om._gw.client.submit_order = MagicMock(side_effect=_submit)
+        om._gw.client.get_orders = MagicMock(return_value=[])
+
+        def _get_order_by_id(oid: str):
+            if oid == "stop-dead":
+                return _alpaca_order(oid, "canceled")
+            return _alpaca_order(oid, "new")
+
+        om._gw.client.get_order_by_id = MagicMock(side_effect=_get_order_by_id)
+
+        await om._check_order_statuses()
+
+        # Fresh stop attached on the same tick.
+        assert len(submits) == 1
+        active = om._active_orders[trade_id]
+        assert active.status == PositionStatus.STOP_AND_TARGET_ACTIVE
+        assert active.alpaca_stop_order_id == "stop-fresh-1"
+
+        conn = sqlite3.connect(tmp_db_path)
+        try:
+            row = conn.execute(
+                "SELECT status, alpaca_stop_order_id FROM positions "
+                "WHERE id = ?",
+                (trade_id,),
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row[0] == PositionStatus.STOP_AND_TARGET_ACTIVE.value
+        assert row[1] == "stop-fresh-1"
+
+    @pytest.mark.asyncio
+    async def test_cancelled_target_does_not_demote(
+        self, config, tmp_db_path: str, mock_notifier
+    ) -> None:
+        """Only stop cancellation triggers the POSITION_OPEN demotion.
+        A cancelled take-profit (target) leg clears its own id but
+        leaves status untouched — the protective stop is still on the
+        book and the position is not naked."""
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        _set_market_open(om)
+
+        trade_id = om._create_position_record(_entry("SPY"))
+        om._update_position_status(trade_id, PositionStatus.STOP_AND_TARGET_ACTIVE)
+        om._update_position_field(trade_id, "quantity", 100)
+        om._update_position_field(trade_id, "alpaca_stop_order_id", "stop-live")
+        om._update_position_field(trade_id, "alpaca_target_order_id", "target-dead")
+
+        def _get_order_by_id(oid: str):
+            if oid == "stop-live":
+                return _alpaca_order(oid, "new")
+            if oid == "target-dead":
+                return _alpaca_order(oid, "canceled")
+            return _alpaca_order(oid, "new")
+
+        om._gw.client.get_order_by_id = MagicMock(side_effect=_get_order_by_id)
+        om._gw.client.get_orders = MagicMock(return_value=[])
+
+        await om._check_order_statuses()
+
+        active = om._active_orders[trade_id]
+        # Status preserved — stop is still active.
+        assert active.status == PositionStatus.STOP_AND_TARGET_ACTIVE
+        # Dead target id cleared.
+        assert active.alpaca_target_order_id is None
+        assert active.alpaca_stop_order_id == "stop-live"
+
+
+# ---------------------------------------------------------------------------
+# Reconciliation report
+# ---------------------------------------------------------------------------
+
+
+class TestStopReconciliation:
+    """The reconciler must surface naked positions even when in-tick
+    recovery silently heals them — that's how the operator learns the
+    underlying drop-the-stop bug occurred at all."""
+
+    def _seed_open_position(
+        self,
+        db_path: str,
+        ticker: str,
+        status: PositionStatus,
+        stop_order_id: str | None,
+    ) -> int:
+        conn = sqlite3.connect(db_path)
+        try:
+            now: str = datetime.now(tz=ET).isoformat()
+            cur = conn.execute(
+                "INSERT INTO positions "
+                "(ticker, exchange, currency, sector, quantity, entry_price, "
+                " entry_time, status, stop_price, target_price, hold_type, "
+                " phase, strategy_id, highest_price, updated_at, "
+                " alpaca_stop_order_id) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    ticker, "US", "USD", "Industrials",
+                    0.5, 100.0, now, status.value,
+                    98.0, 102.0, "intraday",
+                    3, "mean_reversion", 100.0, now,
+                    stop_order_id,
+                ),
+            )
+            conn.commit()
+            return int(cur.lastrowid)
+        finally:
+            conn.close()
+
+    @pytest.mark.asyncio
+    async def test_naked_position_with_null_stop_id_is_reported(
+        self, tmp_db_path: str, mock_notifier
+    ) -> None:
+        self._seed_open_position(
+            tmp_db_path, "XLI", PositionStatus.POSITION_OPEN, None,
+        )
+
+        gw = MagicMock()
+        gw.client = MagicMock()
+
+        result = await reconcile_open_position_stops(
+            db_path=tmp_db_path, gateway=gw, notifier=mock_notifier,
+        )
+
+        assert result.has_naked
+        assert len(result.naked) == 1
+        assert result.naked[0].ticker == "XLI"
+        assert result.naked[0].broker_status == "missing"
+        mock_notifier.send.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_naked_position_with_cancelled_stop_is_reported(
+        self, tmp_db_path: str, mock_notifier
+    ) -> None:
+        self._seed_open_position(
+            tmp_db_path, "SPY", PositionStatus.STOP_AND_TARGET_ACTIVE,
+            "stop-cancelled",
+        )
+
+        gw = MagicMock()
+        gw.client = MagicMock()
+        gw.client.get_order_by_id = MagicMock(
+            return_value=_alpaca_order("stop-cancelled", "canceled"),
+        )
+
+        result = await reconcile_open_position_stops(
+            db_path=tmp_db_path, gateway=gw, notifier=mock_notifier,
+        )
+
+        assert result.has_naked
+        assert result.naked[0].ticker == "SPY"
+        assert result.naked[0].broker_status == "canceled"
+
+    @pytest.mark.asyncio
+    async def test_position_with_active_stop_not_reported(
+        self, tmp_db_path: str, mock_notifier
+    ) -> None:
+        self._seed_open_position(
+            tmp_db_path, "XLK", PositionStatus.STOP_AND_TARGET_ACTIVE,
+            "stop-healthy",
+        )
+
+        gw = MagicMock()
+        gw.client = MagicMock()
+        gw.client.get_order_by_id = MagicMock(
+            return_value=_alpaca_order("stop-healthy", "new"),
+        )
+
+        result = await reconcile_open_position_stops(
+            db_path=tmp_db_path, gateway=gw, notifier=mock_notifier,
+        )
+
+        assert not result.has_naked
+        assert result.rows_checked == 1
+        mock_notifier.send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_alpaca_lookup_failure_treated_as_missing(
+        self, tmp_db_path: str, mock_notifier
+    ) -> None:
+        """A transient Alpaca outage during reconciliation should err on
+        the side of surfacing the position (better a false alarm than a
+        silent naked position)."""
+        self._seed_open_position(
+            tmp_db_path, "XLF", PositionStatus.STOP_AND_TARGET_ACTIVE,
+            "stop-flaky",
+        )
+
+        gw = MagicMock()
+        gw.client = MagicMock()
+        gw.client.get_order_by_id = MagicMock(
+            side_effect=RuntimeError("alpaca 503"),
+        )
+
+        result = await reconcile_open_position_stops(
+            db_path=tmp_db_path, gateway=gw, notifier=mock_notifier,
+        )
+
+        assert result.has_naked
+        assert result.naked[0].broker_status == "missing"
+
+
+# ---------------------------------------------------------------------------
+# Market-hours gate
+# ---------------------------------------------------------------------------
+
+
+class TestStopRecoveryMarketHoursGate:
+
+    @pytest.mark.asyncio
+    async def test_clock_closed_defers_recovery(
+        self, config, tmp_db_path: str, mock_notifier
+    ) -> None:
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        _set_market_closed(om)
+        assert not await om._inside_market_hours_for_stop_attach()
+
+    @pytest.mark.asyncio
+    async def test_clock_open_with_long_runway_allows_recovery(
+        self, config, tmp_db_path: str, mock_notifier
+    ) -> None:
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        _set_market_open(om)
+        assert await om._inside_market_hours_for_stop_attach()
+
+    @pytest.mark.asyncio
+    async def test_clock_open_close_to_bell_defers(
+        self, config, tmp_db_path: str, mock_notifier
+    ) -> None:
+        """4 minutes from close — DAY stop would be deferred to next
+        session, so the recovery should skip rather than create the
+        phantom-stop class of bug PR #102 fixed for recovery."""
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        clock = MagicMock()
+        clock.is_open = True
+        clock.next_close = datetime.now(tz=ET) + timedelta(minutes=4)
+        om._gw.client.get_clock = MagicMock(return_value=clock)
+        assert not await om._inside_market_hours_for_stop_attach()
+
+    @pytest.mark.asyncio
+    async def test_clock_unavailable_falls_back_to_time_gate(
+        self, config, tmp_db_path: str, mock_notifier
+    ) -> None:
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        om._gw.client.get_clock = MagicMock(
+            side_effect=RuntimeError("clock 503"),
+        )
+        # Result depends on wall-clock time; just verify no crash.
+        result = await om._inside_market_hours_for_stop_attach()
+        assert isinstance(result, bool)

--- a/trading_bot/tests/test_standalone_stop_lifecycle_117.py
+++ b/trading_bot/tests/test_standalone_stop_lifecycle_117.py
@@ -388,6 +388,136 @@ class TestFailureModeA_StopCancelledAtBroker:
         assert active.alpaca_target_order_id is None
         assert active.alpaca_stop_order_id == "stop-live"
 
+    @pytest.mark.asyncio
+    async def test_cancelled_stop_breaks_loop_does_not_double_process(
+        self, config, tmp_db_path: str, mock_notifier
+    ) -> None:
+        """After the stop cancellation handler demotes to POSITION_OPEN,
+        the leg loop must break — otherwise remaining legs (target,
+        trail) are polled against a row whose status was just changed,
+        producing confusing logs. Verifies the post-review break fix."""
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        _set_market_open(om)
+
+        trade_id = om._create_position_record(_entry("SPY"))
+        om._update_position_status(trade_id, PositionStatus.STOP_AND_TARGET_ACTIVE)
+        om._update_position_field(trade_id, "quantity", 100)
+        om._update_position_field(trade_id, "alpaca_stop_order_id", "stop-dead")
+        om._update_position_field(trade_id, "alpaca_target_order_id", "target-live")
+
+        get_calls: list[str] = []
+
+        def _get_order_by_id(oid: str):
+            get_calls.append(oid)
+            if oid == "stop-dead":
+                return _alpaca_order(oid, "canceled")
+            if oid == "target-live":
+                return _alpaca_order(oid, "new")
+            return _alpaca_order(oid, "new")
+
+        om._gw.client.get_order_by_id = MagicMock(side_effect=_get_order_by_id)
+        # Make _find_existing_stop return no match so recovery submits fresh.
+        om._gw.client.get_orders = MagicMock(return_value=[])
+        om._gw.client.submit_order = MagicMock(
+            return_value=_alpaca_order("stop-fresh", "new"),
+        )
+
+        await om._check_order_statuses()
+
+        # The target leg must NOT have been queried after the stop's
+        # cancellation handler demoted the row — break exits the loop.
+        assert "stop-dead" in get_calls
+        assert "target-live" not in get_calls
+
+    @pytest.mark.asyncio
+    async def test_cancelled_trail_demotes_to_stop_and_target_active(
+        self, config, tmp_db_path: str, mock_notifier
+    ) -> None:
+        """TRAILING_ACTIVE rows keep ``alpaca_stop_order_id`` populated
+        (activate_trailing_stop only cancels the take-profit leg, not
+        the protective stop). A cancelled trail order therefore is NOT
+        a naked-position event — but the row mustn't get stuck in
+        TRAILING_ACTIVE with a NULL trail id, or check_trail_activations
+        will never re-fire. Demoting to STOP_AND_TARGET_ACTIVE clears
+        the trail-activated flag so re-activation can run on the next
+        price cross."""
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        _set_market_open(om)
+
+        trade_id = om._create_position_record(_entry("SPY"))
+        om._update_position_status(trade_id, PositionStatus.TRAILING_ACTIVE)
+        om._update_position_field(trade_id, "quantity", 100)
+        om._update_position_field(trade_id, "alpaca_stop_order_id", "stop-live")
+        om._update_position_field(trade_id, "alpaca_trail_order_id", "trail-dead")
+        # Mark trail_activated so we can verify the demotion clears it.
+        # (Activation flag is in-memory only on _ActiveOrder; hydrate
+        # manually for the test.)
+
+        def _get_order_by_id(oid: str):
+            if oid == "stop-live":
+                return _alpaca_order(oid, "new")
+            if oid == "trail-dead":
+                return _alpaca_order(oid, "canceled")
+            return _alpaca_order(oid, "new")
+
+        om._gw.client.get_order_by_id = MagicMock(side_effect=_get_order_by_id)
+        om._gw.client.get_orders = MagicMock(return_value=[])
+
+        # Hydrate to load the row, then pre-set trail_activated.
+        om._hydrate_active_orders()
+        om._active_orders[trade_id].trail_activated = True
+
+        await om._check_order_statuses()
+
+        active = om._active_orders[trade_id]
+        # Demoted, not stuck in TRAILING_ACTIVE.
+        assert active.status == PositionStatus.STOP_AND_TARGET_ACTIVE
+        assert active.alpaca_trail_order_id is None
+        # Fixed stop still in place — position is not naked.
+        assert active.alpaca_stop_order_id == "stop-live"
+        # Re-activation flag reset so trail can re-fire next price cross.
+        assert active.trail_activated is False
+
+
+class TestRecoveryGuardEdgeCases:
+    """Edge cases around the new POSITION_OPEN-without-stop recovery branch."""
+
+    @pytest.mark.asyncio
+    async def test_recovery_skipped_when_stop_price_zero(
+        self, config, tmp_db_path: str, mock_notifier, caplog
+    ) -> None:
+        """A row with stop_price=0 cannot have a stop attached — the
+        underlying _place_standalone_stop refuses non-positive prices.
+        The recovery guard must skip with a warning rather than silently
+        falling through (operator needs visibility into upstream bugs)."""
+        import logging
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        _set_market_open(om)
+
+        # Seed: POSITION_OPEN, no stop id, qty > 0, but stop_price = 0.
+        entry = _entry("XLI")
+        entry.stop_price = 0.0  # type: ignore[misc]
+        trade_id = om._create_position_record(entry)
+        om._update_position_status(trade_id, PositionStatus.POSITION_OPEN)
+        om._update_position_field(trade_id, "quantity", 0.5)
+        om._update_position_field(trade_id, "stop_price", 0.0)
+
+        om._gw.client.submit_order = MagicMock(
+            side_effect=AssertionError("must not submit with stop_price=0"),
+        )
+
+        with caplog.at_level(logging.WARNING):
+            await om._check_order_statuses()
+
+        # Recovery skipped, row left for operator inspection.
+        active = om._active_orders[trade_id]
+        assert active.status == PositionStatus.POSITION_OPEN
+        assert active.alpaca_stop_order_id is None
+        # The warning surfaces the upstream bug.
+        assert any(
+            "non-positive" in record.message for record in caplog.records
+        )
+
 
 # ---------------------------------------------------------------------------
 # Reconciliation report


### PR DESCRIPTION
## Summary

Fixes [ai-broker#117](https://github.com/alex5imon/ai-broker/issues/117) — three failure modes that left fractional positions naked at Alpaca. Pre-live blocker per the issue.

All three failure modes share a single root cause: **a `POSITION_OPEN` row with `alpaca_stop_order_id=NULL` is unreachable by `_check_order_statuses`** — no branch handles it. Self-heal only happens at the next market-open `recovery._verify_stop_orders` sweep, an up-to-overnight + weekend window where the position is unprotected.

### Failure mode A — stop cancelled at broker, DB unaware (SPY #90, QQQ #91)
The stop-poll loop in `_check_order_statuses` only handled `filled` status. A `canceled` / `expired` / `rejected` stop left the row stuck in `STOP_AND_TARGET_ACTIVE` with a dead `alpaca_stop_order_id` forever.

**Fix:** clear the dead id; for the stop leg specifically, demote status to `POSITION_OPEN` so the recovery branch re-attaches a fresh stop the same tick.

### Failure mode B — stop never attached (XLI #99)
`_transition_to_open` is interrupted between the `POSITION_OPEN` status write (line 1281) and the `alpaca_stop_order_id` write (line 1337). The row sat with `status=POSITION_OPEN`, `alpaca_stop_order_id=NULL`.

**Fix:** new recovery branch in `_check_order_statuses` re-attempts the standalone stop attach. Adopts an existing broker-side stop via `_find_existing_stop` if one is live (the submit-response-loss path that `_transition_to_open` already handles inline).

### Failure mode C — overnight_drift 15:45 ET entries (XLK #102, XLF #103)
Same `POSITION_OPEN`-without-stop end state, surfacing on the next-tick fill processing for late-session entries. Same fix as B.

### Operator visibility — `stop_reconciler.py`
New per-tick scan that walks DB-open positions, verifies each `alpaca_stop_order_id` is in an active state at Alpaca, and emits a HIGH-priority notification for any naked position. The in-tick recovery is the healer; the reconciler is the alarm so the operator learns the bug class triggered at all.

### Market-hours gate
The recovery branch is gated on the Alpaca clock (with fixed-time fallback) so DAY stops submitted near close aren't deferred to next session as phantoms — the same protection PR #102 added for `recovery._verify_stop_orders`. 5-minute buffer before close, mirroring `_STOP_VERIFY_CLOSE_BUFFER_SEC`.

## Files changed

- `trading_bot/execution/order_manager.py` — stop-cancellation handler + POSITION_OPEN recovery branch + `_inside_market_hours_for_stop_attach` + `_recover_missing_stop`
- `trading_bot/execution/stop_reconciler.py` — new per-tick naked-position scan
- `trading_bot/main.py` — wires the reconciler into the tick (step 6b)
- `trading_bot/tests/test_standalone_stop_lifecycle_117.py` — 14 regression tests for A/B/C + reconciler + market-hours gate

## Test plan

- [x] 14 new regression tests covering all three failure modes
- [x] `pytest trading_bot/tests/` — 937 passed, 4 skipped (no regressions)
- [x] `pytest -m critical` — 213 passed
- [x] Coverage 73.30% > 71% threshold
- [x] `ruff check` — clean
- [x] `mypy --ignore-missing-imports trading_bot/main.py trading_bot/execution/ trading_bot/gateway/` — clean
- [x] `bandit -lll` — clean (HIGH severity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)