### PR TITLE
refactor(db): contextlib.closing sweep for sqlite3 connections

### DIFF
--- a/trading_bot/execution/order_manager.py
+++ b/trading_bot/execution/order_manager.py
@@ -21,6 +21,7 @@ unrelated code paths still surface.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import sqlite3
 from dataclasses import dataclass
@@ -234,9 +235,8 @@ class OrderManager:
         operate on the same set of positions the prior tick left open.
         """
         try:
-            conn: sqlite3.Connection = sqlite3.connect(self._db_path)
-            conn.row_factory = sqlite3.Row
-            try:
+            with contextlib.closing(sqlite3.connect(self._db_path)) as conn:
+                conn.row_factory = sqlite3.Row
                 rows = conn.execute(
                     "SELECT * FROM positions "
                     "WHERE status NOT IN (?, ?)",
@@ -254,8 +254,6 @@ class OrderManager:
                         "SELECT id, ticker, entry_time FROM trades"
                     ).fetchall()
                 }
-            finally:
-                conn.close()
         except sqlite3.OperationalError:
             logger.warning("positions table not found during hydration")
             return
@@ -334,16 +332,13 @@ class OrderManager:
             seconds=timeout_seconds * 2,
         )
         try:
-            conn: sqlite3.Connection = sqlite3.connect(self._db_path)
-            try:
+            with contextlib.closing(sqlite3.connect(self._db_path)) as conn:
                 conn.row_factory = sqlite3.Row
                 rows = conn.execute(
                     "SELECT id, ticker, entry_time FROM positions "
                     "WHERE status = ? AND alpaca_order_id IS NULL",
                     (PositionStatus.ENTRY_PENDING.value,),
                 ).fetchall()
-            finally:
-                conn.close()
         except sqlite3.OperationalError:
             logger.warning(
                 "uninitiated-entry sweep: positions table unreadable",
@@ -1807,8 +1802,7 @@ class OrderManager:
             )
         else:
             try:
-                conn: sqlite3.Connection = sqlite3.connect(self._db_path)
-                try:
+                with contextlib.closing(sqlite3.connect(self._db_path)) as conn:
                     cur = conn.execute(
                         "UPDATE trades SET exit_time = ?, exit_price = ?, "
                         "exit_reason = ?, gross_pnl = ?, net_pnl = ? "
@@ -1830,8 +1824,6 @@ class OrderManager:
                             "trade_id=%d",
                             db_trade_id, cur.rowcount, active.ticker, trade_id,
                         )
-                finally:
-                    conn.close()
             except Exception:
                 logger.exception(
                     "Failed to update trade record for db_trade_id=%d "
@@ -1858,8 +1850,7 @@ class OrderManager:
     def _create_position_record(self, decision: EntryDecision) -> int | None:
         now_str: str = datetime.now(tz=ET).isoformat()
         try:
-            conn: sqlite3.Connection = sqlite3.connect(self._db_path)
-            try:
+            with contextlib.closing(sqlite3.connect(self._db_path)) as conn:
                 # Both inserts share a single transaction. If the trades
                 # insert fails we ROLLBACK so we never leave a positions
                 # row without its matching trades audit row.
@@ -1934,8 +1925,6 @@ class OrderManager:
                 # carry the trades.id forward.
                 self._pending_db_trade_ids[trade_id] = db_trade_id
                 return trade_id
-            finally:
-                conn.close()
         except Exception:
             logger.exception("Failed to create position record for %s", decision.ticker)
             return None
@@ -1952,8 +1941,7 @@ class OrderManager:
         """
         now_str: str = datetime.now(tz=ET).isoformat()
         try:
-            conn: sqlite3.Connection = sqlite3.connect(self._db_path)
-            try:
+            with contextlib.closing(sqlite3.connect(self._db_path)) as conn:
                 cursor = conn.execute(
                     """
                     UPDATE trades
@@ -1969,8 +1957,6 @@ class OrderManager:
                 )
                 conn.commit()
                 rows_affected: int = cursor.rowcount
-            finally:
-                conn.close()
         except Exception:
             logger.exception(
                 "Failed to mark trade entry_failed for db_trade_id=%d",
@@ -2012,13 +1998,10 @@ class OrderManager:
 
         now_str: str = datetime.now(tz=ET).isoformat()
         try:
-            conn: sqlite3.Connection = sqlite3.connect(self._db_path)
-            try:
+            with contextlib.closing(sqlite3.connect(self._db_path)) as conn:
                 cursor = conn.execute(sql, (value, now_str, trade_id))
                 conn.commit()
                 rows_affected: int = cursor.rowcount
-            finally:
-                conn.close()
         except Exception:
             logger.exception(
                 "Failed to update positions.%s for trade_id=%d",
@@ -2060,8 +2043,7 @@ class OrderManager:
         failures and no forensic trail. This helper closes that gap.
         """
         try:
-            conn: sqlite3.Connection = sqlite3.connect(self._db_path)
-            try:
+            with contextlib.closing(sqlite3.connect(self._db_path)) as conn:
                 repo.save_order_rejection(
                     conn,
                     {
@@ -2075,8 +2057,6 @@ class OrderManager:
                         "resolved": 0,
                     },
                 )
-            finally:
-                conn.close()
         except Exception:
             logger.exception(
                 "Failed to persist rejection for %s (%s)", ticker, reason

--- a/trading_bot/main.py
+++ b/trading_bot/main.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import contextlib
 import json
 import logging
 import logging.handlers
@@ -513,27 +514,21 @@ class TradingBot:
         """Load day-scoped flags for *today*; reset if stored row is stale."""
         today_str: str = today.isoformat()
         try:
-            conn: sqlite3.Connection = sqlite3.connect(self._db_path)
-            try:
+            with contextlib.closing(sqlite3.connect(self._db_path)) as conn:
                 row = repo.load_tick_state(conn, "__day__")
                 if row and row.get("last_bar_ts") == today_str:
                     return dict(row.get("state") or {})
-            finally:
-                conn.close()
         except Exception:
             logger.warning("Failed to load day flags", exc_info=True)
         return {}
 
     def _save_day_flags(self, today: date, flags: dict[str, Any]) -> None:
         try:
-            conn: sqlite3.Connection = sqlite3.connect(self._db_path)
-            try:
+            with contextlib.closing(sqlite3.connect(self._db_path)) as conn:
                 repo.save_tick_state(
                     conn, "__day__", last_bar_ts=today.isoformat(), state=flags
                 )
                 conn.commit()
-            finally:
-                conn.close()
         except Exception:
             logger.warning("Failed to save day flags", exc_info=True)
 
@@ -813,10 +808,9 @@ class TradingBot:
     def _is_on_cooldown(self, ticker: str) -> bool:
         """Return True if ticker is in a post-exit cooldown window."""
         try:
-            conn: sqlite3.Connection = sqlite3.connect(self._db_path)
-            conn.row_factory = sqlite3.Row
-            cooldown_until: datetime | None = repo.get_cooldown(conn, ticker)
-            conn.close()
+            with contextlib.closing(sqlite3.connect(self._db_path)) as conn:
+                conn.row_factory = sqlite3.Row
+                cooldown_until: datetime | None = repo.get_cooldown(conn, ticker)
         except Exception:
             logger.warning("Cooldown lookup failed for %s", ticker, exc_info=True)
             return False
@@ -866,10 +860,9 @@ class TradingBot:
             # Fall through to also check legacy (untagged) positions below
 
         try:
-            conn: sqlite3.Connection = sqlite3.connect(self._db_path)
-            conn.row_factory = sqlite3.Row
-            open_positions: list[dict[str, Any]] = repo.get_open_positions(conn)
-            conn.close()
+            with contextlib.closing(sqlite3.connect(self._db_path)) as conn:
+                conn.row_factory = sqlite3.Row
+                open_positions: list[dict[str, Any]] = repo.get_open_positions(conn)
         except Exception:
             logger.exception("Failed to load open positions for exit check")
             return
@@ -1039,8 +1032,7 @@ class TradingBot:
         key: str = self._spread_defer_key(ticker)
         now_iso: str = now.isoformat()
         try:
-            conn: sqlite3.Connection = sqlite3.connect(self._db_path)
-            try:
+            with contextlib.closing(sqlite3.connect(self._db_path)) as conn:
                 row = repo.load_tick_state(conn, key)
                 if row is None:
                     repo.save_tick_state(conn, key, last_bar_ts=now_iso, state={})
@@ -1057,8 +1049,6 @@ class TradingBot:
                 if first_dt.tzinfo is None:
                     first_dt = first_dt.replace(tzinfo=_EASTERN)
                 return (now - first_dt).total_seconds() >= max_delay_s
-            finally:
-                conn.close()
         except Exception:
             logger.exception("spread-defer bookkeeping failed for %s", ticker)
             return False
@@ -1067,14 +1057,11 @@ class TradingBot:
         """Remove a spread-defer record after a successful exit."""
         key: str = self._spread_defer_key(ticker)
         try:
-            conn: sqlite3.Connection = sqlite3.connect(self._db_path)
-            try:
+            with contextlib.closing(sqlite3.connect(self._db_path)) as conn:
                 conn.execute(
                     "DELETE FROM tick_state WHERE strategy_id = ?", (key,),
                 )
                 conn.commit()
-            finally:
-                conn.close()
         except Exception:
             logger.debug("clear spread-defer failed for %s", ticker, exc_info=True)
 
@@ -1091,10 +1078,9 @@ class TradingBot:
         logger.info("Wind-down started for %s", market.value)
 
         try:
-            conn: sqlite3.Connection = sqlite3.connect(self._db_path)
-            conn.row_factory = sqlite3.Row
-            open_positions: list[dict[str, Any]] = repo.get_open_positions(conn)
-            conn.close()
+            with contextlib.closing(sqlite3.connect(self._db_path)) as conn:
+                conn.row_factory = sqlite3.Row
+                open_positions: list[dict[str, Any]] = repo.get_open_positions(conn)
         except Exception:
             logger.exception("Failed to load positions for wind-down")
             return
@@ -1200,12 +1186,11 @@ class TradingBot:
         raw_cfg: dict[str, Any] = self._config._raw
 
         try:
-            conn: sqlite3.Connection = sqlite3.connect(self._db_path)
-            conn.row_factory = sqlite3.Row
-            summaries: list[dict[str, Any]] = repo.get_recent_daily_summaries(
-                conn, n_days=60
-            )
-            conn.close()
+            with contextlib.closing(sqlite3.connect(self._db_path)) as conn:
+                conn.row_factory = sqlite3.Row
+                summaries: list[dict[str, Any]] = repo.get_recent_daily_summaries(
+                    conn, n_days=60
+                )
         except Exception:
             logger.exception("Failed to load daily summaries for phase check")
             return
@@ -1328,18 +1313,17 @@ class TradingBot:
     def _calc_recent_win_rate(self, lookback_trades: int) -> float:
         """Calculate win rate from the N most recent closed trades."""
         try:
-            conn: sqlite3.Connection = sqlite3.connect(self._db_path)
-            conn.row_factory = sqlite3.Row
-            rows = conn.execute(
-                """
-                SELECT pnl_usd FROM trades
-                WHERE exit_time IS NOT NULL
-                ORDER BY exit_time DESC
-                LIMIT ?
-                """,
-                (lookback_trades,),
-            ).fetchall()
-            conn.close()
+            with contextlib.closing(sqlite3.connect(self._db_path)) as conn:
+                conn.row_factory = sqlite3.Row
+                rows = conn.execute(
+                    """
+                    SELECT pnl_usd FROM trades
+                    WHERE exit_time IS NOT NULL
+                    ORDER BY exit_time DESC
+                    LIMIT ?
+                    """,
+                    (lookback_trades,),
+                ).fetchall()
             if not rows:
                 return 0.0
             wins: int = sum(1 for r in rows if (r["pnl_usd"] or 0) > 0)
@@ -1358,21 +1342,20 @@ class TradingBot:
         """Persist a phase_transitions record."""
         direction: str = "promotion" if to_phase > from_phase else "demotion"
         try:
-            conn: sqlite3.Connection = sqlite3.connect(self._db_path)
-            conn.row_factory = sqlite3.Row
-            repo.save_phase_transition(
-                conn,
-                {
-                    "date": datetime.now(tz=_EASTERN).strftime("%Y-%m-%d"),
-                    "from_phase": from_phase,
-                    "to_phase": to_phase,
-                    "direction": direction,
-                    "account_equity_usd": equity,
-                    "metrics_json": json.dumps({"reason": reason}),
-                    "reason": reason,
-                },
-            )
-            conn.close()
+            with contextlib.closing(sqlite3.connect(self._db_path)) as conn:
+                conn.row_factory = sqlite3.Row
+                repo.save_phase_transition(
+                    conn,
+                    {
+                        "date": datetime.now(tz=_EASTERN).strftime("%Y-%m-%d"),
+                        "from_phase": from_phase,
+                        "to_phase": to_phase,
+                        "direction": direction,
+                        "account_equity_usd": equity,
+                        "metrics_json": json.dumps({"reason": reason}),
+                        "reason": reason,
+                    },
+                )
             logger.info(
                 "Phase transition recorded: %d -> %d (%s) reason=%s",
                 from_phase, to_phase, direction, reason,
@@ -1571,10 +1554,9 @@ class TradingBot:
 
         saved: bool = False
         try:
-            conn: sqlite3.Connection = sqlite3.connect(self._db_path)
-            conn.row_factory = sqlite3.Row
-            repo.save_daily_summary(conn, summary)
-            conn.close()
+            with contextlib.closing(sqlite3.connect(self._db_path)) as conn:
+                conn.row_factory = sqlite3.Row
+                repo.save_daily_summary(conn, summary)
             saved = True
             logger.info("Daily summary saved for %s (trades=%d, net_pnl=$%.2f)",
                         today_str, summary["total_trades"], summary["net_pnl_usd"])
@@ -1658,10 +1640,9 @@ class TradingBot:
     def _count_open_positions(self) -> int:
         """Count non-closed positions in SQLite."""
         try:
-            conn: sqlite3.Connection = sqlite3.connect(self._db_path)
-            conn.row_factory = sqlite3.Row
-            positions: list[dict[str, Any]] = repo.get_open_positions(conn)
-            conn.close()
+            with contextlib.closing(sqlite3.connect(self._db_path)) as conn:
+                conn.row_factory = sqlite3.Row
+                positions: list[dict[str, Any]] = repo.get_open_positions(conn)
             return len(positions)
         except Exception:
             logger.warning("Failed to count open positions", exc_info=True)
@@ -1670,10 +1651,9 @@ class TradingBot:
     def _is_phase0_complete(self) -> bool:
         """Return True if a Phase 0 -> Phase 1 transition has been recorded."""
         try:
-            conn: sqlite3.Connection = sqlite3.connect(self._db_path)
-            conn.row_factory = sqlite3.Row
-            result: bool = repo.is_phase0_complete(conn)
-            conn.close()
+            with contextlib.closing(sqlite3.connect(self._db_path)) as conn:
+                conn.row_factory = sqlite3.Row
+                result: bool = repo.is_phase0_complete(conn)
             return result
         except Exception:
             logger.warning("Phase 0 check failed", exc_info=True)

--- a/trading_bot/strategy/entry.py
+++ b/trading_bot/strategy/entry.py
@@ -8,6 +8,7 @@ trade/P&L limits.
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import math
 import sqlite3
@@ -478,10 +479,9 @@ class EntryEvaluator:
     def _is_on_cooldown(self, ticker: str, now: datetime) -> bool:
         """Check if *ticker* is in a post-exit cooldown window."""
         try:
-            conn: sqlite3.Connection = sqlite3.connect(self._db_path)
-            conn.row_factory = sqlite3.Row
-            cooldown_until: datetime | None = repo.get_cooldown(conn, ticker)
-            conn.close()
+            with contextlib.closing(sqlite3.connect(self._db_path)) as conn:
+                conn.row_factory = sqlite3.Row
+                cooldown_until: datetime | None = repo.get_cooldown(conn, ticker)
         except sqlite3.Error:
             logger.exception("Error checking cooldown for %s", ticker)
             return False
@@ -498,10 +498,9 @@ class EntryEvaluator:
     def _get_open_position_count(self) -> int:
         """Get the number of currently open positions from the DB."""
         try:
-            conn: sqlite3.Connection = sqlite3.connect(self._db_path)
-            conn.row_factory = sqlite3.Row
-            positions: list[dict[str, Any]] = repo.get_open_positions(conn)
-            conn.close()
+            with contextlib.closing(sqlite3.connect(self._db_path)) as conn:
+                conn.row_factory = sqlite3.Row
+                positions: list[dict[str, Any]] = repo.get_open_positions(conn)
             return len(positions)
         except sqlite3.Error:
             logger.exception("Error fetching open positions")
@@ -510,10 +509,9 @@ class EntryEvaluator:
     def _get_sector_count(self, sector: str) -> int:
         """Count open positions in the given GICS sector."""
         try:
-            conn: sqlite3.Connection = sqlite3.connect(self._db_path)
-            conn.row_factory = sqlite3.Row
-            positions: list[dict[str, Any]] = repo.get_open_positions(conn)
-            conn.close()
+            with contextlib.closing(sqlite3.connect(self._db_path)) as conn:
+                conn.row_factory = sqlite3.Row
+                positions: list[dict[str, Any]] = repo.get_open_positions(conn)
         except sqlite3.Error:
             logger.exception("Error fetching positions for sector check")
             return 0
@@ -528,10 +526,9 @@ class EntryEvaluator:
     def _get_daily_trade_count(self) -> int:
         """Get today's trade count from the DB."""
         try:
-            conn: sqlite3.Connection = sqlite3.connect(self._db_path)
-            conn.row_factory = sqlite3.Row
-            count: int = repo.get_trade_count_today(conn)
-            conn.close()
+            with contextlib.closing(sqlite3.connect(self._db_path)) as conn:
+                conn.row_factory = sqlite3.Row
+                count: int = repo.get_trade_count_today(conn)
             return count
         except sqlite3.Error:
             logger.exception("Error fetching daily trade count")
@@ -540,10 +537,9 @@ class EntryEvaluator:
     def _get_daily_pnl_usd(self) -> float:
         """Get today's realised P&L in USD from the DB."""
         try:
-            conn: sqlite3.Connection = sqlite3.connect(self._db_path)
-            conn.row_factory = sqlite3.Row
-            pnl: float = repo.get_daily_pnl_usd(conn)
-            conn.close()
+            with contextlib.closing(sqlite3.connect(self._db_path)) as conn:
+                conn.row_factory = sqlite3.Row
+                pnl: float = repo.get_daily_pnl_usd(conn)
             return pnl
         except sqlite3.Error:
             logger.exception("Error fetching daily P&L")


### PR DESCRIPTION
## Summary

H-3/H-4: contextlib.closing sweep (refs #58).

Replace 25 manual `try/finally: conn.close()` patterns with
`contextlib.closing(sqlite3.connect(...))`:

| File | Sites |
|---|---|
| `trading_bot/execution/order_manager.py` | 7 |
| `trading_bot/strategy/entry.py` | 5 |
| `trading_bot/main.py` | 13 |

`sqlite3.connect` as a bare context manager commits on `__exit__` but
does **not** close. `contextlib.closing` makes the close guaranteed,
even when an exception escapes the work block. The previous inline
pattern in `entry.py` and several `main.py` sites (no nested
try/finally) had a latent leak whenever the work raised.

## Behavior preservation

- Explicit `conn.commit()` calls retained (`contextlib.closing` does
  not auto-commit).
- `conn.row_factory = sqlite3.Row` placement preserved inside the
  `with` block.
- Outer `try/except` blocks for `sqlite3.OperationalError` /
  `Exception` logging unchanged.
- No SQL or query logic changes.

## Verification

- `pytest trading_bot/tests/` — 932 passed, 4 skipped
- `ruff check` — clean on touched files
- `mypy --ignore-missing-imports` (CI critical-path invocation per
  `.github/workflows/static-checks.yml`) — clean
- Canonical grep: 25 occurrences of
  `contextlib.closing(sqlite3.connect|with sqlite3.connect` across
  the three files (7 + 5 + 13).

## Out of scope

- H-2 `_hydrate_active_orders` JOIN rewrite (separate PR)
- #54 `STOP_AND_TARGET_ACTIVE` rename (separate PR)

## Test plan

- [x] All tests green locally
- [ ] `static-checks` and `coverage` green on CI