### PR TITLE
fix(recovery): UPDATE entry trades row instead of inserting stub (#132)

### DIFF
--- a/trading_bot/db/repository.py
+++ b/trading_bot/db/repository.py
@@ -51,6 +51,106 @@ def _today_eastern() -> str:
 
 
 # ---------------------------------------------------------------------------
+# Trades — close-or-insert
+# ---------------------------------------------------------------------------
+
+def close_or_insert_trade_row(
+    conn: sqlite3.Connection,
+    *,
+    position_row: sqlite3.Row,
+    exit_time: str,
+    exit_reason: str,
+    notes: str,
+) -> tuple[str, int]:
+    """Close the entry trades row for *position_row*, or insert a stub.
+
+    Issue #132: the recovery / orphan-drain code paths used to blindly
+    ``INSERT INTO trades`` every time they CLOSED a position. The
+    normal entry flow (``OrderManager._create_position_record``) had
+    already written an entry trades row carrying the strategy metadata,
+    so the second INSERT produced duplicate rows on
+    ``(ticker, entry_time, strategy_id)`` — 25% of prod rows
+    (2026-05-14 audit). The hydration JOIN had to lean on ``MIN(t.id)``
+    for determinism (#128).
+
+    New contract: locate the entry trades row by
+    ``(ticker, entry_time, strategy_id, exit_time IS NULL)`` and UPDATE
+    its exit columns. Only INSERT a stub if no entry row exists — the
+    legitimate case for positions discovered by recovery from a stray
+    Alpaca holding (``gateway/recovery.py:_create_db_position``).
+
+    Picks ``MIN(trades.id)`` when multiple legacy duplicates remain so
+    the choice is stable and matches the JOIN convention in
+    ``OrderManager._hydrate_active_orders``.
+
+    Returns ``("update", trades.id)`` or ``("insert", trades.id)`` so
+    callers can log which branch fired.
+
+    Caller owns the transaction — wrap in ``with conn:`` or commit
+    explicitly afterwards.
+    """
+    ticker: str = position_row["ticker"]
+    entry_time: str = position_row["entry_time"]
+    strategy_id: str = position_row["strategy_id"] or "unknown"
+    # Float-typed: positions.quantity may be fractional. int() truncation
+    # of -0.43 → 0 would mis-derive side as BUY. Sign-of-the-float is
+    # the only invariant we need here.
+    qty: float = float(position_row["quantity"] or 0)
+    # The bot is long-only at the strategy layer, but the schema
+    # technically allows shorts — derive rather than assume. Positive
+    # qty == long entry.
+    entry_side: str = "BUY" if qty >= 0 else "SELL"
+
+    existing = conn.execute(
+        "SELECT MIN(id) FROM trades "
+        "WHERE ticker = ? AND entry_time = ? "
+        "  AND strategy_id = ? AND exit_time IS NULL",
+        (ticker, entry_time, strategy_id),
+    ).fetchone()
+    existing_id: int | None = (
+        int(existing[0]) if existing is not None and existing[0] is not None
+        else None
+    )
+
+    if existing_id is not None:
+        conn.execute(
+            "UPDATE trades "
+            "SET exit_time = ?, exit_reason = ?, notes = ? "
+            "WHERE id = ?",
+            (exit_time, exit_reason, notes, existing_id),
+        )
+        return ("update", existing_id)
+
+    cur = conn.execute(
+        "INSERT INTO trades "
+        "(ticker, exchange, currency, side, entry_time, "
+        " entry_price, quantity, exit_time, exit_reason, "
+        " hold_type, phase, strategy_id, notes) "
+        "VALUES (:ticker, :exchange, :currency, :side, "
+        "        :entry_time, :entry_price, :quantity, "
+        "        :exit_time, :exit_reason, :hold_type, "
+        "        :phase, :strategy_id, :notes)",
+        {
+            "ticker": ticker,
+            "exchange": position_row["exchange"],
+            "currency": position_row["currency"],
+            "side": entry_side,
+            "entry_time": entry_time,
+            "entry_price": position_row["entry_price"],
+            "quantity": abs(qty),
+            "exit_time": exit_time,
+            "exit_reason": exit_reason,
+            "hold_type": position_row["hold_type"],
+            "phase": position_row["phase"],
+            "strategy_id": strategy_id,
+            "notes": notes,
+        },
+    )
+    new_id: int = cur.lastrowid  # type: ignore[assignment]
+    return ("insert", new_id)
+
+
+# ---------------------------------------------------------------------------
 # Trades
 # ---------------------------------------------------------------------------
 

--- a/trading_bot/gateway/recovery.py
+++ b/trading_bot/gateway/recovery.py
@@ -19,6 +19,7 @@ from alpaca.trading.models import Position as AlpacaPosition
 from alpaca.trading.models import Order as AlpacaOrder
 
 from trading_bot.constants import TZ_EASTERN
+from trading_bot.db.repository import close_or_insert_trade_row
 from trading_bot.gateway.connection import GatewayConnection
 from trading_bot.notifications.notifier import Notifier
 
@@ -903,6 +904,18 @@ class StateRecovery:
         tool can populate them from order history. Pre-fix hardcoded
         side='SELL' made every recovery-driven trade look like a short
         entry, with no strategy attribution at all.
+
+        Issue #132 fix: prefer UPDATE-on-existing-entry-row over INSERT
+        of a stub. Most reconciliation-mismatch closes hit a position
+        that was created by ``OrderManager._create_position_record`` —
+        which already wrote an entry trades row carrying the strategy
+        metadata. INSERT-ing a second row produced 25% duplicates on
+        ``(ticker, entry_time, strategy_id)`` in prod and forced the
+        hydration JOIN to lean on ``MIN(t.id)`` for determinism (#128).
+        Now: locate the entry row (``exit_time IS NULL`` with matching
+        key) and update its exit columns. Only INSERT when no entry
+        row exists — the legitimate case for positions discovered by
+        ``_create_db_position`` from a stray Alpaca holding.
         """
         now: str = datetime.now(tz=ET).isoformat()
         conn: sqlite3.Connection = sqlite3.connect(self._db_path)
@@ -926,43 +939,21 @@ class StateRecovery:
                         "SELECT * FROM positions WHERE id = ?", (position_id,)
                     ).fetchone()
                     if row:
-                        # Float-typed: positions.quantity may be fractional.
-                        # int() truncation of -0.43 → 0 would mis-derive side
-                        # as BUY. Sign-of-the-float is the only invariant we
-                        # need here.
-                        qty: float = float(row["quantity"] or 0)
-                        # The bot is long-only at the strategy layer, but
-                        # the schema technically allows shorts — derive
-                        # rather than assume. Positive qty == long entry.
-                        entry_side: str = "BUY" if qty >= 0 else "SELL"
-                        conn.execute(
-                            "INSERT INTO trades "
-                            "(ticker, exchange, currency, side, entry_time, "
-                            " entry_price, quantity, exit_time, exit_reason, "
-                            " hold_type, phase, strategy_id, notes) "
-                            "VALUES (:ticker, :exchange, :currency, :side, "
-                            "        :entry_time, :entry_price, :quantity, "
-                            "        :exit_time, :exit_reason, :hold_type, "
-                            "        :phase, :strategy_id, :notes)",
-                            {
-                                "ticker": row["ticker"],
-                                "exchange": row["exchange"],
-                                "currency": row["currency"],
-                                "side": entry_side,
-                                "entry_time": row["entry_time"],
-                                "entry_price": row["entry_price"],
-                                "quantity": abs(qty),
-                                "exit_time": now,
-                                "exit_reason": reason,
-                                "hold_type": row["hold_type"],
-                                "phase": row["phase"],
-                                "strategy_id": row["strategy_id"] or "unknown",
-                                "notes": (
-                                    "Auto-closed by state recovery; "
-                                    "exit_price/net_pnl pending "
-                                    "alpaca_backfill"
-                                ),
-                            },
+                        branch, trade_id = close_or_insert_trade_row(
+                            conn,
+                            position_row=row,
+                            exit_time=now,
+                            exit_reason=reason,
+                            notes=(
+                                "Auto-closed by state recovery; "
+                                "exit_price/net_pnl pending "
+                                "alpaca_backfill"
+                            ),
+                        )
+                        logger.info(
+                            "Recovery close: position_id=%d trades.id=%d "
+                            "branch=%s reason=%s",
+                            position_id, trade_id, branch, reason,
                         )
             except sqlite3.OperationalError:
                 logger.warning("Could not close position id=%d", position_id)

--- a/trading_bot/strategy/strategy_manager.py
+++ b/trading_bot/strategy/strategy_manager.py
@@ -782,35 +782,22 @@ class StrategyManager:
                     ).fetchone()
                     if row is None:
                         return
-                    qty: float = float(row["quantity"] or 0)
-                    entry_side: str = "BUY" if qty >= 0 else "SELL"
-                    conn.execute(
-                        "INSERT INTO trades "
-                        "(ticker, exchange, currency, side, entry_time, "
-                        " entry_price, quantity, exit_time, exit_reason, "
-                        " hold_type, phase, strategy_id, notes) "
-                        "VALUES (:ticker, :exchange, :currency, :side, "
-                        "        :entry_time, :entry_price, :quantity, "
-                        "        :exit_time, :exit_reason, :hold_type, "
-                        "        :phase, :strategy_id, :notes)",
-                        {
-                            "ticker": row["ticker"],
-                            "exchange": row["exchange"],
-                            "currency": row["currency"],
-                            "side": entry_side,
-                            "entry_time": row["entry_time"],
-                            "entry_price": row["entry_price"],
-                            "quantity": abs(qty),
-                            "exit_time": now_str,
-                            "exit_reason": "reconciliation_mismatch",
-                            "hold_type": row["hold_type"],
-                            "phase": row["phase"],
-                            "strategy_id": row["strategy_id"] or "unknown",
-                            "notes": (
-                                "orphan_sleeve_drain: Alpaca holds 0; "
-                                "exit_price/net_pnl pending alpaca_backfill"
-                            ),
-                        },
+                    # Issue #132: prefer UPDATE on the existing entry
+                    # trades row over INSERT of a stub. See
+                    # ``close_or_insert_trade_row`` for the contract.
+                    branch, trade_id = repo.close_or_insert_trade_row(
+                        conn,
+                        position_row=row,
+                        exit_time=now_str,
+                        exit_reason="reconciliation_mismatch",
+                        notes=(
+                            "orphan_sleeve_drain: Alpaca holds 0; "
+                            "exit_price/net_pnl pending alpaca_backfill"
+                        ),
+                    )
+                    logger.info(
+                        "Drain close: position_id=%d trades.id=%d branch=%s",
+                        position_id, trade_id, branch,
                     )
             finally:
                 conn.close()

--- a/trading_bot/tests/test_phase3_regressions.py
+++ b/trading_bot/tests/test_phase3_regressions.py
@@ -390,6 +390,287 @@ class TestB4_RecoveryCloseDbPositionWritesCompleteRow:
 
 
 # ---------------------------------------------------------------------------
+# Issue #132 — recovery / drain paths must not create duplicate trades rows
+# ---------------------------------------------------------------------------
+
+
+class TestIssue132_NoDuplicateTradesOnRecoveryClose:
+    """Issue #132: pre-fix, ``_close_db_position`` and ``_mark_position_closed``
+    blindly INSERTed a stub trades row even when an entry row already
+    existed. Prod audit (2026-05-14) found 25% of trades rows in dup groups
+    on ``(ticker, entry_time, strategy_id)``.
+
+    These tests pin both the entry-row-exists UPDATE branch and the
+    no-entry-row INSERT branch (broker-discovered orphan case).
+    """
+
+    def _make_recovery(self, config, tmp_db_path: str, mock_notifier):
+        from trading_bot.gateway.recovery import StateRecovery
+
+        gw = MagicMock()
+        return StateRecovery(gw, tmp_db_path, mock_notifier)
+
+    def _seed_with_entry_row(
+        self,
+        tmp_db_path: str,
+        *,
+        ticker: str = "SPY",
+        strategy_id: str = "overnight_drift",
+        qty: float = 0.4412,
+    ) -> tuple[int, int, str]:
+        """Mirror the production entry flow: insert paired positions +
+        trades rows the way ``_create_position_record`` does. Returns
+        ``(position_id, entry_trade_id, entry_time)``.
+        """
+        entry_time: str = "2026-05-04T15:45:37.982852-04:00"
+        conn = sqlite3.connect(tmp_db_path)
+        try:
+            pos_cur = conn.execute(
+                "INSERT INTO positions "
+                "(ticker, exchange, currency, quantity, entry_price, "
+                " entry_time, status, hold_type, phase, strategy_id) "
+                "VALUES (?, 'US', 'USD', ?, 100.0, ?, "
+                " 'POSITION_OPEN', 'intraday', 1, ?)",
+                (ticker, qty, entry_time, strategy_id),
+            )
+            position_id = int(pos_cur.lastrowid)
+            trade_cur = conn.execute(
+                "INSERT INTO trades "
+                "(ticker, exchange, currency, side, entry_time, entry_price, "
+                " quantity, hold_type, phase, signal_price, sentiment_score, "
+                " signals, strategy_id) "
+                "VALUES (?, 'US', 'USD', 'BUY', ?, 100.0, ?, "
+                " 'intraday', 1, 100.0, 0.0, 'test', ?)",
+                (ticker, entry_time, qty, strategy_id),
+            )
+            entry_trade_id = int(trade_cur.lastrowid)
+            conn.commit()
+            return position_id, entry_trade_id, entry_time
+        finally:
+            conn.close()
+
+    def test_recovery_close_updates_existing_entry_row(
+        self, config, tmp_db_path: str, mock_notifier,
+    ):
+        """When an entry trades row already exists, the recovery close
+        path must UPDATE it (set exit_time / exit_reason / notes) — not
+        INSERT a second row.
+        """
+        position_id, entry_trade_id, entry_time = self._seed_with_entry_row(
+            tmp_db_path,
+        )
+        rm = self._make_recovery(config, tmp_db_path, mock_notifier)
+
+        rm._close_db_position(position_id, "reconciliation_mismatch")
+
+        conn = sqlite3.connect(tmp_db_path)
+        try:
+            # Exactly one trades row for this (ticker, entry_time,
+            # strategy_id) tuple — proves no stub was inserted.
+            count = conn.execute(
+                "SELECT COUNT(*) FROM trades "
+                "WHERE ticker = ? AND entry_time = ? AND strategy_id = ?",
+                ("SPY", entry_time, "overnight_drift"),
+            ).fetchone()[0]
+            assert count == 1, (
+                f"Expected exactly one trades row; got {count} — "
+                "recovery path re-introduced the stub INSERT."
+            )
+            # And it must be the *original* entry row (preserving its id),
+            # now populated with exit columns.
+            row = conn.execute(
+                "SELECT id, side, strategy_id, exit_time, exit_reason, "
+                "       quantity, notes "
+                "FROM trades WHERE id = ?",
+                (entry_trade_id,),
+            ).fetchone()
+            assert row is not None
+            assert row[0] == entry_trade_id
+            assert row[1] == "BUY"
+            assert row[2] == "overnight_drift"
+            assert row[3] is not None  # exit_time populated
+            assert row[4] == "reconciliation_mismatch"
+            assert abs(float(row[5]) - 0.4412) < 1e-9  # qty preserved
+            assert "alpaca_backfill" in (row[6] or "")
+        finally:
+            conn.close()
+
+    def test_recovery_close_inserts_when_no_entry_row(
+        self, config, tmp_db_path: str, mock_notifier,
+    ):
+        """Broker-discovered orphan case (``_create_db_position`` flow):
+        the positions row exists but has no matching trades row. The
+        recovery close must still write a trades row so the audit trail
+        and alpaca_backfill candidate set are complete.
+        """
+        conn = sqlite3.connect(tmp_db_path)
+        try:
+            cur = conn.execute(
+                "INSERT INTO positions "
+                "(ticker, exchange, currency, quantity, entry_price, "
+                " entry_time, status, hold_type, phase, strategy_id) "
+                "VALUES ('QQQ', 'US', 'USD', 5.0, 50.0, "
+                " '2026-04-28T10:00:00', 'POSITION_OPEN', 'swing', 1, "
+                " 'unknown')",
+            )
+            position_id = int(cur.lastrowid)
+            conn.commit()
+        finally:
+            conn.close()
+
+        rm = self._make_recovery(config, tmp_db_path, mock_notifier)
+        rm._close_db_position(position_id, "reconciliation_mismatch")
+
+        conn = sqlite3.connect(tmp_db_path)
+        try:
+            rows = conn.execute(
+                "SELECT side, strategy_id, exit_reason, quantity "
+                "FROM trades WHERE ticker = 'QQQ'"
+            ).fetchall()
+        finally:
+            conn.close()
+        # Exactly one stub row inserted.
+        assert len(rows) == 1
+        assert rows[0][0] == "BUY"
+        assert rows[0][1] == "unknown"
+        assert rows[0][2] == "reconciliation_mismatch"
+        assert abs(float(rows[0][3]) - 5.0) < 1e-9
+
+    def test_recovery_close_ignores_already_closed_entry_row(
+        self, config, tmp_db_path: str, mock_notifier,
+    ):
+        """If the entry trades row already has exit_time set (e.g., a
+        prior tick closed it via a different code path), the recovery
+        close path must NOT match it — that would overwrite a real exit
+        with a reconciliation stub. Insert a new stub instead.
+        """
+        position_id, entry_trade_id, entry_time = self._seed_with_entry_row(
+            tmp_db_path,
+        )
+        # Simulate an earlier tick already closing the entry row.
+        conn = sqlite3.connect(tmp_db_path)
+        try:
+            conn.execute(
+                "UPDATE trades SET exit_time = ?, exit_reason = ?, "
+                "exit_price = ?, pnl_usd = ? WHERE id = ?",
+                (
+                    "2026-05-04T16:00:00-04:00", "stop_loss",
+                    99.5, -0.22, entry_trade_id,
+                ),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        rm = self._make_recovery(config, tmp_db_path, mock_notifier)
+        rm._close_db_position(position_id, "reconciliation_mismatch")
+
+        conn = sqlite3.connect(tmp_db_path)
+        try:
+            # Two rows now: the original closed entry row + a new stub.
+            # The real exit is preserved; reconciliation didn't clobber
+            # the stop_loss attribution.
+            entry_row = conn.execute(
+                "SELECT exit_reason, pnl_usd FROM trades WHERE id = ?",
+                (entry_trade_id,),
+            ).fetchone()
+            assert entry_row[0] == "stop_loss"
+            assert abs(float(entry_row[1]) - (-0.22)) < 1e-9
+
+            stub_rows = conn.execute(
+                "SELECT id FROM trades "
+                "WHERE ticker = ? AND entry_time = ? AND strategy_id = ? "
+                "AND id != ?",
+                ("SPY", entry_time, "overnight_drift", entry_trade_id),
+            ).fetchall()
+            assert len(stub_rows) == 1
+        finally:
+            conn.close()
+
+
+class TestIssue132_NoDuplicateOnOrphanDrain:
+    """Same contract as TestIssue132_NoDuplicateTradesOnRecoveryClose,
+    but for ``strategy_manager._mark_position_closed`` — the orphan-sleeve
+    drain path that fires when Alpaca reports zero holdings for a sleeve
+    the DB believes is long.
+    """
+
+    def _seed_with_entry_row(
+        self, tmp_db_path: str,
+    ) -> tuple[int, int, str]:
+        entry_time: str = "2026-05-04T15:45:37.982852-04:00"
+        conn = sqlite3.connect(tmp_db_path)
+        try:
+            pos_cur = conn.execute(
+                "INSERT INTO positions "
+                "(ticker, exchange, currency, quantity, entry_price, "
+                " entry_time, status, hold_type, phase, strategy_id) "
+                "VALUES ('SPY', 'US', 'USD', 0.4412, 100.0, ?, "
+                " 'POSITION_OPEN', 'intraday', 1, 'overnight_drift')",
+                (entry_time,),
+            )
+            position_id = int(pos_cur.lastrowid)
+            trade_cur = conn.execute(
+                "INSERT INTO trades "
+                "(ticker, exchange, currency, side, entry_time, entry_price, "
+                " quantity, hold_type, phase, signal_price, sentiment_score, "
+                " signals, strategy_id) "
+                "VALUES ('SPY', 'US', 'USD', 'BUY', ?, 100.0, 0.4412, "
+                " 'intraday', 1, 100.0, 0.0, 'test', 'overnight_drift')",
+                (entry_time,),
+            )
+            entry_trade_id = int(trade_cur.lastrowid)
+            conn.commit()
+            return position_id, entry_trade_id, entry_time
+        finally:
+            conn.close()
+
+    def test_drain_close_updates_existing_entry_row(
+        self, config, tmp_db_path: str, mock_notifier,
+    ):
+        """``_mark_position_closed`` must UPDATE the entry trades row,
+        not INSERT a second one.
+
+        StrategyManager has a wide constructor and the drain helper only
+        touches ``self._db_path``; bind the method to a lightweight stub
+        rather than wiring the full dependency graph.
+        """
+        from trading_bot.strategy.strategy_manager import StrategyManager
+
+        position_id, entry_trade_id, entry_time = self._seed_with_entry_row(
+            tmp_db_path,
+        )
+
+        class _StubSM:
+            _db_path: str = tmp_db_path
+
+        # Call the unbound method directly against the stub.
+        StrategyManager._mark_position_closed(_StubSM(), position_id)  # type: ignore[arg-type]
+
+        conn = sqlite3.connect(tmp_db_path)
+        try:
+            count = conn.execute(
+                "SELECT COUNT(*) FROM trades "
+                "WHERE ticker = ? AND entry_time = ? AND strategy_id = ?",
+                ("SPY", entry_time, "overnight_drift"),
+            ).fetchone()[0]
+            assert count == 1, (
+                f"Expected exactly one trades row; got {count} — "
+                "orphan-drain path re-introduced the stub INSERT."
+            )
+            row = conn.execute(
+                "SELECT id, exit_reason, notes FROM trades WHERE id = ?",
+                (entry_trade_id,),
+            ).fetchone()
+            assert row is not None
+            assert row[0] == entry_trade_id
+            assert row[1] == "reconciliation_mismatch"
+            assert "orphan_sleeve_drain" in (row[2] or "")
+        finally:
+            conn.close()
+
+
+# ---------------------------------------------------------------------------
 # B5 — _update_position_field observability
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #132. Follow-up to #131 (the JOIN-side determinism fix).

## Summary

The recovery / orphan-drain code paths were the root cause of the
trades-table duplicates that #128 / #131 paper over. Two call sites
blindly `INSERT`-ed into trades every time they CLOSED a position:

- `gateway/recovery.py:_close_db_position` (reconciliation mismatch)
- `strategy/strategy_manager.py:_mark_position_closed` (orphan-sleeve drain)

The normal entry flow (`OrderManager._create_position_record`) had
already written an entry trades row, so the second INSERT produced
duplicates on `(ticker, entry_time, strategy_id)`. The 2026-05-14
audit found **44 of 174 rows (25%) in dup groups**.

This PR replaces both INSERTs with a shared helper
`close_or_insert_trade_row()` in `db/repository.py` that:

- Locates the entry row by `(ticker, entry_time, strategy_id,
  exit_time IS NULL)` and **UPDATEs** its exit columns, or
- **INSERTs** a stub only when no entry row exists — the legitimate
  case for positions discovered by `recovery._create_db_position`
  from a stray Alpaca holding (no `_create_position_record` ran).

Picks `MIN(trades.id)` when legacy duplicates already exist so the
choice is stable and matches the `MIN(t.id)` JOIN convention in
`OrderManager._hydrate_active_orders` introduced by #131.

## Why a shared helper

Both call sites had near-identical code (UPDATE positions → SELECT
positions row → INSERT trades). The recovery test seeded the
positions row directly, so the strategy_manager copy was drifting
without a regression net. The shared helper makes the no-duplicate
contract single-sourced.

## Tests

- `TestIssue132_NoDuplicateTradesOnRecoveryClose`
  - `test_recovery_close_updates_existing_entry_row` — entry row
    exists → must UPDATE, not INSERT (1 row total, same id, exit
    columns populated).
  - `test_recovery_close_inserts_when_no_entry_row` — broker-
    discovered orphan → INSERT stub as before.
  - `test_recovery_close_ignores_already_closed_entry_row` — guard
    against clobbering a real exit if a prior tick already closed
    the entry row via a different code path (`exit_time` NOT NULL →
    fall through to INSERT).
- `TestIssue132_NoDuplicateOnOrphanDrain::test_drain_close_updates_existing_entry_row`
  pins the same contract on the strategy_manager drain path.

946 passed, 4 skipped (was 942 before — +4 new). ruff / mypy /
live-path guards clean.

## Out of scope (follow-up)

- **One-shot repair script** for the 44 already-duplicated prod
  rows. Per the issue body, this is a separate PR — it needs a dry
  run against a copy of prod first, idempotency, and per-merge
  logging. Will file as a follow-up issue.
- **Schema-level uniqueness** (e.g., `UNIQUE(ticker, entry_time,
  strategy_id) WHERE exit_time IS NULL`). Adding it now would block
  the repair script from doing any UPDATE-merge work. Defer until
  after the dedupe.

## Test plan

- [x] All four new tests pass
- [x] Existing `TestB4_RecoveryCloseDbPositionWritesCompleteRow`
      still passes (no-entry-row INSERT branch unchanged)
- [x] Full pytest suite green (946 / 4 skip)
- [x] ruff / mypy / live-path guards green
- [ ] `static-checks` and `coverage` green on CI

Net diff: +425 / −66 LOC (helper + two call-site swaps + four
regression tests).