### PR TITLE
fix(notifier): offload blocking requests.post to to_thread (H-1)

### DIFF
--- a/trading_bot/notifications/notifier.py
+++ b/trading_bot/notifications/notifier.py
@@ -8,6 +8,7 @@ HTTP POST via ``requests`` and return immediately.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import subprocess
@@ -121,7 +122,11 @@ class Notifier:
             )
             return
 
-        self._do_send(title, message, priority, resolved_tags)
+        # Offload the blocking ``requests.post`` to a worker thread so the
+        # event loop keeps making progress when ntfy.sh is slow or rate-limited.
+        await asyncio.to_thread(
+            self._do_send, title, message, priority, resolved_tags
+        )
 
     def send_sync(
         self,


### PR DESCRIPTION
## Summary

- `Notifier.send` is `async` but used to invoke the blocking `requests.post` to ntfy.sh inline, blocking the event loop whenever ntfy is slow or rate-limited.
- Wrap the `_do_send` call inside `Notifier.send` in `asyncio.to_thread` so the loop keeps making progress.
- `_do_send` internals untouched. No new dependency (no httpx). Dedupe layer untouched.

`Notifier.send_sync` (line 149) is **deliberately** the synchronous entry point for callers running outside an event loop (e.g. `RiskManager.can_trade()`); wrapping it in `asyncio.to_thread` would change its return type to a coroutine and break those call sites. Left as-is.

Refs ai-broker#58 (**H-1**).

## Test plan

- [x] `pytest trading_bot/tests/test_data_layer.py trading_bot/tests/test_data_staleness.py trading_bot/tests/test_main_tick.py trading_bot/tests/test_order_manager_lifecycle.py` — 147 passed
- [x] Full suite: `pytest trading_bot/tests/` — 923 passed, 4 skipped
- [x] `ruff check trading_bot/notifications/notifier.py` — clean
- [x] `mypy trading_bot/notifications/notifier.py` — clean