### PR TITLE
perf(execution): rewrite _hydrate_active_orders as JOIN + V13 index (H-2)

### DIFF
--- a/trading_bot/constants.py
+++ b/trading_bot/constants.py
@@ -196,4 +196,4 @@ def ticker_market(ticker: str) -> Market:
 # Schema version — must match the DB migration target
 # ---------------------------------------------------------------------------
 
-SCHEMA_VERSION: int = 12
+SCHEMA_VERSION: int = 13

--- a/trading_bot/db/migrations.py
+++ b/trading_bot/db/migrations.py
@@ -425,6 +425,36 @@ def _migration_v12(conn: sqlite3.Connection) -> None:
     logger.info("Applied migration V12: status rename")
 
 
+def _migration_v13(conn: sqlite3.Connection) -> None:
+    """V13: add ``idx_trades_ticker_entry_time`` composite index.
+
+    ``OrderManager._hydrate_active_orders`` resolves the trades-table
+    primary key for each non-terminal position via a LEFT JOIN on
+    ``(ticker, entry_time)``. Pre-V13 it instead scanned the whole
+    ``trades`` table on every tick and built a Python dict — O(trades)
+    per tick, which grows unbounded as the historical record grows.
+
+    This index makes the JOIN O(active positions). The columns mirror
+    the ``(ticker, entry_time)`` pair used in
+    ``trading_bot/tools/alpaca_backfill`` and a few other places that
+    also pair the two tables.
+
+    Idempotent: ``CREATE INDEX IF NOT EXISTS`` is a no-op when run
+    against a fresh DB that already has the index from
+    ``_SCHEMA_SQL``.
+    """
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_trades_ticker_entry_time "
+        "ON trades(ticker, entry_time)"
+    )
+    conn.execute(
+        "INSERT OR REPLACE INTO schema_version (version, description) "
+        "VALUES (13, "
+        "'V13 schema - idx_trades_ticker_entry_time for hydration JOIN')"
+    )
+    logger.info("Applied migration V13: idx_trades_ticker_entry_time")
+
+
 _MIGRATIONS: list[tuple[int, str, MigrationFn]] = [
     (4, "V4 schema - multi-market adaptive trading bot", _migration_v4),
     (5, "V5 schema - multi-strategy Alpaca trading bot", _migration_v5),
@@ -437,6 +467,8 @@ _MIGRATIONS: list[tuple[int, str, MigrationFn]] = [
      _migration_v11),
     (12, "V12 schema - rename STOP_AND_TARGET_ACTIVE → STOP_ACTIVE",
      _migration_v12),
+    (13, "V13 schema - idx_trades_ticker_entry_time for hydration JOIN",
+     _migration_v13),
 ]
 
 

--- a/trading_bot/db/schema.py
+++ b/trading_bot/db/schema.py
@@ -47,6 +47,11 @@ CREATE INDEX IF NOT EXISTS idx_trades_ticker ON trades(ticker);
 CREATE INDEX IF NOT EXISTS idx_trades_entry_time ON trades(entry_time);
 CREATE INDEX IF NOT EXISTS idx_trades_exit_reason ON trades(exit_reason);
 CREATE INDEX IF NOT EXISTS idx_trades_phase ON trades(phase);
+-- V13: composite index used by OrderManager._hydrate_active_orders to
+-- LEFT JOIN trades onto non-terminal positions in O(active positions)
+-- rather than O(trades) per tick.
+CREATE INDEX IF NOT EXISTS idx_trades_ticker_entry_time
+    ON trades(ticker, entry_time);
 
 -- Positions table: currently open positions and their management state
 CREATE TABLE IF NOT EXISTS positions (
@@ -267,7 +272,7 @@ CREATE TABLE IF NOT EXISTS schema_version (
 
 _SEED_VERSION_SQL: str = (
     "INSERT OR IGNORE INTO schema_version (version, description) "
-    "VALUES (?, 'V10 schema - USD-only column rename');"
+    "VALUES (?, 'V13 schema - idx_trades_ticker_entry_time for hydration JOIN');"
 )
 
 # Expected tables — used for quick health check

--- a/trading_bot/execution/order_manager.py
+++ b/trading_bot/execution/order_manager.py
@@ -233,27 +233,29 @@ class OrderManager:
         Each tick starts with an empty in-memory dict; we rehydrate from
         the DB so ``_check_order_statuses`` and entry-timeout sweeps can
         operate on the same set of positions the prior tick left open.
+
+        The trades-table primary key is resolved via a LEFT JOIN on
+        ``(ticker, entry_time)`` so we only read rows for non-terminal
+        positions. Pre-V13 this scanned the entire ``trades`` table on
+        every tick and built the pair map in Python; the JOIN + the V13
+        ``idx_trades_ticker_entry_time`` index reduce wall-time from
+        O(trades) to O(active positions).
         """
         try:
             with contextlib.closing(sqlite3.connect(self._db_path)) as conn:
                 conn.row_factory = sqlite3.Row
                 rows = conn.execute(
-                    "SELECT * FROM positions "
-                    "WHERE status NOT IN (?, ?)",
+                    "SELECT p.*, t.id AS db_trade_id "
+                    "FROM positions p "
+                    "LEFT JOIN trades t "
+                    "  ON t.ticker = p.ticker "
+                    " AND t.entry_time = p.entry_time "
+                    "WHERE p.status NOT IN (?, ?)",
                     (
                         PositionStatus.CLOSED.value,
                         PositionStatus.ENTRY_FAILED.value,
                     ),
                 ).fetchall()
-                # Pair-key index for trades.id lookup. Same pairing the
-                # alpaca_backfill tool uses (ticker, entry_time) since
-                # there is no FK between the tables.
-                trades_index: dict[tuple[str, str], int] = {
-                    (str(t["ticker"]), str(t["entry_time"])): int(t["id"])
-                    for t in conn.execute(
-                        "SELECT id, ticker, entry_time FROM trades"
-                    ).fetchall()
-                }
         except sqlite3.OperationalError:
             logger.warning("positions table not found during hydration")
             return
@@ -280,6 +282,11 @@ class OrderManager:
                 else None
             )
 
+            db_trade_id_raw = row["db_trade_id"]
+            db_trade_id: int | None = (
+                int(db_trade_id_raw) if db_trade_id_raw is not None else None
+            )
+
             active = _ActiveOrder(
                 trade_id=trade_id,
                 ticker=str(row["ticker"]),
@@ -299,9 +306,7 @@ class OrderManager:
                 target_price=float(row["target_price"] or 0),
                 hold_type=str(row["hold_type"]),
                 strategy_id=row["strategy_id"],
-                db_trade_id=trades_index.get(
-                    (str(row["ticker"]), str(row["entry_time"]))
-                ),
+                db_trade_id=db_trade_id,
             )
             self._active_orders[trade_id] = active
             for oid in (

--- a/trading_bot/tests/test_migration_v13_trades_index.py
+++ b/trading_bot/tests/test_migration_v13_trades_index.py
@@ -1,0 +1,137 @@
+"""Tests for V13: add ``idx_trades_ticker_entry_time`` composite index.
+
+Pre-V13 ``OrderManager._hydrate_active_orders`` scanned the entire
+``trades`` table on every tick to build a ``(ticker, entry_time) →
+trade_id`` Python dict. V13 lets the JOIN use the new composite index
+so hydration drops from O(trades) to O(active positions).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from trading_bot.constants import SCHEMA_VERSION
+from trading_bot.db.migrations import _migration_v13, run_migrations
+
+
+def _index_names(conn: sqlite3.Connection, table: str) -> set[str]:
+    return {
+        row[1]
+        for row in conn.execute(f"PRAGMA index_list({table})")
+    }
+
+
+@pytest.fixture
+def db_at_v12(tmp_path: Path) -> Path:
+    """Build a SQLite DB at V12 so we can drive _migration_v13 directly."""
+    db = tmp_path / "v12.db"
+    run_migrations(str(db))
+    conn = sqlite3.connect(str(db))
+    try:
+        conn.execute("DELETE FROM schema_version WHERE version >= 13")
+        # Drop the V13 index to mirror a real V12-era schema.
+        conn.execute("DROP INDEX IF EXISTS idx_trades_ticker_entry_time")
+        conn.commit()
+    finally:
+        conn.close()
+    return db
+
+
+@pytest.mark.unit
+def test_fresh_db_at_target_version_has_index(tmp_path: Path) -> None:
+    """A clean run_migrations on an empty DB lands at SCHEMA_VERSION
+    with the composite index present (via _SCHEMA_SQL)."""
+    db = tmp_path / "fresh.db"
+    run_migrations(str(db))
+    conn = sqlite3.connect(str(db))
+    try:
+        indexes = _index_names(conn, "trades")
+        version = conn.execute(
+            "SELECT MAX(version) FROM schema_version"
+        ).fetchone()[0]
+    finally:
+        conn.close()
+    assert "idx_trades_ticker_entry_time" in indexes
+    assert version == SCHEMA_VERSION
+
+
+@pytest.mark.unit
+def test_v13_adds_index_on_existing_db(db_at_v12: Path) -> None:
+    """V12 → V13 adds the new composite index; existing rows survive."""
+    conn = sqlite3.connect(str(db_at_v12))
+    try:
+        conn.execute(
+            "INSERT INTO trades (ticker, exchange, currency, side, entry_time, "
+            "entry_price, quantity, hold_type, phase) "
+            "VALUES ('SPY','NYSE','USD','BUY','2026-05-01T10:00:00-04:00',"
+            "100.0,10,'intraday',1)"
+        )
+        conn.commit()
+        assert "idx_trades_ticker_entry_time" not in _index_names(conn, "trades")
+
+        _migration_v13(conn)
+        conn.commit()
+
+        indexes = _index_names(conn, "trades")
+        assert "idx_trades_ticker_entry_time" in indexes, (
+            "V13 must add the composite index"
+        )
+
+        row = conn.execute(
+            "SELECT ticker FROM trades WHERE ticker='SPY'"
+        ).fetchone()
+        assert row == ("SPY",), "existing rows must survive"
+
+        version = conn.execute(
+            "SELECT MAX(version) FROM schema_version"
+        ).fetchone()[0]
+        assert version == 13
+    finally:
+        conn.close()
+
+
+@pytest.mark.unit
+def test_v13_is_idempotent(db_at_v12: Path) -> None:
+    """Running V13 twice must be safe — fresh installs get the index
+    from _SCHEMA_SQL, then the V13 migration runs against an
+    already-correct schema and must not error."""
+    conn = sqlite3.connect(str(db_at_v12))
+    try:
+        _migration_v13(conn)
+        conn.commit()
+        _migration_v13(conn)
+        conn.commit()
+
+        indexes = list(conn.execute("PRAGMA index_list(trades)"))
+        composite = [
+            r for r in indexes if r[1] == "idx_trades_ticker_entry_time"
+        ]
+        assert len(composite) == 1, (
+            f"expected exactly one idx_trades_ticker_entry_time, got "
+            f"{len(composite)}"
+        )
+    finally:
+        conn.close()
+
+
+@pytest.mark.unit
+def test_index_covers_both_columns(tmp_path: Path) -> None:
+    """The composite index must include both ticker and entry_time —
+    otherwise the JOIN in _hydrate_active_orders would fall back to
+    a per-row scan."""
+    db = tmp_path / "fresh.db"
+    run_migrations(str(db))
+    conn = sqlite3.connect(str(db))
+    try:
+        info = list(
+            conn.execute("PRAGMA index_info(idx_trades_ticker_entry_time)")
+        )
+        cols = [row[2] for row in info]
+    finally:
+        conn.close()
+    assert cols == ["ticker", "entry_time"], (
+        f"expected (ticker, entry_time), got {cols}"
+    )

--- a/trading_bot/tests/test_order_manager_lifecycle.py
+++ b/trading_bot/tests/test_order_manager_lifecycle.py
@@ -95,6 +95,71 @@ class TestHydration:
         om._hydrate_active_orders()
         assert len(om._active_orders) == 0
 
+    def test_hydrate_join_returns_only_non_terminal_positions(
+        self, config, tmp_db_path: str, mock_notifier
+    ):
+        """H-2: the (positions LEFT JOIN trades) rewrite must materialise
+        exactly the non-terminal positions and resolve db_trade_id from
+        the matching trades row in one pass.
+
+        Seeds a mix of CLOSED / ENTRY_FAILED / POSITION_OPEN /
+        STOP_ACTIVE / ENTRY_PENDING positions and asserts:
+
+        - terminal rows (CLOSED, ENTRY_FAILED) are excluded
+        - non-terminal rows are present
+        - each non-terminal row's db_trade_id points at the trades row
+          that shares its (ticker, entry_time) pair
+        """
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        # Drop the per-position pending-trade-id cache so hydration is
+        # forced to resolve db_trade_id via the JOIN.
+        seeds = {
+            "AAPL": PositionStatus.ENTRY_PENDING,
+            "MSFT": PositionStatus.POSITION_OPEN,
+            "GOOG": PositionStatus.STOP_ACTIVE,
+            "TSLA": PositionStatus.CLOSED,
+            "NVDA": PositionStatus.ENTRY_FAILED,
+        }
+        trade_ids: dict[str, int] = {}
+        for ticker, status in seeds.items():
+            tid = om._create_position_record(_entry(ticker))
+            assert tid is not None
+            trade_ids[ticker] = tid
+            if status != PositionStatus.ENTRY_PENDING:
+                om._update_position_status(tid, status)
+
+        # Clear the in-memory cache so hydration cannot satisfy
+        # db_trade_id from _pending_db_trade_ids — the JOIN must
+        # populate it from the trades table.
+        om._pending_db_trade_ids.clear()
+        om._active_orders.clear()
+        om._alpaca_to_trade.clear()
+
+        om._hydrate_active_orders()
+
+        live_tickers = {a.ticker for a in om._active_orders.values()}
+        assert live_tickers == {"AAPL", "MSFT", "GOOG"}
+        assert "TSLA" not in live_tickers
+        assert "NVDA" not in live_tickers
+
+        # Look up the trades.id for each non-terminal position and
+        # assert the JOIN populated db_trade_id.
+        conn = sqlite3.connect(tmp_db_path)
+        try:
+            for ticker in ("AAPL", "MSFT", "GOOG"):
+                row = conn.execute(
+                    "SELECT t.id "
+                    "FROM positions p JOIN trades t "
+                    "  ON t.ticker = p.ticker AND t.entry_time = p.entry_time "
+                    "WHERE p.ticker = ?",
+                    (ticker,),
+                ).fetchone()
+                expected_trade_id = int(row[0])
+                tid = trade_ids[ticker]
+                assert om._active_orders[tid].db_trade_id == expected_trade_id
+        finally:
+            conn.close()
+
 
 # ---------------------------------------------------------------------------
 # Entry fill → standalone stop attach


### PR DESCRIPTION
## H-2: hydration JOIN rewrite

Closes the H-2 follow-up from #58.

### Problem

`OrderManager._hydrate_active_orders` (order_manager.py:229) used to
`SELECT id, ticker, entry_time FROM trades` on every tick — full
scan, every row, every 5 minutes — then built a Python dict to
resolve `db_trade_id` for the handful of non-terminal positions. As
the historical record grows the per-tick cost grows linearly with
total trades while the actual work (live positions) stays small.

### Fix

- Replace the two-query + dict-merge pattern with a single
  `positions LEFT JOIN trades` keyed on `(ticker, entry_time)`,
  filtered to non-terminal statuses.
- Add a V13 composite index `idx_trades_ticker_entry_time` so the
  JOIN runs in O(active positions). EXPLAIN QUERY PLAN confirms the
  planner picks it up as a covering index:

      SEARCH t USING COVERING INDEX idx_trades_ticker_entry_time
        (ticker=? AND entry_time=?) LEFT-JOIN

- Index also added to `_SCHEMA_SQL` so fresh installs get it without
  needing the migration step.
- Bump `SCHEMA_VERSION` 12 -> 13; migration is idempotent
  (`CREATE INDEX IF NOT EXISTS`). V12 was already claimed by #121
  (STOP_AND_TARGET_ACTIVE -> STOP_ACTIVE rename).

### Benchmark

Synthetic DB with 5,000 historical trades + 50 non-terminal
positions, 200 iterations each:

| Approach | mean wall-time | rows returned |
|---|---|---|
| Old (full trades scan + Python merge) | 2.886 ms | 5,000 idx entries |
| New (JOIN + V13 index) | 0.119 ms | 50 rows |
| **Speedup** | **~24x** | |

The gap widens as `trades` grows. The new query reads only what it
needs.

### Acceptance

- [x] `pytest trading_bot/tests/` — 929 passed, 4 skipped (the 2
      `hypothesis`-gated suites were pre-existing collection errors
      in this worktree's venv and are unrelated to this change).
- [x] New `TestHydration.test_hydrate_join_returns_only_non_terminal_positions`
      seeds CLOSED / ENTRY_FAILED / POSITION_OPEN / STOP_ACTIVE /
      ENTRY_PENDING rows and asserts the hydration map contains exactly
      the three non-terminal positions with `db_trade_id` resolved via
      the JOIN.
- [x] New `test_migration_v13_trades_index.py` covers fresh-install,
      V12->V13 upgrade, idempotency, and column ordering.
- [x] Ruff clean on changed files.

### Scope

Same in, same out — `_hydrate_active_orders` still emits the same
`_ActiveOrder` set with the same `db_trade_id` mapping, just resolved
in SQL.