### PR TITLE
fix(stop_reconciler): suppress overnight_drift grace-window notifications (#129)

### DIFF
--- a/trading_bot/execution/stop_reconciler.py
+++ b/trading_bot/execution/stop_reconciler.py
@@ -9,6 +9,17 @@ recovery (see ``OrderManager._recover_missing_stop``) silently heals it.
 This is intended to run once per tick — it's cheap (one Alpaca query
 per recorded stop, plus the open-orders scan that the recovery layer
 already performs). It does NOT mutate state; it only reports.
+
+Notification suppression: overnight_drift entries fire at 15:45 ET and
+intentionally land in ``POSITION_OPEN`` with ``stop_price > 0`` and
+``alpaca_stop_order_id IS NULL`` until the next tick's
+``_transition_to_open`` call attaches the standalone stop. Inside that
+brief grace window the reconciler still detects the row and the
+emergency stop-attach logic still fires, but the priority-4 push
+notification is suppressed (a WARNING log line is emitted instead) so
+the operator isn't desensitised to real signals by a recurring
+false-alarm flood (issue #129). Do not "fix" the suppression thinking
+it's a bug — past the grace window, both log and notification fire.
 """
 
 from __future__ import annotations
@@ -17,11 +28,12 @@ import asyncio
 import logging
 import sqlite3
 from dataclasses import dataclass, field
+from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
 
 from alpaca.trading.models import Order as AlpacaOrder
 
-from trading_bot.constants import PositionStatus
+from trading_bot.constants import TZ_EASTERN, PositionStatus
 
 if TYPE_CHECKING:
     from trading_bot.gateway import GatewayConnection
@@ -51,6 +63,8 @@ class NakedPosition:
     stop_price: float
     alpaca_stop_order_id: str | None
     broker_status: str  # 'missing' / 'canceled' / 'expired' / 'rejected' / 'filled' / etc.
+    strategy_id: str | None = None
+    entry_time: str | None = None
 
     def describe(self) -> str:
         sid: str = self.alpaca_stop_order_id or "NULL"
@@ -59,6 +73,43 @@ class NakedPosition:
             f"entry=${self.entry_price:.4f}, stop=${self.stop_price:.4f}, "
             f"stop_order_id={sid}, broker_status={self.broker_status})"
         )
+
+
+# overnight_drift entries fire at 15:45 ET; the next tick (15:50 ET) is
+# where ``_transition_to_open`` attaches the standalone stop. A 10-minute
+# grace window covers that one-tick gap with safety margin without
+# masking a real failure (which persists for many ticks).
+_OVERNIGHT_DRIFT_GRACE_MINUTES: int = 10
+
+
+def _is_expected_naked_window(
+    position: NakedPosition,
+    now: datetime,
+    *,
+    grace_minutes: int = _OVERNIGHT_DRIFT_GRACE_MINUTES,
+) -> bool:
+    """True iff this naked state is the legitimate brief post-fill window.
+
+    overnight_drift enters at 15:45 ET and gets its stop attached on the
+    next tick. During that single-tick window the row legitimately has
+    ``POSITION_OPEN`` + ``alpaca_stop_order_id IS NULL``. Any other
+    strategy, or overnight_drift past the grace window, is treated as a
+    real naked-position event.
+    """
+    if position.strategy_id != "overnight_drift":
+        return False
+    if not position.entry_time:
+        return False
+    try:
+        entry_dt: datetime = datetime.fromisoformat(str(position.entry_time))
+    except ValueError:
+        return False
+    if entry_dt.tzinfo is None:
+        entry_dt = entry_dt.replace(tzinfo=TZ_EASTERN)
+    else:
+        entry_dt = entry_dt.astimezone(TZ_EASTERN)
+    delta: timedelta = now - entry_dt
+    return timedelta(0) <= delta <= timedelta(minutes=grace_minutes)
 
 
 @dataclass
@@ -108,7 +159,7 @@ def _load_open_positions(db_path: str) -> list[sqlite3.Row]:
             placeholders: str = ",".join("?" * len(_STATUSES_NEEDING_STOP))
             rows: list[sqlite3.Row] = conn.execute(
                 f"SELECT id, ticker, status, quantity, entry_price, "  # nosec B608
-                f"stop_price, alpaca_stop_order_id "
+                f"stop_price, alpaca_stop_order_id, strategy_id, entry_time "
                 f"FROM positions WHERE status IN ({placeholders})",
                 _STATUSES_NEEDING_STOP,
             ).fetchall()
@@ -169,6 +220,12 @@ async def reconcile_open_position_stops(
         # the in-tick recovery may have just attached one, but if this
         # check runs before the recovery branch (or outside the
         # market-hours window) the row is still naked at the broker.
+        strategy_id: str | None = (
+            str(row["strategy_id"]) if row["strategy_id"] else None
+        )
+        entry_time: str | None = (
+            str(row["entry_time"]) if row["entry_time"] else None
+        )
         if not stop_oid:
             naked: NakedPosition = NakedPosition(
                 trade_id=int(row["id"]),
@@ -179,6 +236,8 @@ async def reconcile_open_position_stops(
                 stop_price=float(row["stop_price"] or 0),
                 alpaca_stop_order_id=None,
                 broker_status="missing",
+                strategy_id=strategy_id,
+                entry_time=entry_time,
             )
             result.naked.append(naked)
             continue
@@ -196,6 +255,8 @@ async def reconcile_open_position_stops(
                 stop_price=float(row["stop_price"] or 0),
                 alpaca_stop_order_id=stop_oid,
                 broker_status=broker_status,
+                strategy_id=strategy_id,
+                entry_time=entry_time,
             )
         )
 
@@ -206,12 +267,25 @@ async def reconcile_open_position_stops(
         )
         for naked in result.naked:
             logger.warning("  naked: %s", naked.describe())
-        if notifier is not None:
-            body: str = "\n".join(n.describe() for n in result.naked)
+
+        now: datetime = datetime.now(tz=TZ_EASTERN)
+        notifiable: list[NakedPosition] = [
+            n for n in result.naked
+            if not _is_expected_naked_window(n, now=now)
+        ]
+        for suppressed in result.naked:
+            if suppressed not in notifiable:
+                logger.warning(
+                    "stop reconciler: suppressing notification for "
+                    "overnight_drift in expected grace window: %s",
+                    suppressed.describe(),
+                )
+        if notifier is not None and notifiable:
+            body: str = "\n".join(n.describe() for n in notifiable)
             await notifier.send(
                 "Naked Position Detected",
                 (
-                    f"Found {len(result.naked)} DB-open "
+                    f"Found {len(notifiable)} DB-open "
                     f"position(s) without an active broker-side stop. "
                     f"Issue #117 surface — in-tick recovery should "
                     f"heal during market hours; verify and "

--- a/trading_bot/tests/test_standalone_stop_lifecycle_117.py
+++ b/trading_bot/tests/test_standalone_stop_lifecycle_117.py
@@ -535,9 +535,16 @@ class TestStopReconciliation:
         ticker: str,
         status: PositionStatus,
         stop_order_id: str | None,
+        *,
+        strategy_id: str = "mean_reversion",
+        entry_time: datetime | None = None,
     ) -> int:
         conn = sqlite3.connect(db_path)
         try:
+            entry_iso: str = (
+                entry_time.isoformat() if entry_time is not None
+                else datetime.now(tz=ET).isoformat()
+            )
             now: str = datetime.now(tz=ET).isoformat()
             cur = conn.execute(
                 "INSERT INTO positions "
@@ -548,9 +555,9 @@ class TestStopReconciliation:
                 "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     ticker, "US", "USD", "Industrials",
-                    0.5, 100.0, now, status.value,
+                    0.5, 100.0, entry_iso, status.value,
                     98.0, 102.0, "intraday",
-                    3, "mean_reversion", 100.0, now,
+                    3, strategy_id, 100.0, now,
                     stop_order_id,
                 ),
             )
@@ -650,6 +657,125 @@ class TestStopReconciliation:
 
         assert result.has_naked
         assert result.naked[0].broker_status == "missing"
+
+    # ------------------------------------------------------------------
+    # Issue #129: strategy-aware notification suppression for the
+    # legitimate overnight_drift entry → next-tick stop-attach window.
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_reconciler_notifies_naked_mean_reversion(
+        self, tmp_db_path: str, mock_notifier
+    ) -> None:
+        """Baseline: mean_reversion entries have no grace window — a
+        naked row fires the priority-4 notification regardless of how
+        recent the entry is."""
+        self._seed_open_position(
+            tmp_db_path, "XLI", PositionStatus.POSITION_OPEN, None,
+            strategy_id="mean_reversion",
+            entry_time=datetime.now(tz=ET) - timedelta(minutes=2),
+        )
+
+        gw = MagicMock()
+        gw.client = MagicMock()
+
+        result = await reconcile_open_position_stops(
+            db_path=tmp_db_path, gateway=gw, notifier=mock_notifier,
+        )
+
+        assert result.has_naked
+        mock_notifier.send.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_reconciler_suppresses_overnight_drift_in_grace_window(
+        self, tmp_db_path: str, mock_notifier, caplog
+    ) -> None:
+        """An overnight_drift entry timestamped within the 10-minute
+        grace window is detected and logged but does NOT fire the push
+        notification — that's the operator-fatigue mitigation from
+        issue #129."""
+        import logging
+        self._seed_open_position(
+            tmp_db_path, "XLK", PositionStatus.POSITION_OPEN, None,
+            strategy_id="overnight_drift",
+            entry_time=datetime.now(tz=ET) - timedelta(minutes=2),
+        )
+
+        gw = MagicMock()
+        gw.client = MagicMock()
+
+        with caplog.at_level(logging.WARNING):
+            result = await reconcile_open_position_stops(
+                db_path=tmp_db_path, gateway=gw, notifier=mock_notifier,
+            )
+
+        # Detection still happens — emergency stop-attach path still fires.
+        assert result.has_naked
+        assert result.naked[0].strategy_id == "overnight_drift"
+        # Notification suppressed.
+        mock_notifier.send.assert_not_awaited()
+        # Operator can grep the log for the suppressed event.
+        assert any(
+            "suppressing notification" in record.message
+            for record in caplog.records
+        )
+
+    @pytest.mark.asyncio
+    async def test_reconciler_notifies_overnight_drift_past_grace_window(
+        self, tmp_db_path: str, mock_notifier
+    ) -> None:
+        """An overnight_drift entry older than the grace window is a
+        real failure of the stop-attach path — both log and
+        notification must fire. Guards against silently masking the
+        very class of bug the reconciler exists to catch (#117 mode C)."""
+        self._seed_open_position(
+            tmp_db_path, "XLF", PositionStatus.POSITION_OPEN, None,
+            strategy_id="overnight_drift",
+            entry_time=datetime.now(tz=ET) - timedelta(minutes=30),
+        )
+
+        gw = MagicMock()
+        gw.client = MagicMock()
+
+        result = await reconcile_open_position_stops(
+            db_path=tmp_db_path, gateway=gw, notifier=mock_notifier,
+        )
+
+        assert result.has_naked
+        mock_notifier.send.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_reconciler_mixed_batch_notifies_only_non_grace(
+        self, tmp_db_path: str, mock_notifier
+    ) -> None:
+        """When one overnight_drift row is in grace and one
+        mean_reversion row is naked, exactly one notification fires and
+        its body excludes the suppressed row."""
+        self._seed_open_position(
+            tmp_db_path, "XLK", PositionStatus.POSITION_OPEN, None,
+            strategy_id="overnight_drift",
+            entry_time=datetime.now(tz=ET) - timedelta(minutes=2),
+        )
+        self._seed_open_position(
+            tmp_db_path, "XLI", PositionStatus.POSITION_OPEN, None,
+            strategy_id="mean_reversion",
+            entry_time=datetime.now(tz=ET) - timedelta(minutes=2),
+        )
+
+        gw = MagicMock()
+        gw.client = MagicMock()
+
+        result = await reconcile_open_position_stops(
+            db_path=tmp_db_path, gateway=gw, notifier=mock_notifier,
+        )
+
+        assert len(result.naked) == 2
+        mock_notifier.send.assert_awaited_once()
+        # Inspect the body — only the mean_reversion ticker should appear.
+        call_args = mock_notifier.send.await_args
+        body: str = call_args.args[1]
+        assert "XLI" in body
+        assert "XLK" not in body
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #129.

## Summary

- Make `stop_reconciler` strategy-aware. `overnight_drift` rows that are still inside the legitimate 10-minute window between the 15:45 ET entry fill and the next tick's `_transition_to_open` stop-attach are detected and logged but **do not** trigger the priority-4 push notification.
- Pre-live operator-fatigue mitigation: without this, every overnight_drift entry produces ~78 false-alarm pushes per trading day on the 5-min cron — exactly the desensitisation pattern that defeats #117's whole point.
- The emergency stop-attach logic, `_STATUSES_NEEDING_STOP`, and the broker-side reconciliation pass are all unchanged. Only the notification path filters out grace-window rows.

## Implementation

- Extend the `_load_open_positions` SELECT with `strategy_id` and `entry_time`; thread both onto `NakedPosition` as optional kwargs (backward-compatible).
- New `_is_expected_naked_window` helper — returns `True` only for `overnight_drift` rows whose `entry_time` is within `_OVERNIGHT_DRIFT_GRACE_MINUTES` (10) of now ET. Anything else falls through to the existing notify path.
- Reconcile loop partitions `result.naked` into notifiable vs suppressed. Suppressed rows still log a WARNING so operators can grep for the pattern in postmortem.
- Module docstring documents the suppression so the next reader doesn't "fix" it.

Net diff: +207 / -7 LOC (most of the test file is the four new cases).

## Test plan

- [x] `pytest trading_bot/tests/test_standalone_stop_lifecycle_117.py` — 21/21 pass (17 existing + 4 new).
- [x] `pytest trading_bot/tests/` — 939 pass, 4 skipped.
- [x] `ruff check` clean on touched files.
- [x] `mypy trading_bot/execution/stop_reconciler.py` — no new errors (pre-existing `finnhub` stubs error in unrelated modules).

### New tests

- `test_reconciler_notifies_naked_mean_reversion` — baseline: non-overnight_drift strategies always notify.
- `test_reconciler_suppresses_overnight_drift_in_grace_window` — in-grace overnight_drift is detected, logged, **not** pushed.
- `test_reconciler_notifies_overnight_drift_past_grace_window` — past-grace overnight_drift still notifies (guards the real #117 mode C failure mode the reconciler was built to catch).
- `test_reconciler_mixed_batch_notifies_only_non_grace` — when both fire on the same tick, the push body excludes the suppressed row.

## Out of scope (per #129)

- `_STATUSES_NEEDING_STOP` unchanged — `POSITION_OPEN` stays in the detection list.
- No changes to the actual stop-attach logic or recovery branch.
- No global "quiet hours" / rate limiter — strategy-aware suppression is the precise fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)