### PR TITLE
refactor: rename PositionStatus.STOP_AND_TARGET_ACTIVE → STOP_ACTIVE (#54)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -373,7 +373,7 @@ The defer state is persisted in `tick_state` so a deferred exit picks up on the 
 Each position transitions through:
 
 ```
-SIGNAL_DETECTED → ENTRY_PENDING → POSITION_OPEN → STOP_AND_TARGET_ACTIVE
+SIGNAL_DETECTED → ENTRY_PENDING → POSITION_OPEN → STOP_ACTIVE
                                                       ↓
                                                 TRAILING_ACTIVE
                                                       ↓

--- a/trading_bot/constants.py
+++ b/trading_bot/constants.py
@@ -62,7 +62,7 @@ class PositionStatus(str, Enum):
     """
     ENTRY_PENDING = "ENTRY_PENDING"
     POSITION_OPEN = "POSITION_OPEN"
-    STOP_AND_TARGET_ACTIVE = "STOP_AND_TARGET_ACTIVE"
+    STOP_ACTIVE = "STOP_ACTIVE"
     TRAILING_ACTIVE = "TRAILING_ACTIVE"
     CLOSING = "CLOSING"
     CLOSED = "CLOSED"
@@ -196,4 +196,4 @@ def ticker_market(ticker: str) -> Market:
 # Schema version — must match the DB migration target
 # ---------------------------------------------------------------------------
 
-SCHEMA_VERSION: int = 11
+SCHEMA_VERSION: int = 12

--- a/trading_bot/db/migrations.py
+++ b/trading_bot/db/migrations.py
@@ -401,6 +401,30 @@ def _migration_v11(conn: sqlite3.Connection) -> None:
     logger.info("Applied migration V11: positions.alpaca_exit_order_id")
 
 
+def _migration_v12(conn: sqlite3.Connection) -> None:
+    """V12: rename ``positions.status`` value ``STOP_AND_TARGET_ACTIVE`` → ``STOP_ACTIVE``.
+
+    Under the new entry path (plain-limit + standalone-stop, PR #53 /
+    ai-broker#39) only the stop is broker-side; take-profit is polled
+    in ``main.check_exits`` against ``target_price``. The legacy enum
+    name suggested both legs were live at the broker, which is no
+    longer true.
+
+    Data-only migration. Idempotent: the UPDATE is a no-op if no rows
+    still carry the legacy value.
+    """
+    conn.execute(
+        "UPDATE positions SET status='STOP_ACTIVE' "
+        "WHERE status='STOP_AND_TARGET_ACTIVE'"
+    )
+    conn.execute(
+        "INSERT OR REPLACE INTO schema_version (version, description) "
+        "VALUES (12, "
+        "'V12 schema - rename STOP_AND_TARGET_ACTIVE → STOP_ACTIVE')"
+    )
+    logger.info("Applied migration V12: status rename")
+
+
 _MIGRATIONS: list[tuple[int, str, MigrationFn]] = [
     (4, "V4 schema - multi-market adaptive trading bot", _migration_v4),
     (5, "V5 schema - multi-strategy Alpaca trading bot", _migration_v5),
@@ -411,6 +435,8 @@ _MIGRATIONS: list[tuple[int, str, MigrationFn]] = [
     (10, "V10 schema - USD-only column rename", _migration_v10),
     (11, "V11 schema - positions.alpaca_exit_order_id for cross-tick exit tracking",
      _migration_v11),
+    (12, "V12 schema - rename STOP_AND_TARGET_ACTIVE → STOP_ACTIVE",
+     _migration_v12),
 ]
 
 

--- a/trading_bot/docs/self_improve_followups.md
+++ b/trading_bot/docs/self_improve_followups.md
@@ -37,15 +37,18 @@ says "exercise extreme care with all order logic."
 - **#41 — Verify PR #20 drain logic.** The verify-before-SELL guard merged after
   the churn it was meant to prevent; needs unit + integration coverage before
   the next sleeve-disable event proves it the hard way.
-- **Rename `STOP_AND_TARGET_ACTIVE` → `STOP_ACTIVE`.** Under the
-  ai-broker#39 entry path only the stop is broker-side (take-profit is
-  polled in `main.check_exits` against `target_price`), so the status
-  name is semantically inaccurate. Deferred from #39 because the rename
-  touches 45 references across 10 files plus a DB migration on the
-  GHA-cached SQLite — too much churn pre-launch for a naming fix.
-  Action: add `PositionStatus.STOP_ACTIVE`, migration v11 (`UPDATE
-  positions SET status='STOP_ACTIVE' WHERE status='STOP_AND_TARGET_ACTIVE'`),
-  bump SCHEMA_VERSION, sweep tests + scripts. No behavior change.
+- **~~Rename `STOP_AND_TARGET_ACTIVE` → `STOP_ACTIVE`.~~** **Resolved by
+  ai-broker#54.** Under the ai-broker#39 entry path only the stop is
+  broker-side (take-profit is polled in `main.check_exits` against
+  `target_price`), so the status name was semantically inaccurate.
+  Deferred from #39 because the rename touched 45+ references across
+  10+ files plus a DB migration on the GHA-cached SQLite — too much
+  churn pre-launch for a naming fix. Landed in ai-broker#54: added
+  `PositionStatus.STOP_ACTIVE`, migration V12 (`UPDATE positions SET
+  status='STOP_ACTIVE' WHERE status='STOP_AND_TARGET_ACTIVE'`), bumped
+  `SCHEMA_VERSION` to 12, swept call-sites and tests. No behavior
+  change. Historical SQL snapshots below still quote the legacy value
+  verbatim — that's the audit trail of what was in the DB at the time.
 
 The legacy "Task #2 / #3 / Bug B6" sections below are kept for the audit trail
 but their resolved status is summarized at the top of each.

--- a/trading_bot/docs/self_improve_reports/reconcile_2026-04-29.md
+++ b/trading_bot/docs/self_improve_reports/reconcile_2026-04-29.md
@@ -389,3 +389,8 @@ Counts above map directly to the data-layer bugs in [docs/self_improve_followups
 ---
 
 _This report is read-only. No DB rows were modified and no orders were submitted. Use it to plan Phase 2 (DB migration) and Phase 3 (live order logic fixes)._
+
+> **Note (post-hoc):** The status value `STOP_AND_TARGET_ACTIVE` quoted
+> throughout this report was renamed to `STOP_ACTIVE` in ai-broker#54
+> (V12 migration). The historical text is left intact as the audit
+> trail of what was actually in the DB at the time of the snapshot.

--- a/trading_bot/execution/order_manager.py
+++ b/trading_bot/execution/order_manager.py
@@ -468,7 +468,7 @@ class OrderManager:
 
             # Check exit orders (stop/target/trail)
             if active.status in (
-                PositionStatus.STOP_AND_TARGET_ACTIVE,
+                PositionStatus.STOP_ACTIVE,
                 PositionStatus.TRAILING_ACTIVE,
             ):
                 for order_id_attr, exit_reason in [
@@ -505,7 +505,7 @@ class OrderManager:
                             # Issue #117 failure mode A: a stop/target/trail
                             # cancelled at the broker (DAY expiry, external
                             # cancel, EOD wind-down) leaves the row pinned to
-                            # STOP_AND_TARGET_ACTIVE with a dead order_id —
+                            # STOP_ACTIVE with a dead order_id —
                             # subsequent ticks never re-attach because no
                             # branch handles that state. Clear the dead id
                             # and, for the protective stop specifically,
@@ -537,7 +537,7 @@ class OrderManager:
                                 # (alpaca_stop_order_id) is independent —
                                 # not nulled when activate_trailing_stop
                                 # ran, so the position is still protected.
-                                # Demote to STOP_AND_TARGET_ACTIVE so the
+                                # Demote to STOP_ACTIVE so the
                                 # trail re-activation logic in
                                 # check_trail_activations can re-fire
                                 # next time price crosses the threshold;
@@ -546,11 +546,11 @@ class OrderManager:
                                 # forever.
                                 active.trail_activated = False
                                 active.status = (
-                                    PositionStatus.STOP_AND_TARGET_ACTIVE
+                                    PositionStatus.STOP_ACTIVE
                                 )
                                 self._update_position_status(
                                     trade_id,
-                                    PositionStatus.STOP_AND_TARGET_ACTIVE,
+                                    PositionStatus.STOP_ACTIVE,
                                 )
                             # Don't continue checking remaining legs on
                             # this iteration — the row's status has
@@ -664,17 +664,17 @@ class OrderManager:
                                 )
                     elif exit_order.status.value in ("canceled", "expired", "rejected"):  # type: ignore[union-attr]
                         # Limit exit didn't fill (e.g. price gapped through
-                        # the limit). Roll back to STOP_AND_TARGET_ACTIVE so
+                        # the limit). Roll back to STOP_ACTIVE so
                         # the next tick re-evaluates the exit condition; the
                         # protective stop is re-attached by recovery if it
                         # was cancelled.
                         logger.warning(
-                            "Strategy exit %s for %s — rolling back to STOP_AND_TARGET_ACTIVE",
+                            "Strategy exit %s for %s — rolling back to STOP_ACTIVE",
                             exit_order.status.value, active.ticker,  # type: ignore[union-attr]
                         )
                         active.alpaca_exit_order_id = None
                         active.exit_reason = None
-                        active.status = PositionStatus.STOP_AND_TARGET_ACTIVE
+                        active.status = PositionStatus.STOP_ACTIVE
                         # V11+: clear the persisted exit order_id too,
                         # so the next tick re-evaluates the exit
                         # condition cleanly instead of seeing a stale
@@ -683,7 +683,7 @@ class OrderManager:
                             trade_id, "alpaca_exit_order_id", None,
                         )
                         self._update_position_status(
-                            trade_id, PositionStatus.STOP_AND_TARGET_ACTIVE,
+                            trade_id, PositionStatus.STOP_ACTIVE,
                         )
                 except Exception:
                     logger.warning(
@@ -1172,7 +1172,7 @@ class OrderManager:
                     matching_active.exit_reason = reason
                 # Persist the exit order_id BEFORE flipping status to
                 # CLOSING — a crash between the two writes leaves the
-                # row still STOP_AND_TARGET_ACTIVE with the order id
+                # row still STOP_ACTIVE with the order id
                 # set, which the next tick's rehydration handles
                 # gracefully. V11+: column lives on positions table.
                 self._update_position_field(
@@ -1427,8 +1427,8 @@ class OrderManager:
         # tree). Under this entry path only the stop is broker-side; take-
         # profit is polled in main.check_exits via target_price. Renaming is
         # tracked as a post-launch follow-up.
-        active.status = PositionStatus.STOP_AND_TARGET_ACTIVE
-        self._update_position_status(trade_id, PositionStatus.STOP_AND_TARGET_ACTIVE)
+        active.status = PositionStatus.STOP_ACTIVE
+        self._update_position_status(trade_id, PositionStatus.STOP_ACTIVE)
         logger.info(
             "Protective stop active for %s (trade_id=%d): stop_id=%s @ %.4f",
             active.ticker, trade_id, stop_id, active.stop_price,
@@ -1634,9 +1634,9 @@ class OrderManager:
             self._update_position_field(
                 trade_id, "alpaca_stop_order_id", recovered,
             )
-            active.status = PositionStatus.STOP_AND_TARGET_ACTIVE
+            active.status = PositionStatus.STOP_ACTIVE
             self._update_position_status(
-                trade_id, PositionStatus.STOP_AND_TARGET_ACTIVE,
+                trade_id, PositionStatus.STOP_ACTIVE,
             )
             await self._notifier.send(
                 "Stop Recovery: Adopted Existing Broker Stop",
@@ -1671,9 +1671,9 @@ class OrderManager:
         active.alpaca_stop_order_id = stop_id
         self._alpaca_to_trade[stop_id] = trade_id
         self._update_position_field(trade_id, "alpaca_stop_order_id", stop_id)
-        active.status = PositionStatus.STOP_AND_TARGET_ACTIVE
+        active.status = PositionStatus.STOP_ACTIVE
         self._update_position_status(
-            trade_id, PositionStatus.STOP_AND_TARGET_ACTIVE,
+            trade_id, PositionStatus.STOP_ACTIVE,
         )
         logger.warning(
             "Stop recovery: attached fresh stop %s for %s (trade_id=%d, "
@@ -1733,7 +1733,7 @@ class OrderManager:
         for trade_id, active in list(self._active_orders.items()):
             if active.trail_activated:
                 continue
-            if active.status != PositionStatus.STOP_AND_TARGET_ACTIVE:
+            if active.status != PositionStatus.STOP_ACTIVE:
                 continue
             if active.trail_pct is None or active.trail_activation_price is None:
                 continue

--- a/trading_bot/execution/stop_reconciler.py
+++ b/trading_bot/execution/stop_reconciler.py
@@ -90,7 +90,7 @@ class ReconciliationResult:
 # the market-hours gate.
 _STATUSES_NEEDING_STOP: tuple[str, ...] = (
     PositionStatus.POSITION_OPEN.value,
-    PositionStatus.STOP_AND_TARGET_ACTIVE.value,
+    PositionStatus.STOP_ACTIVE.value,
     PositionStatus.TRAILING_ACTIVE.value,
 )
 

--- a/trading_bot/self_improve/repair_orphans.py
+++ b/trading_bot/self_improve/repair_orphans.py
@@ -193,7 +193,7 @@ async def _repair_entry_failed(
     Three outcomes per row:
 
     - Order **filled and ticker is still held** → flip to
-      ``STOP_AND_TARGET_ACTIVE`` (adopt matching broker stop) or
+      ``STOP_ACTIVE`` (adopt matching broker stop) or
       ``POSITION_OPEN`` (no live stop yet — next reconciler tick
       attaches one).
     - Order **filled but ticker is NOT held at Alpaca** → mark
@@ -269,7 +269,7 @@ async def _repair_entry_failed(
         )
 
         new_status: str = (
-            PositionStatus.STOP_AND_TARGET_ACTIVE.value
+            PositionStatus.STOP_ACTIVE.value
             if stop_id is not None
             else PositionStatus.POSITION_OPEN.value
         )

--- a/trading_bot/tests/test_config_disabled_strategy_guard.py
+++ b/trading_bot/tests/test_config_disabled_strategy_guard.py
@@ -70,7 +70,7 @@ def test_warns_for_open_position_on_disabled_strategy(tmp_db_path):
     })
     conn = sqlite3.connect(tmp_db_path)
     _insert_position(conn, ticker="SPY", strategy_id="breakout",
-                     status="STOP_AND_TARGET_ACTIVE", quantity=1.0)
+                     status="STOP_ACTIVE", quantity=1.0)
     conn.commit()
     conn.close()
 
@@ -178,12 +178,12 @@ def test_warning_message_includes_status_and_qty(tmp_db_path):
     cfg = _build_config({"breakout": {"enabled": False}})
     conn = sqlite3.connect(tmp_db_path)
     _insert_position(conn, ticker="SPY", strategy_id="breakout",
-                     status="STOP_AND_TARGET_ACTIVE", quantity=1.0)
+                     status="STOP_ACTIVE", quantity=1.0)
     conn.commit()
     conn.close()
 
     out = cfg.detect_disabled_strategy_orphans(tmp_db_path)
     assert len(out) == 1
     msg = out[0]
-    assert "STOP_AND_TARGET_ACTIVE" in msg
+    assert "STOP_ACTIVE" in msg
     assert "1" in msg  # qty

--- a/trading_bot/tests/test_exit_persistence_v11.py
+++ b/trading_bot/tests/test_exit_persistence_v11.py
@@ -69,7 +69,7 @@ def _entry(ticker: str = "SPY") -> EntryDecision:
 def _seed_open_position(
     om: OrderManager, ticker: str = "SPY"
 ) -> int:
-    """Helper: seed a STOP_AND_TARGET_ACTIVE position (entry already
+    """Helper: seed a STOP_ACTIVE position (entry already
     filled) ready for place_exit to act on."""
     trade_id = om._create_position_record(_entry(ticker))
     # Wire the in-memory _ActiveOrder so place_exit can find it.
@@ -80,7 +80,7 @@ def _seed_open_position(
         alpaca_entry_order_id="entry-1",
         alpaca_stop_order_id="stop-1",
         alpaca_target_order_id="target-1",
-        status=PositionStatus.STOP_AND_TARGET_ACTIVE,
+        status=PositionStatus.STOP_ACTIVE,
         entry_shares=10.0,
         filled_shares=10.0,
         entry_price=100.0,
@@ -90,7 +90,7 @@ def _seed_open_position(
         strategy_id="overnight_drift",
     )
     om._update_position_status(
-        trade_id, PositionStatus.STOP_AND_TARGET_ACTIVE,
+        trade_id, PositionStatus.STOP_ACTIVE,
     )
     return trade_id
 
@@ -168,7 +168,7 @@ async def test_cancel_rollback_clears_persisted_exit_order_id(
     config, tmp_db_path: str, mock_notifier,
 ):
     """If a limit exit is canceled/expired/rejected, the OM rolls back
-    the position to STOP_AND_TARGET_ACTIVE. The persisted exit_order_id
+    the position to STOP_ACTIVE. The persisted exit_order_id
     must also be cleared in the DB so the next tick re-evaluates the
     exit fresh and doesn't see a stale order id pointing at a dead
     Alpaca order."""
@@ -204,7 +204,7 @@ async def test_cancel_rollback_clears_persisted_exit_order_id(
     assert om._active_orders[trade_id].alpaca_exit_order_id is None
     assert (
         om._active_orders[trade_id].status
-        == PositionStatus.STOP_AND_TARGET_ACTIVE
+        == PositionStatus.STOP_ACTIVE
     )
     conn = sqlite3.connect(tmp_db_path)
     try:
@@ -215,7 +215,7 @@ async def test_cancel_rollback_clears_persisted_exit_order_id(
     finally:
         conn.close()
     assert row[0] is None, "DB column must be cleared on rollback"
-    assert row[1] == "STOP_AND_TARGET_ACTIVE"
+    assert row[1] == "STOP_ACTIVE"
 
 
 @pytest.mark.asyncio

--- a/trading_bot/tests/test_flatten_orphans.py
+++ b/trading_bot/tests/test_flatten_orphans.py
@@ -101,7 +101,7 @@ def test_find_db_position_returns_open_row_with_child_orders(tmp_db):
            status, hold_type, phase, strategy_id,
            alpaca_stop_order_id, alpaca_target_order_id, alpaca_trail_order_id)
         VALUES ('SPY', 'NYSE', 'USD', 1, 700.0, '2026-04-27T15:40:00-04:00',
-                'STOP_AND_TARGET_ACTIVE', 'swing', 1, 'breakout',
+                'STOP_ACTIVE', 'swing', 1, 'breakout',
                 'stop-abc', 'target-def', NULL)
         """
     )

--- a/trading_bot/tests/test_migration_v8_entry_failed.py
+++ b/trading_bot/tests/test_migration_v8_entry_failed.py
@@ -283,7 +283,7 @@ def test_terminal_status_set_includes_both_terminal_states() -> None:
     for s in (
         PositionStatus.ENTRY_PENDING,
         PositionStatus.POSITION_OPEN,
-        PositionStatus.STOP_AND_TARGET_ACTIVE,
+        PositionStatus.STOP_ACTIVE,
         PositionStatus.TRAILING_ACTIVE,
         PositionStatus.CLOSING,
     ):

--- a/trading_bot/tests/test_order_manager_lifecycle.py
+++ b/trading_bot/tests/test_order_manager_lifecycle.py
@@ -135,7 +135,7 @@ class TestEntryFill:
         await om._check_order_statuses()
 
         active = om._active_orders[trade_id]
-        assert active.status == PositionStatus.STOP_AND_TARGET_ACTIVE
+        assert active.status == PositionStatus.STOP_ACTIVE
         # Second submit_order call was the standalone stop
         assert len(captured) == 2
         stop_req = captured[1]
@@ -198,7 +198,7 @@ class TestEntryFill:
             "fractional with error 42210000)"
         )
         active = om._active_orders[trade_id]
-        assert active.status == PositionStatus.STOP_AND_TARGET_ACTIVE
+        assert active.status == PositionStatus.STOP_ACTIVE
 
     @pytest.mark.asyncio
     async def test_stop_attach_failure_triggers_emergency_flatten(
@@ -285,9 +285,9 @@ class TestEntryTimeout:
 
         # Cancelled the timed-out entry
         om._gw.client.cancel_order_by_id.assert_called()
-        # Position transitioned to STOP_AND_TARGET_ACTIVE with standalone stop
+        # Position transitioned to STOP_ACTIVE with standalone stop
         active = om._active_orders[trade_id]
-        assert active.status == PositionStatus.STOP_AND_TARGET_ACTIVE
+        assert active.status == PositionStatus.STOP_ACTIVE
         assert active.alpaca_stop_order_id == "stop-1"
         assert active.alpaca_target_order_id is None
 
@@ -568,12 +568,12 @@ class TestExitFill:
             alpaca_entry_order_id="entry-1",
             alpaca_stop_order_id="stop-1",
             alpaca_target_order_id="target-1",
-            status=PositionStatus.STOP_AND_TARGET_ACTIVE,
+            status=PositionStatus.STOP_ACTIVE,
             entry_shares=100, filled_shares=100,
             entry_price=10.0, stop_price=9.8, target_price=10.4,
         )
         om._active_orders[trade_id] = active
-        om._update_position_status(trade_id, PositionStatus.STOP_AND_TARGET_ACTIVE)
+        om._update_position_status(trade_id, PositionStatus.STOP_ACTIVE)
 
         # Stop fills @ 9.80, target still open (gets cancelled)
         def get_order_by_id(oid: str):
@@ -604,12 +604,12 @@ class TestExitFill:
             alpaca_entry_order_id="entry-1",
             alpaca_stop_order_id="stop-1",
             alpaca_target_order_id="target-1",
-            status=PositionStatus.STOP_AND_TARGET_ACTIVE,
+            status=PositionStatus.STOP_ACTIVE,
             entry_shares=100, filled_shares=100,
             entry_price=10.0, stop_price=9.8, target_price=10.4,
         )
         om._active_orders[trade_id] = active
-        om._update_position_status(trade_id, PositionStatus.STOP_AND_TARGET_ACTIVE)
+        om._update_position_status(trade_id, PositionStatus.STOP_ACTIVE)
 
         def get_order_by_id(oid: str):
             if oid == "target-1":
@@ -640,13 +640,13 @@ class TestTrailActivation:
             alpaca_entry_order_id="entry-1",
             alpaca_stop_order_id="stop-1",
             alpaca_target_order_id="target-1",
-            status=PositionStatus.STOP_AND_TARGET_ACTIVE,
+            status=PositionStatus.STOP_ACTIVE,
             entry_shares=100, filled_shares=100,
             entry_price=10.0, stop_price=9.8, target_price=10.4,
             trail_pct=0.02, trail_activation_price=10.20,
         )
         om._active_orders[trade_id] = active
-        om._update_position_status(trade_id, PositionStatus.STOP_AND_TARGET_ACTIVE)
+        om._update_position_status(trade_id, PositionStatus.STOP_ACTIVE)
 
         # Trailing-stop placement returns an order id
         om._gw.client.submit_order = MagicMock(return_value=_alpaca_order("trail-1", "new"))
@@ -665,7 +665,7 @@ class TestTrailActivation:
         trade_id = om._create_position_record(_entry("SPY"))
         active = _ActiveOrder(
             trade_id=trade_id, ticker="SPY", exchange="US",
-            status=PositionStatus.STOP_AND_TARGET_ACTIVE,
+            status=PositionStatus.STOP_ACTIVE,
             entry_shares=100, filled_shares=100,
             entry_price=10.0,
             trail_pct=0.02, trail_activation_price=10.20,
@@ -681,7 +681,7 @@ class TestTrailActivation:
         trade_id = om._create_position_record(_entry("SPY"))
         active = _ActiveOrder(
             trade_id=trade_id, ticker="SPY", exchange="US",
-            status=PositionStatus.STOP_AND_TARGET_ACTIVE,
+            status=PositionStatus.STOP_ACTIVE,
             entry_shares=100, filled_shares=100,
             trail_pct=0.02, trail_activation_price=10.20,
         )
@@ -765,7 +765,7 @@ class TestPlaceExit:
             alpaca_entry_order_id="entry-1",
             alpaca_stop_order_id="stop-1",  # locally tracked
             alpaca_target_order_id="target-1",  # locally tracked
-            status=PositionStatus.STOP_AND_TARGET_ACTIVE,
+            status=PositionStatus.STOP_ACTIVE,
             entry_shares=10.0,
             filled_shares=10.0,
             entry_price=100.0,
@@ -843,7 +843,7 @@ class TestPlaceExit:
             exchange="US",
             alpaca_entry_order_id="entry-1",
             alpaca_stop_order_id="stop-1",
-            status=PositionStatus.STOP_AND_TARGET_ACTIVE,
+            status=PositionStatus.STOP_ACTIVE,
             entry_shares=10.0,
             filled_shares=10.0,
             entry_price=50.0,
@@ -902,7 +902,7 @@ class TestPlaceExit:
             exchange="US",
             alpaca_entry_order_id="entry-1",
             alpaca_stop_order_id="stop-1",
-            status=PositionStatus.STOP_AND_TARGET_ACTIVE,
+            status=PositionStatus.STOP_ACTIVE,
             entry_shares=10.0,
             filled_shares=10.0,
             entry_price=50.0,
@@ -959,7 +959,7 @@ class TestPlaceExit:
             exchange="US",
             alpaca_entry_order_id="entry-1",
             alpaca_stop_order_id="stop-known",
-            status=PositionStatus.STOP_AND_TARGET_ACTIVE,
+            status=PositionStatus.STOP_ACTIVE,
             entry_shares=10.0,
             filled_shares=10.0,
             entry_price=50.0,
@@ -1158,7 +1158,7 @@ class TestPlaceExit:
             alpaca_entry_order_id="entry-1",
             alpaca_stop_order_id="stop-1",
             alpaca_target_order_id="target-1",
-            status=PositionStatus.STOP_AND_TARGET_ACTIVE,
+            status=PositionStatus.STOP_ACTIVE,
             entry_shares=10.0,
             filled_shares=10.0,
             entry_price=100.0,
@@ -1573,7 +1573,7 @@ class TestPlaceLimitExit:
             alpaca_entry_order_id="entry-1",
             alpaca_stop_order_id="stop-1",
             alpaca_target_order_id="target-1",
-            status=PositionStatus.STOP_AND_TARGET_ACTIVE,
+            status=PositionStatus.STOP_ACTIVE,
             entry_shares=10.0,
             filled_shares=10.0,
             entry_price=100.0,
@@ -1590,7 +1590,7 @@ class TestPlaceLimitExit:
 
         assert order_id is None
         # Status MUST be back to its prior value, not stuck at CLOSING.
-        assert active.status == PositionStatus.STOP_AND_TARGET_ACTIVE
+        assert active.status == PositionStatus.STOP_ACTIVE
 
     @pytest.mark.asyncio
     async def test_rejects_non_positive_qty(
@@ -1619,7 +1619,7 @@ class TestPlaceLimitExit:
             exchange="US",
             alpaca_entry_order_id="entry-1",
             alpaca_stop_order_id="stop-1",  # locally tracked
-            status=PositionStatus.STOP_AND_TARGET_ACTIVE,
+            status=PositionStatus.STOP_ACTIVE,
             entry_shares=10.0,
             filled_shares=10.0,
             entry_price=100.0,
@@ -1740,7 +1740,7 @@ class TestStrategyExitFillCallback:
         self, config, tmp_db_path: str, mock_notifier,
     ):
         """A limit exit that gets cancelled rolls back to
-        STOP_AND_TARGET_ACTIVE — the position remains open, so no
+        STOP_ACTIVE — the position remains open, so no
         outcome is recorded.
         """
         om = _make_om(config, tmp_db_path, mock_notifier)
@@ -1755,7 +1755,7 @@ class TestStrategyExitFillCallback:
 
         await om._check_order_statuses()
 
-        assert active.status == PositionStatus.STOP_AND_TARGET_ACTIVE
+        assert active.status == PositionStatus.STOP_ACTIVE
         assert captured == []
 
     @pytest.mark.asyncio
@@ -1878,7 +1878,7 @@ class TestStrategyExitFillCallback:
         active = _ActiveOrder(
             trade_id=1, ticker="SPY", exchange="US",
             alpaca_entry_order_id="entry-1",
-            status=PositionStatus.STOP_AND_TARGET_ACTIVE,
+            status=PositionStatus.STOP_ACTIVE,
             entry_shares=10.0, filled_shares=10.0,
             entry_price=100.0, stop_price=98.0, target_price=104.0,
             hold_type="intraday", strategy_id="mean_reversion",

--- a/trading_bot/tests/test_phase3_regressions.py
+++ b/trading_bot/tests/test_phase3_regressions.py
@@ -470,7 +470,7 @@ class TestB6_TransitionToOpenRecoversFromStopAttachResponseLoss:
 
     The fix queries Alpaca for an open SELL stop matching the ticker and
     qty before assuming submission failed; if found, the order is adopted
-    and the position transitions to STOP_AND_TARGET_ACTIVE normally.
+    and the position transitions to STOP_ACTIVE normally.
     """
 
     @pytest.mark.asyncio
@@ -522,7 +522,7 @@ class TestB6_TransitionToOpenRecoversFromStopAttachResponseLoss:
         finally:
             conn.close()
         assert row is not None
-        assert row[0] == PositionStatus.STOP_AND_TARGET_ACTIVE.value, (
+        assert row[0] == PositionStatus.STOP_ACTIVE.value, (
             "Recovery must adopt the live broker stop and proceed to the "
             "normal active-stop status — not stamp ENTRY_FAILED."
         )

--- a/trading_bot/tests/test_repair_orphans.py
+++ b/trading_bot/tests/test_repair_orphans.py
@@ -139,7 +139,7 @@ async def test_flips_to_active_when_filled_and_held_with_stop(tmp_db_path: str):
         "FROM positions WHERE id = ?", (pos_id,),
     ).fetchone()
     conn.close()
-    assert row[0] == PositionStatus.STOP_AND_TARGET_ACTIVE.value
+    assert row[0] == PositionStatus.STOP_ACTIVE.value
     assert abs(row[1] - 724.72) < 1e-6
     assert row[2] == "stop-recovered"
 
@@ -260,7 +260,7 @@ async def test_closes_unknown_duplicate_when_real_sibling_exists(
 ):
     real_id = _seed_position(
         tmp_db_path, ticker="SPY",
-        status=PositionStatus.STOP_AND_TARGET_ACTIVE.value,
+        status=PositionStatus.STOP_ACTIVE.value,
         strategy_id="overnight_drift",
         alpaca_order_id="entry-real",
     )
@@ -285,7 +285,7 @@ async def test_closes_unknown_duplicate_when_real_sibling_exists(
 
     assert report.unknown_duplicates_closed == 1
     rows_by_id = {r[0]: r for r in rows}
-    assert rows_by_id[real_id][1] == PositionStatus.STOP_AND_TARGET_ACTIVE.value
+    assert rows_by_id[real_id][1] == PositionStatus.STOP_ACTIVE.value
     assert rows_by_id[unk_id][1] == "CLOSED"
 
 
@@ -355,7 +355,7 @@ async def test_phantom_step_closes_older_duplicate_keeps_latest(
     tmp_db_path: str,
 ):
     """Live bug: positions 74 (SPY 5/4) and 80 (SPY 5/5) both
-    POSITION_OPEN/STOP_AND_TARGET_ACTIVE for the same held ticker.
+    POSITION_OPEN/STOP_ACTIVE for the same held ticker.
     The reconciler's db_by_ticker dict overwrites duplicates and
     silently drops one — so the older row never gets closed.
 
@@ -370,7 +370,7 @@ async def test_phantom_step_closes_older_duplicate_keeps_latest(
     )
     newer_id = _seed_position(
         tmp_db_path, ticker="SPY",
-        status=PositionStatus.STOP_AND_TARGET_ACTIVE.value,
+        status=PositionStatus.STOP_ACTIVE.value,
         strategy_id="overnight_drift",
         entry_time="2026-05-05T15:45:00",  # newer
     )
@@ -390,7 +390,7 @@ async def test_phantom_step_closes_older_duplicate_keeps_latest(
         "older duplicate must be closed — it can't all map to the one "
         "broker-side position"
     )
-    assert by_id[newer_id] == PositionStatus.STOP_AND_TARGET_ACTIVE.value, (
+    assert by_id[newer_id] == PositionStatus.STOP_ACTIVE.value, (
         "newer row must be preserved — it matches the broker"
     )
 
@@ -401,7 +401,7 @@ async def test_phantom_step_leaves_single_held_row_alone(tmp_db_path: str):
     must not touch it."""
     pos_id = _seed_position(
         tmp_db_path, ticker="SPY",
-        status=PositionStatus.STOP_AND_TARGET_ACTIVE.value,
+        status=PositionStatus.STOP_ACTIVE.value,
         strategy_id="overnight_drift",
     )
     client = _make_client(held_tickers=["SPY"])
@@ -416,7 +416,7 @@ async def test_phantom_step_leaves_single_held_row_alone(tmp_db_path: str):
         conn.close()
 
     assert report.phantom_live_closed == 0
-    assert row[0] == PositionStatus.STOP_AND_TARGET_ACTIVE.value
+    assert row[0] == PositionStatus.STOP_ACTIVE.value
 
 
 # ---------------------------------------------------------------------------
@@ -518,13 +518,13 @@ async def test_full_scenario_2026_05_06_repair_state(tmp_db_path: str):
     # Real held positions from 5/5.
     spy_real_id = _seed_position(
         tmp_db_path, ticker="SPY",
-        status=PositionStatus.STOP_AND_TARGET_ACTIVE.value,
+        status=PositionStatus.STOP_ACTIVE.value,
         strategy_id="overnight_drift",
         entry_time="2026-05-05T15:45:36",
     )
     qqq_real_id = _seed_position(
         tmp_db_path, ticker="QQQ",
-        status=PositionStatus.STOP_AND_TARGET_ACTIVE.value,
+        status=PositionStatus.STOP_ACTIVE.value,
         strategy_id="overnight_drift",
         entry_time="2026-05-05T15:45:36",
     )
@@ -545,6 +545,6 @@ async def test_full_scenario_2026_05_06_repair_state(tmp_db_path: str):
     assert by_id[xlb_id][1] == PositionStatus.CLOSED.value
     assert by_id[spy_old_id][1] == PositionStatus.CLOSED.value
     assert by_id[qqq_old_id][1] == PositionStatus.CLOSED.value
-    assert by_id[spy_real_id][1] == PositionStatus.STOP_AND_TARGET_ACTIVE.value
-    assert by_id[qqq_real_id][1] == PositionStatus.STOP_AND_TARGET_ACTIVE.value
+    assert by_id[spy_real_id][1] == PositionStatus.STOP_ACTIVE.value
+    assert by_id[qqq_real_id][1] == PositionStatus.STOP_ACTIVE.value
     assert report.phantom_live_closed == 4

--- a/trading_bot/tests/test_self_improve_reconcile.py
+++ b/trading_bot/tests/test_self_improve_reconcile.py
@@ -322,7 +322,7 @@ def _seed_realistic_db(conn: sqlite3.Connection) -> None:
     conn.execute(
         "INSERT INTO positions (ticker, exchange, currency, quantity, "
         "entry_price, entry_time, status, hold_type, phase, strategy_id) "
-        "VALUES ('XLF','ARCA','USD',5,40.0,?,'STOP_AND_TARGET_ACTIVE',"
+        "VALUES ('XLF','ARCA','USD',5,40.0,?,'STOP_ACTIVE',"
         "'intraday',1,'breakout')",
         (ENTRY_TIME.isoformat(),),
     )

--- a/trading_bot/tests/test_standalone_stop_lifecycle_117.py
+++ b/trading_bot/tests/test_standalone_stop_lifecycle_117.py
@@ -4,7 +4,7 @@ Covers three failure modes that left fractional positions naked at Alpaca:
 
 A. Stop cancelled at the broker but DB still references the dead order id —
    pre-#117 the stop-poll loop ignored ``canceled`` / ``expired`` / ``rejected``
-   statuses, so the row sat in ``STOP_AND_TARGET_ACTIVE`` forever.
+   statuses, so the row sat in ``STOP_ACTIVE`` forever.
 B. ``_transition_to_open`` interrupted between the status flip and the
    stop-id write — the row landed in ``POSITION_OPEN`` with
    ``alpaca_stop_order_id=NULL`` and no branch in ``_check_order_statuses``
@@ -160,7 +160,7 @@ class TestFailureModeB_StopNeverAttached:
 
         # Status promoted and order id persisted.
         active = om._active_orders[trade_id]
-        assert active.status == PositionStatus.STOP_AND_TARGET_ACTIVE
+        assert active.status == PositionStatus.STOP_ACTIVE
         assert active.alpaca_stop_order_id == "stop-recovered-1"
 
         conn = sqlite3.connect(tmp_db_path)
@@ -172,7 +172,7 @@ class TestFailureModeB_StopNeverAttached:
             ).fetchone()
         finally:
             conn.close()
-        assert row[0] == PositionStatus.STOP_AND_TARGET_ACTIVE.value
+        assert row[0] == PositionStatus.STOP_ACTIVE.value
         assert row[1] == "stop-recovered-1"
 
     @pytest.mark.asyncio
@@ -210,7 +210,7 @@ class TestFailureModeB_StopNeverAttached:
 
         active = om._active_orders[trade_id]
         assert active.alpaca_stop_order_id == "stop-on-broker"
-        assert active.status == PositionStatus.STOP_AND_TARGET_ACTIVE
+        assert active.status == PositionStatus.STOP_ACTIVE
 
 
 # ---------------------------------------------------------------------------
@@ -254,7 +254,7 @@ class TestFailureModeC_OvernightDriftEntry:
 
         assert len(submits) == 1
         active = om._active_orders[trade_id]
-        assert active.status == PositionStatus.STOP_AND_TARGET_ACTIVE
+        assert active.status == PositionStatus.STOP_ACTIVE
         assert active.alpaca_stop_order_id == "stop-1"
 
     @pytest.mark.asyncio
@@ -297,7 +297,7 @@ class TestFailureModeA_StopCancelledAtBroker:
     """Reproduces SPY #90 / QQQ #91 (2026-05-07): stops were attached
     correctly at entry but cancelled at 16:07 ET. Pre-#117 the stop-poll
     loop only handled ``filled`` status; ``canceled`` was a no-op, so
-    the row sat in ``STOP_AND_TARGET_ACTIVE`` with a dead order id and
+    the row sat in ``STOP_ACTIVE`` with a dead order id and
     no protective stop on the book.
     """
 
@@ -309,7 +309,7 @@ class TestFailureModeA_StopCancelledAtBroker:
         _set_market_open(om)
 
         trade_id = om._create_position_record(_entry("SPY", shares=0.1681, price=732.976))
-        om._update_position_status(trade_id, PositionStatus.STOP_AND_TARGET_ACTIVE)
+        om._update_position_status(trade_id, PositionStatus.STOP_ACTIVE)
         om._update_position_field(trade_id, "quantity", 0.1681)
         om._update_position_field(trade_id, "entry_price", 732.976)
         om._update_position_field(trade_id, "alpaca_stop_order_id", "stop-dead")
@@ -337,7 +337,7 @@ class TestFailureModeA_StopCancelledAtBroker:
         # Fresh stop attached on the same tick.
         assert len(submits) == 1
         active = om._active_orders[trade_id]
-        assert active.status == PositionStatus.STOP_AND_TARGET_ACTIVE
+        assert active.status == PositionStatus.STOP_ACTIVE
         assert active.alpaca_stop_order_id == "stop-fresh-1"
 
         conn = sqlite3.connect(tmp_db_path)
@@ -349,7 +349,7 @@ class TestFailureModeA_StopCancelledAtBroker:
             ).fetchone()
         finally:
             conn.close()
-        assert row[0] == PositionStatus.STOP_AND_TARGET_ACTIVE.value
+        assert row[0] == PositionStatus.STOP_ACTIVE.value
         assert row[1] == "stop-fresh-1"
 
     @pytest.mark.asyncio
@@ -364,7 +364,7 @@ class TestFailureModeA_StopCancelledAtBroker:
         _set_market_open(om)
 
         trade_id = om._create_position_record(_entry("SPY"))
-        om._update_position_status(trade_id, PositionStatus.STOP_AND_TARGET_ACTIVE)
+        om._update_position_status(trade_id, PositionStatus.STOP_ACTIVE)
         om._update_position_field(trade_id, "quantity", 100)
         om._update_position_field(trade_id, "alpaca_stop_order_id", "stop-live")
         om._update_position_field(trade_id, "alpaca_target_order_id", "target-dead")
@@ -383,7 +383,7 @@ class TestFailureModeA_StopCancelledAtBroker:
 
         active = om._active_orders[trade_id]
         # Status preserved — stop is still active.
-        assert active.status == PositionStatus.STOP_AND_TARGET_ACTIVE
+        assert active.status == PositionStatus.STOP_ACTIVE
         # Dead target id cleared.
         assert active.alpaca_target_order_id is None
         assert active.alpaca_stop_order_id == "stop-live"
@@ -400,7 +400,7 @@ class TestFailureModeA_StopCancelledAtBroker:
         _set_market_open(om)
 
         trade_id = om._create_position_record(_entry("SPY"))
-        om._update_position_status(trade_id, PositionStatus.STOP_AND_TARGET_ACTIVE)
+        om._update_position_status(trade_id, PositionStatus.STOP_ACTIVE)
         om._update_position_field(trade_id, "quantity", 100)
         om._update_position_field(trade_id, "alpaca_stop_order_id", "stop-dead")
         om._update_position_field(trade_id, "alpaca_target_order_id", "target-live")
@@ -438,7 +438,7 @@ class TestFailureModeA_StopCancelledAtBroker:
         the protective stop). A cancelled trail order therefore is NOT
         a naked-position event — but the row mustn't get stuck in
         TRAILING_ACTIVE with a NULL trail id, or check_trail_activations
-        will never re-fire. Demoting to STOP_AND_TARGET_ACTIVE clears
+        will never re-fire. Demoting to STOP_ACTIVE clears
         the trail-activated flag so re-activation can run on the next
         price cross."""
         om = _make_om(config, tmp_db_path, mock_notifier)
@@ -471,7 +471,7 @@ class TestFailureModeA_StopCancelledAtBroker:
 
         active = om._active_orders[trade_id]
         # Demoted, not stuck in TRAILING_ACTIVE.
-        assert active.status == PositionStatus.STOP_AND_TARGET_ACTIVE
+        assert active.status == PositionStatus.STOP_ACTIVE
         assert active.alpaca_trail_order_id is None
         # Fixed stop still in place — position is not naked.
         assert active.alpaca_stop_order_id == "stop-live"
@@ -585,7 +585,7 @@ class TestStopReconciliation:
         self, tmp_db_path: str, mock_notifier
     ) -> None:
         self._seed_open_position(
-            tmp_db_path, "SPY", PositionStatus.STOP_AND_TARGET_ACTIVE,
+            tmp_db_path, "SPY", PositionStatus.STOP_ACTIVE,
             "stop-cancelled",
         )
 
@@ -608,7 +608,7 @@ class TestStopReconciliation:
         self, tmp_db_path: str, mock_notifier
     ) -> None:
         self._seed_open_position(
-            tmp_db_path, "XLK", PositionStatus.STOP_AND_TARGET_ACTIVE,
+            tmp_db_path, "XLK", PositionStatus.STOP_ACTIVE,
             "stop-healthy",
         )
 
@@ -634,7 +634,7 @@ class TestStopReconciliation:
         the side of surfacing the position (better a false alarm than a
         silent naked position)."""
         self._seed_open_position(
-            tmp_db_path, "XLF", PositionStatus.STOP_AND_TARGET_ACTIVE,
+            tmp_db_path, "XLF", PositionStatus.STOP_ACTIVE,
             "stop-flaky",
         )
 

--- a/trading_bot/tests/test_strategy_manager.py
+++ b/trading_bot/tests/test_strategy_manager.py
@@ -759,7 +759,7 @@ class TestDrainDisabledSleeves:
             INSERT INTO positions (
                 ticker, exchange, currency, quantity, entry_price,
                 entry_time, status, hold_type, phase, strategy_id
-            ) VALUES (?, 'US', 'USD', 5.0, 100.0, ?, 'STOP_AND_TARGET_ACTIVE', 'swing', 1, ?)
+            ) VALUES (?, 'US', 'USD', 5.0, 100.0, ?, 'STOP_ACTIVE', 'swing', 1, ?)
             """,
             ("SPY", "2026-04-27T15:40:00-04:00", "breakout"),
         )
@@ -900,7 +900,7 @@ class TestDrainDisabledSleeves:
                 entry_time, status, hold_type, phase, strategy_id
             ) VALUES (99, 'SPY', 'US', 'USD', 1.0, 100.0,
                       '2026-04-27T15:40:00-04:00',
-                      'STOP_AND_TARGET_ACTIVE', 'swing', 1, 'breakout')
+                      'STOP_ACTIVE', 'swing', 1, 'breakout')
             """
         )
         conn.commit()
@@ -983,7 +983,7 @@ class TestDrainDisabledSleeves:
                 entry_time, status, hold_type, phase, strategy_id
             ) VALUES (77, 'SPY', 'US', 'USD', 1.0, 100.0,
                       '2026-04-27T15:40:00-04:00',
-                      'STOP_AND_TARGET_ACTIVE', 'swing', 1, 'breakout')
+                      'STOP_ACTIVE', 'swing', 1, 'breakout')
             """
         )
         conn.commit()
@@ -1018,7 +1018,7 @@ class TestDrainDisabledSleeves:
             ).fetchone()
         finally:
             conn.close()
-        assert row[0] == "STOP_AND_TARGET_ACTIVE"
+        assert row[0] == "STOP_ACTIVE"
 
     @pytest.mark.asyncio
     async def test_drain_proceeds_when_alpaca_confirms_same_side(
@@ -1045,7 +1045,7 @@ class TestDrainDisabledSleeves:
                 entry_time, status, hold_type, phase, strategy_id
             ) VALUES ('SPY', 'US', 'USD', 5.0, 100.0,
                       '2026-04-27T15:40:00-04:00',
-                      'STOP_AND_TARGET_ACTIVE', 'swing', 1, 'breakout')
+                      'STOP_ACTIVE', 'swing', 1, 'breakout')
             """
         )
         conn.commit()
@@ -1110,7 +1110,7 @@ class TestDrainDisabledSleeves:
                 entry_time, status, hold_type, phase, strategy_id
             ) VALUES ('SPY', 'US', 'USD', 10.0, 100.0,
                       '2026-04-27T15:40:00-04:00',
-                      'STOP_AND_TARGET_ACTIVE', 'swing', 1, 'breakout')
+                      'STOP_ACTIVE', 'swing', 1, 'breakout')
             """
         )
         conn.commit()
@@ -1170,7 +1170,7 @@ class TestDrainDisabledSleeves:
                 entry_time, status, hold_type, phase, strategy_id
             ) VALUES ('SPY', 'US', 'USD', 5.0, 100.0,
                       '2026-04-27T15:40:00-04:00',
-                      'STOP_AND_TARGET_ACTIVE', 'swing', 1, 'breakout')
+                      'STOP_ACTIVE', 'swing', 1, 'breakout')
             """
         )
         conn.commit()
@@ -1234,10 +1234,10 @@ class TestDrainDisabledSleeves:
             ) VALUES
               ('SPY',  'US', 'USD', 5.0, 100.0,
                '2026-04-27T15:40:00-04:00',
-               'STOP_AND_TARGET_ACTIVE', 'swing', 1, 'breakout'),
+               'STOP_ACTIVE', 'swing', 1, 'breakout'),
               ('XLRE', 'US', 'USD', 20.0, 50.0,
                '2026-04-28T09:40:00-04:00',
-               'STOP_AND_TARGET_ACTIVE', 'swing', 1, 'trend_following')
+               'STOP_ACTIVE', 'swing', 1, 'trend_following')
             """
         )
         conn.commit()
@@ -1310,7 +1310,7 @@ class TestDrainDisabledSleeves:
                 entry_time, status, hold_type, phase, strategy_id
             ) VALUES ('SPY', 'US', 'USD', 10.0, 100.0,
                       '2026-04-27T15:40:00-04:00',
-                      'STOP_AND_TARGET_ACTIVE', 'swing', 1, 'breakout')
+                      'STOP_ACTIVE', 'swing', 1, 'breakout')
             """
         )
         conn.commit()
@@ -1365,7 +1365,7 @@ class TestDrainDisabledSleeves:
                 entry_time, status, hold_type, phase, strategy_id
             ) VALUES ('SPY', 'US', 'USD', 10.0, 100.0,
                       '2026-04-27T15:40:00-04:00',
-                      'STOP_AND_TARGET_ACTIVE', 'swing', 1, 'breakout')
+                      'STOP_ACTIVE', 'swing', 1, 'breakout')
             """
         )
         conn.commit()
@@ -1435,7 +1435,7 @@ class TestDrainDisabledSleeves:
                 entry_time, status, hold_type, phase, strategy_id
             ) VALUES (55, 'SPY', 'US', 'USD', 1.0, 100.0,
                       '2026-04-27T15:40:00-04:00',
-                      'STOP_AND_TARGET_ACTIVE', 'swing', 1, 'breakout')
+                      'STOP_ACTIVE', 'swing', 1, 'breakout')
             """
         )
         conn.commit()
@@ -1474,7 +1474,7 @@ class TestDrainDisabledSleeves:
             ).fetchone()
         finally:
             conn.close()
-        assert row[0] == "STOP_AND_TARGET_ACTIVE", (
+        assert row[0] == "STOP_ACTIVE", (
             "transient Alpaca error must NOT mark DB CLOSED — pre-fix "
             "regression"
         )
@@ -1504,7 +1504,7 @@ class TestDrainDisabledSleeves:
                 entry_time, status, hold_type, phase, strategy_id
             ) VALUES (66, 'SPY', 'US', 'USD', 1.0, 100.0,
                       '2026-04-27T15:40:00-04:00',
-                      'STOP_AND_TARGET_ACTIVE', 'swing', 1, 'breakout')
+                      'STOP_ACTIVE', 'swing', 1, 'breakout')
             """
         )
         conn.commit()
@@ -1537,7 +1537,7 @@ class TestDrainDisabledSleeves:
             ).fetchone()
         finally:
             conn.close()
-        assert row[0] == "STOP_AND_TARGET_ACTIVE"
+        assert row[0] == "STOP_ACTIVE"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #54.

## Summary

- Rename `PositionStatus.STOP_AND_TARGET_ACTIVE` → `STOP_ACTIVE` in `trading_bot/constants.py`
- Add **V12** migration (`UPDATE positions SET status='STOP_ACTIVE' WHERE status='STOP_AND_TARGET_ACTIVE'`) — data-only, idempotent
- Bump `SCHEMA_VERSION` 11 → 12 (V11 was consumed by #114 for `positions.alpaca_exit_order_id`)
- Sweep all call-sites and string fixtures in tests (17 files)
- Update `SPEC.md` and the `self_improve_followups.md` scope item
- Leave historical SQL snapshots in `self_improve_reports/reconcile_2026-04-29.md` intact and add a post-hoc footer note pointing at this PR

## Why

Under the post-#53 / ai-broker#39 entry path (plain-limit + standalone-stop) only the stop is broker-side; the take-profit is polled in `main.check_exits` against `target_price`. The legacy name implied both legs were live at the broker, which is no longer the case.

## Behavior change

None. Pure rename.

## Verification

- `pytest trading_bot/tests/` → **932 passed, 4 skipped**.
- Sanity-checked V12 against the GHA-cached DB from the most recent `bot.yml` run (`25830403581`):
  - Pre: `{CLOSED, ENTRY_FAILED, POSITION_OPEN, STOP_AND_TARGET_ACTIVE}`
  - Post: `{CLOSED, ENTRY_FAILED, POSITION_OPEN, STOP_ACTIVE}`
  - `schema_version` now lists `12`.

## Test plan

- [x] `pytest trading_bot/tests/` green locally
- [x] Migration applies cleanly to GHA-cached DB with existing `STOP_AND_TARGET_ACTIVE` rows
- [ ] `static-checks` green in CI
- [ ] `coverage` green in CI