### PR TITLE
chore(repair): one-shot dedupe of legacy duplicate trades rows (#132)

### DIFF
--- a/.github/workflows/repair-trades-dedupe.yml
+++ b/.github/workflows/repair-trades-dedupe.yml
@@ -1,0 +1,82 @@
+name: repair-trades-dedupe
+
+# One-shot repair for trades rows duplicated on
+# (ticker, entry_time, strategy_id) by the pre-#133 recovery / orphan-drain
+# paths. #133 stops new duplicates from being created but does not heal
+# the 26 existing dup groups (52 rows, 2026-05-14 audit). This workflow
+# merges each canonical entry row with its stub and deletes the stub.
+#
+# Manual trigger only. After it runs successfully, this workflow and
+# scripts/repair_trades_dedupe.py + the test file should be removed in a
+# follow-up PR.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run (log changes without writing)"
+        type: boolean
+        default: true
+
+# Own concurrency group so a scheduled bot.yml tick (which sets
+# cancel-in-progress=true on the bot-run group) cannot send a cancel
+# signal mid-write. The repair re-restores the most recent bot-db-*
+# cache via restore-keys and writes back under the same prefix, so
+# the next bot tick picks our changes up.
+concurrency:
+  group: repair-run
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  repair:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install deps
+        run: pip install -r requirements.txt
+
+      - name: Restore SQLite DB
+        uses: actions/cache@v5
+        with:
+          path: trading_bot/data/trading_bot.db*
+          key: bot-db-${{ github.run_id }}
+          restore-keys: |
+            bot-db-
+
+      - name: Run repair (dry_run=${{ inputs.dry_run }})
+        env:
+          BOT_LOG_DIR: logs
+        run: |
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            python scripts/repair_trades_dedupe.py
+          else
+            python scripts/repair_trades_dedupe.py --apply
+          fi
+
+      - name: Recompute daily_summaries
+        # Defense in depth. The repair preserves SUM(pnl_usd) per ET-date
+        # because the exit data moves from stub to canonical — same
+        # exit_time, same pnl_usd, just different row id. But re-running
+        # the aggregator is harmless and confirms the invariant.
+        if: inputs.dry_run == false
+        env:
+          BOT_LOG_DIR: logs
+        run: python -m trading_bot.self_improve.recompute_daily_summaries --days 30
+
+      - name: Upload DB artifact for inspection
+        uses: actions/upload-artifact@v4
+        with:
+          name: repair-db-${{ github.run_id }}
+          path: trading_bot/data/trading_bot.db
+          retention-days: 30

--- a/scripts/repair_trades_dedupe.py
+++ b/scripts/repair_trades_dedupe.py
@@ -1,0 +1,270 @@
+"""One-shot repair: dedupe trades rows on (ticker, entry_time, strategy_id).
+
+Context — fixed in ai-broker#133 forward-only:
+
+  Pre-#133 the recovery / orphan-drain code paths
+  (``gateway/recovery.py:_close_db_position``,
+  ``strategy/strategy_manager.py:_mark_position_closed``) blindly
+  INSERT-ed a stub trades row when CLOSE-ing a position. The normal
+  entry flow had already written an entry row in
+  ``OrderManager._create_position_record``, so every recovery-driven
+  close produced a duplicate on ``(ticker, entry_time, strategy_id)``.
+  ``alpaca_backfill`` subsequently UPDATE-d the stub with real exit
+  data, leaving the entry row orphaned with NULL exit columns.
+
+  #133 stops new duplicates from being created — both call sites now
+  UPDATE the entry row in place. But the 26 already-existing dup
+  groups (52 rows, audit 2026-05-14) need a separate one-shot pass
+  to merge the orphaned entry row with its stub.
+
+Scope:
+
+  - Only groups where ``COUNT(*) > 1`` on
+    ``(ticker, entry_time, strategy_id)``.
+  - Only groups where the canonical row (lowest id) has
+    ``exit_time IS NULL`` and at least one non-canonical row has
+    ``exit_time IS NOT NULL``. This matches the recovery-stub pattern
+    exactly and rules out odd shapes that need human review.
+  - Skip groups overlapping any non-terminal positions row — should
+    be zero in current prod (verified empirically) but guarded
+    because the script must never disturb live tick state.
+
+Action per affected group:
+
+  1. Copy stub's exit columns (``exit_time``, ``exit_price``,
+     ``exit_reason``, ``gross_pnl``, ``net_pnl``, ``pnl_usd``,
+     ``notes``) into the canonical row.
+  2. DELETE every non-canonical row in the group.
+
+Idempotent: re-running on a deduped DB reports "no rows to repair"
+and exits 0. Picks the highest-id stub when multiple exist (the most
+recently updated, i.e. the alpaca_backfill output).
+
+The repair preserves the net pnl reported in ``daily_summaries``:
+the exit data is moved from the stub to the canonical row, so the
+aggregate ``SUM(pnl_usd) GROUP BY substr(exit_time, 1, 10)`` is
+byte-identical pre/post repair. ``daily_summaries`` recompute is
+included in the workflow as defense-in-depth, not because the math
+changes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sqlite3
+import sys
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+# Columns copied from stub → canonical. Quantity / entry_price /
+# entry_time are NOT in this list: they were identical between the two
+# rows when the duplicate was created (both came from the same positions
+# row), and the canonical's value is the canonical-by-construction one.
+_EXIT_COLUMNS: tuple[str, ...] = (
+    "exit_time",
+    "exit_price",
+    "exit_reason",
+    "gross_pnl",
+    "net_pnl",
+    "pnl_usd",
+    "notes",
+)
+
+
+def find_dup_groups(
+    conn: sqlite3.Connection,
+) -> list[tuple[int, int, str, str, list[int]]]:
+    """Return one tuple per affected group:
+    ``(canon_id, stub_id, ticker, strategy_id, all_stub_ids)``.
+
+    *stub_id* is the row whose exit data will be merged into the canonical
+    — the highest-id row with ``exit_time IS NOT NULL``. *all_stub_ids*
+    is the full list of non-canonical rows in the group (== all rows to
+    DELETE). The two are usually identical because every observed group
+    has exactly 2 rows, but the helper keeps them distinct so a 3+ row
+    group would also repair cleanly.
+    """
+    conn.row_factory = sqlite3.Row
+    # Use a window function to compute the canonical id per group, then
+    # filter to groups where the canonical is open and at least one
+    # non-canonical row is closed. Exclude any group that overlaps a
+    # non-terminal positions row.
+    rows = conn.execute(
+        """
+        WITH dup_keys AS (
+          SELECT ticker, entry_time, strategy_id
+            FROM trades
+           GROUP BY ticker, entry_time, strategy_id
+           HAVING COUNT(*) > 1
+        ),
+        ranked AS (
+          SELECT t.id, t.ticker, t.entry_time, t.strategy_id,
+                 t.exit_time,
+                 MIN(t.id) OVER (
+                   PARTITION BY t.ticker, t.entry_time, t.strategy_id
+                 ) AS canon_id
+            FROM trades t JOIN dup_keys d
+              ON t.ticker = d.ticker
+             AND t.entry_time = d.entry_time
+             AND t.strategy_id = d.strategy_id
+        )
+        SELECT * FROM ranked
+        ORDER BY ticker, entry_time, id
+        """,
+    ).fetchall()
+
+    # Group by (ticker, entry_time, strategy_id).
+    groups: dict[tuple[str, str, str], list[sqlite3.Row]] = {}
+    for r in rows:
+        key = (r["ticker"], r["entry_time"], r["strategy_id"])
+        groups.setdefault(key, []).append(r)
+
+    out: list[tuple[int, int, str, str, list[int]]] = []
+    for (ticker, entry_time, strategy_id), group_rows in groups.items():
+        canon_id: int = int(group_rows[0]["canon_id"])
+        canon_row = next(r for r in group_rows if int(r["id"]) == canon_id)
+        if canon_row["exit_time"] is not None:
+            logger.info(
+                "Skipping group %s/%s/%s — canonical id=%d already closed.",
+                ticker, entry_time, strategy_id, canon_id,
+            )
+            continue
+        stub_rows = [r for r in group_rows if int(r["id"]) != canon_id]
+        closed_stubs = [r for r in stub_rows if r["exit_time"] is not None]
+        if not closed_stubs:
+            logger.info(
+                "Skipping group %s/%s/%s — no closed non-canonical row.",
+                ticker, entry_time, strategy_id,
+            )
+            continue
+        # Pick the highest-id closed stub — that's the alpaca_backfill
+        # output (latest UPDATE in time).
+        stub_id: int = max(int(r["id"]) for r in closed_stubs)
+        all_stub_ids: list[int] = [int(r["id"]) for r in stub_rows]
+
+        # Guard: never touch a group that overlaps a live position.
+        overlap = conn.execute(
+            """
+            SELECT COUNT(*) FROM positions
+             WHERE ticker = ? AND entry_time = ? AND strategy_id = ?
+               AND status NOT IN ('CLOSED', 'ENTRY_FAILED')
+            """,
+            (ticker, entry_time, strategy_id),
+        ).fetchone()[0]
+        if overlap > 0:
+            logger.warning(
+                "Skipping group %s/%s/%s — overlaps %d live position(s).",
+                ticker, entry_time, strategy_id, overlap,
+            )
+            continue
+
+        out.append((canon_id, stub_id, ticker, strategy_id, all_stub_ids))
+    return out
+
+
+def merge_and_delete(
+    conn: sqlite3.Connection,
+    canon_id: int,
+    stub_id: int,
+    delete_ids: list[int],
+) -> None:
+    """Copy stub's exit columns into canonical, then DELETE delete_ids.
+
+    Single transaction — caller owns commit. Uses a parametrised
+    UPDATE that reads from ``stub_id`` via a correlated subquery
+    pattern so the column list stays explicit (no
+    ``UPDATE ... FROM`` cross-version concern on older SQLite).
+    """
+    stub_row = conn.execute(
+        f"SELECT {', '.join(_EXIT_COLUMNS)} FROM trades WHERE id = ?",
+        (stub_id,),
+    ).fetchone()
+    if stub_row is None:
+        raise RuntimeError(
+            f"Stub row id={stub_id} disappeared between scan and merge"
+        )
+    set_clause: str = ", ".join(f"{col} = ?" for col in _EXIT_COLUMNS)
+    conn.execute(
+        f"UPDATE trades SET {set_clause} WHERE id = ?",
+        (*stub_row, canon_id),
+    )
+    placeholders: str = ",".join("?" * len(delete_ids))
+    conn.execute(
+        f"DELETE FROM trades WHERE id IN ({placeholders})",
+        delete_ids,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--db",
+        default="trading_bot/data/trading_bot.db",
+        help="Path to the SQLite DB (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Commit the repair. Without this flag, runs as a dry-run "
+             "and prints what would change.",
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+    )
+
+    db_path = Path(args.db)
+    if not db_path.exists():
+        logger.error("DB not found: %s", db_path)
+        return 2
+
+    conn = sqlite3.connect(db_path)
+    try:
+        groups = find_dup_groups(conn)
+        if not groups:
+            logger.info(
+                "No duplicate groups to repair — every "
+                "(ticker, entry_time, strategy_id) tuple is unique.",
+            )
+            return 0
+
+        logger.info(
+            "Found %d duplicate group(s) eligible for merge:", len(groups),
+        )
+        total_deletes: int = 0
+        for canon_id, stub_id, ticker, strategy_id, delete_ids in groups:
+            logger.info(
+                "  %-5s/%-15s canon=%d  stub=%d  delete=%s",
+                ticker, strategy_id, canon_id, stub_id, delete_ids,
+            )
+            total_deletes += len(delete_ids)
+        logger.info(
+            "Total rows to merge: %d canonical(s) updated, %d row(s) deleted.",
+            len(groups), total_deletes,
+        )
+
+        if not args.apply:
+            logger.info(
+                "Dry-run — pass --apply to commit. Exiting without changes.",
+            )
+            return 0
+
+        for canon_id, stub_id, _ticker, _strategy, delete_ids in groups:
+            merge_and_delete(conn, canon_id, stub_id, delete_ids)
+        conn.commit()
+        logger.info(
+            "Repair committed: %d group(s) merged, %d row(s) deleted.",
+            len(groups), total_deletes,
+        )
+        return 0
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/trading_bot/tests/test_repair_trades_dedupe.py
+++ b/trading_bot/tests/test_repair_trades_dedupe.py
@@ -1,0 +1,357 @@
+"""Tests for ``scripts/repair_trades_dedupe.py``.
+
+Pre-#133 the recovery / orphan-drain paths produced duplicate trades rows
+on ``(ticker, entry_time, strategy_id)``: the canonical entry row (lowest
+id, NULL exit columns) plus a stub created when the position closed.
+This script merges the stub's exit data into the canonical row and
+deletes the stub.
+
+Coverage:
+
+- ``find_dup_groups`` only flags groups where canonical is open and at
+  least one non-canonical row is closed (the recovery-stub pattern).
+- Groups overlapping a live position are skipped.
+- Groups with multiple stub rows pick the highest-id (most recent) one
+  and delete all non-canonical rows.
+- ``merge_and_delete`` copies the exit columns and deletes the stubs in
+  a single transaction.
+- ``main`` dry-run / apply / idempotent re-run.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make scripts/ importable for direct unit-testing.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_REPO_ROOT / "scripts"))
+
+import repair_trades_dedupe as repair  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def conn(tmp_path: Path) -> sqlite3.Connection:
+    db_path = tmp_path / "trading_bot.db"
+    c = sqlite3.connect(db_path)
+    c.executescript(
+        """
+        CREATE TABLE positions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            ticker TEXT NOT NULL,
+            exchange TEXT NOT NULL,
+            currency TEXT NOT NULL,
+            quantity REAL NOT NULL,
+            entry_price REAL NOT NULL,
+            entry_time TEXT NOT NULL,
+            status TEXT NOT NULL,
+            hold_type TEXT NOT NULL,
+            phase INTEGER NOT NULL,
+            strategy_id TEXT
+        );
+        CREATE TABLE trades (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            ticker TEXT NOT NULL,
+            exchange TEXT NOT NULL,
+            currency TEXT NOT NULL,
+            side TEXT NOT NULL,
+            entry_time TEXT NOT NULL,
+            entry_price REAL NOT NULL,
+            quantity REAL NOT NULL,
+            exit_time TEXT,
+            exit_price REAL,
+            exit_reason TEXT,
+            gross_pnl REAL,
+            net_pnl REAL,
+            pnl_usd REAL,
+            hold_type TEXT NOT NULL,
+            phase INTEGER NOT NULL,
+            strategy_id TEXT,
+            notes TEXT
+        );
+        """,
+    )
+    c.commit()
+    return c
+
+
+def _insert_entry_row(
+    conn: sqlite3.Connection,
+    *,
+    ticker: str = "SPY",
+    entry_time: str = "2026-05-04T15:45:37.982852-04:00",
+    strategy_id: str = "overnight_drift",
+    quantity: float = 0.4412,
+) -> int:
+    cur = conn.execute(
+        "INSERT INTO trades "
+        "(ticker, exchange, currency, side, entry_time, entry_price, "
+        " quantity, hold_type, phase, strategy_id) "
+        "VALUES (?, 'US', 'USD', 'BUY', ?, 100.0, ?, 'intraday', 1, ?)",
+        (ticker, entry_time, quantity, strategy_id),
+    )
+    conn.commit()
+    return int(cur.lastrowid)  # type: ignore[arg-type]
+
+
+def _insert_stub_row(
+    conn: sqlite3.Connection,
+    *,
+    ticker: str = "SPY",
+    entry_time: str = "2026-05-04T15:45:37.982852-04:00",
+    strategy_id: str = "overnight_drift",
+    quantity: float = 0.4412,
+    exit_time: str = "2026-05-05T09:30:00-04:00",
+    exit_price: float | None = 101.5,
+    pnl: float | None = 0.66,
+    exit_reason: str = "manual",
+    notes: str = "backfill:position:42",
+) -> int:
+    cur = conn.execute(
+        "INSERT INTO trades "
+        "(ticker, exchange, currency, side, entry_time, entry_price, "
+        " quantity, exit_time, exit_price, exit_reason, "
+        " gross_pnl, net_pnl, pnl_usd, "
+        " hold_type, phase, strategy_id, notes) "
+        "VALUES (?, 'US', 'USD', 'BUY', ?, 100.0, ?, "
+        "        ?, ?, ?, ?, ?, ?, 'intraday', 1, ?, ?)",
+        (
+            ticker, entry_time, quantity,
+            exit_time, exit_price, exit_reason,
+            pnl, pnl, pnl,
+            strategy_id, notes,
+        ),
+    )
+    conn.commit()
+    return int(cur.lastrowid)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# find_dup_groups
+# ---------------------------------------------------------------------------
+
+
+def test_find_returns_empty_when_no_dups(conn: sqlite3.Connection) -> None:
+    _insert_entry_row(conn)
+    assert repair.find_dup_groups(conn) == []
+
+
+def test_find_flags_canonical_open_stub_closed(conn: sqlite3.Connection) -> None:
+    canon = _insert_entry_row(conn)
+    stub = _insert_stub_row(conn)
+
+    groups = repair.find_dup_groups(conn)
+    assert len(groups) == 1
+    canon_id, stub_id, ticker, strategy_id, delete_ids = groups[0]
+    assert canon_id == canon
+    assert stub_id == stub
+    assert ticker == "SPY"
+    assert strategy_id == "overnight_drift"
+    assert delete_ids == [stub]
+
+
+def test_find_skips_when_canonical_already_closed(
+    conn: sqlite3.Connection,
+) -> None:
+    """If canonical was already closed (e.g., by a prior repair run or
+    real exit path), don't touch the group — that could clobber real
+    data with stub data.
+    """
+    canon = _insert_entry_row(conn)
+    conn.execute(
+        "UPDATE trades SET exit_time = ?, exit_reason = ?, pnl_usd = ? "
+        "WHERE id = ?",
+        ("2026-05-05T09:30:00-04:00", "stop_loss", -0.22, canon),
+    )
+    _insert_stub_row(conn)
+    conn.commit()
+    assert repair.find_dup_groups(conn) == []
+
+
+def test_find_skips_when_no_closed_stub(conn: sqlite3.Connection) -> None:
+    """Two open rows for the same key shouldn't happen but if they do,
+    there's no exit data to merge — skip rather than guess."""
+    _insert_entry_row(conn)
+    _insert_entry_row(conn)  # second open row at same key
+    assert repair.find_dup_groups(conn) == []
+
+
+def test_find_skips_when_overlaps_live_position(
+    conn: sqlite3.Connection,
+) -> None:
+    """Live position with status POSITION_OPEN must never be touched."""
+    _insert_entry_row(conn)
+    _insert_stub_row(conn)
+    conn.execute(
+        "INSERT INTO positions "
+        "(ticker, exchange, currency, quantity, entry_price, entry_time, "
+        " status, hold_type, phase, strategy_id) "
+        "VALUES ('SPY', 'US', 'USD', 0.4412, 100.0, "
+        " '2026-05-04T15:45:37.982852-04:00', 'POSITION_OPEN', 'intraday', "
+        " 1, 'overnight_drift')",
+    )
+    conn.commit()
+    assert repair.find_dup_groups(conn) == []
+
+
+def test_find_handles_three_row_group(conn: sqlite3.Connection) -> None:
+    """Picks the highest-id closed stub as the merge source and queues
+    every non-canonical row for deletion."""
+    canon = _insert_entry_row(conn)
+    stub_a = _insert_stub_row(conn, exit_time="2026-05-05T09:30:00-04:00")
+    stub_b = _insert_stub_row(conn, exit_time="2026-05-05T10:00:00-04:00",
+                              exit_price=101.6, pnl=0.71)
+
+    groups = repair.find_dup_groups(conn)
+    assert len(groups) == 1
+    canon_id, stub_id, _, _, delete_ids = groups[0]
+    assert canon_id == canon
+    assert stub_id == stub_b  # highest-id closed stub
+    assert sorted(delete_ids) == sorted([stub_a, stub_b])
+
+
+# ---------------------------------------------------------------------------
+# merge_and_delete
+# ---------------------------------------------------------------------------
+
+
+def test_merge_copies_exit_columns_and_deletes_stub(
+    conn: sqlite3.Connection,
+) -> None:
+    canon = _insert_entry_row(conn)
+    stub = _insert_stub_row(
+        conn,
+        exit_time="2026-05-05T09:30:00-04:00",
+        exit_price=101.5,
+        pnl=0.66,
+        exit_reason="manual",
+        notes="backfill:position:42",
+    )
+
+    repair.merge_and_delete(conn, canon, stub, [stub])
+    conn.commit()
+
+    canon_row = conn.execute(
+        "SELECT exit_time, exit_price, exit_reason, pnl_usd, notes, quantity "
+        "FROM trades WHERE id = ?",
+        (canon,),
+    ).fetchone()
+    assert canon_row is not None
+    assert canon_row[0] == "2026-05-05T09:30:00-04:00"
+    assert abs(canon_row[1] - 101.5) < 1e-9
+    assert canon_row[2] == "manual"
+    assert abs(canon_row[3] - 0.66) < 1e-9
+    assert canon_row[4] == "backfill:position:42"
+    # Quantity must NOT be overwritten — canonical kept its entry-row qty.
+    assert abs(canon_row[5] - 0.4412) < 1e-9
+
+    # Stub is gone.
+    assert conn.execute(
+        "SELECT COUNT(*) FROM trades WHERE id = ?", (stub,),
+    ).fetchone()[0] == 0
+
+
+# ---------------------------------------------------------------------------
+# main — dry-run / apply / idempotent
+# ---------------------------------------------------------------------------
+
+
+def test_main_dry_run_does_not_mutate(
+    conn: sqlite3.Connection, tmp_path: Path,
+) -> None:
+    _insert_entry_row(conn)
+    _insert_stub_row(conn)
+    db_path = Path(conn.execute("PRAGMA database_list").fetchone()[2])
+    conn.close()
+
+    rc = repair.main(["--db", str(db_path)])
+    assert rc == 0
+
+    after = sqlite3.connect(db_path)
+    try:
+        assert after.execute("SELECT COUNT(*) FROM trades").fetchone()[0] == 2
+    finally:
+        after.close()
+
+
+def test_main_apply_merges_and_deletes(
+    conn: sqlite3.Connection, tmp_path: Path,
+) -> None:
+    canon = _insert_entry_row(conn)
+    _insert_stub_row(conn, exit_price=99.0, pnl=-0.44)
+    db_path = Path(conn.execute("PRAGMA database_list").fetchone()[2])
+    conn.close()
+
+    rc = repair.main(["--db", str(db_path), "--apply"])
+    assert rc == 0
+
+    after = sqlite3.connect(db_path)
+    try:
+        # One row left, exit data populated, id preserved.
+        rows = after.execute(
+            "SELECT id, exit_price, pnl_usd FROM trades"
+        ).fetchall()
+        assert len(rows) == 1
+        assert rows[0][0] == canon
+        assert abs(rows[0][1] - 99.0) < 1e-9
+        assert abs(rows[0][2] - (-0.44)) < 1e-9
+        # Re-running is a no-op.
+        rc2 = repair.main(["--db", str(db_path), "--apply"])
+        assert rc2 == 0
+        assert after.execute("SELECT COUNT(*) FROM trades").fetchone()[0] == 1
+    finally:
+        after.close()
+
+
+def test_main_preserves_total_pnl_across_repair(
+    conn: sqlite3.Connection, tmp_path: Path,
+) -> None:
+    """Aggregate ``SUM(pnl_usd)`` across the trades table is unchanged
+    pre/post repair — the exit data is moved, not invented or dropped.
+    Pinning this invariant protects ``daily_summaries`` from accidental
+    drift.
+    """
+    _insert_entry_row(conn, ticker="SPY")
+    _insert_stub_row(conn, ticker="SPY", pnl=0.12)
+    _insert_entry_row(conn, ticker="XLF", entry_time="2026-05-05T15:45:00-04:00")
+    _insert_stub_row(
+        conn, ticker="XLF",
+        entry_time="2026-05-05T15:45:00-04:00",
+        pnl=-0.05,
+    )
+    db_path = Path(conn.execute("PRAGMA database_list").fetchone()[2])
+    conn.close()
+
+    before_conn = sqlite3.connect(db_path)
+    try:
+        before = before_conn.execute(
+            "SELECT ROUND(SUM(pnl_usd), 4) FROM trades"
+        ).fetchone()[0]
+    finally:
+        before_conn.close()
+
+    rc = repair.main(["--db", str(db_path), "--apply"])
+    assert rc == 0
+
+    after_conn = sqlite3.connect(db_path)
+    try:
+        after = after_conn.execute(
+            "SELECT ROUND(SUM(pnl_usd), 4) FROM trades"
+        ).fetchone()[0]
+    finally:
+        after_conn.close()
+
+    assert before == after
+
+
+def test_main_db_missing_returns_nonzero(tmp_path: Path) -> None:
+    rc = repair.main(["--db", str(tmp_path / "nope.db")])
+    assert rc == 2


### PR DESCRIPTION
Follow-up to #133. The forward-only fix in #133 stops new duplicates
from being created but leaves the **26 dup groups (52 rows)** that
prod already accumulated. This PR adds the one-shot repair that
merges each canonical entry row with its stub.

Modeled on #110 (the pnl-truncation repair): script + workflow_dispatch
+ tests, dry-run by default, removed in a follow-up PR after one live
apply.

## What the repair does

For each group on `(ticker, entry_time, strategy_id)` with >1 rows:

1. **Canonical** = lowest-id row. Audit shows it's always the entry
   row from `OrderManager._create_position_record` — correct
   quantity, NULL exit columns.
2. **Stub** = highest-id row with `exit_time IS NOT NULL`. Audit
   shows it's always the recovery + `alpaca_backfill` output —
   exit_time, exit_price, exit_reason, pnl_usd, notes all populated.
3. Copy the stub's exit columns into the canonical row.
4. DELETE every non-canonical row in the group.

The repair preserves `SUM(pnl_usd)` across the trades table because
the exit data moves rather than being recomputed or dropped.

## Verification against prod DB copy

Ran against a copy of `bot-db-25864292529` (cached 2026-05-14 13:30 UTC):

| metric | before | after |
|---|---|---|
| trades rows | 180 | 154 |
| `SUM(pnl_usd)` | \$27.2831 | \$27.2831 |
| distinct `(ticker, entry_time, strategy_id)` | 100 | 100 |
| daily_summaries aggregate | unchanged on every ET date | unchanged |

Re-running on the deduped DB: "No duplicate groups to repair —
every (ticker, entry_time, strategy_id) tuple is unique." Idempotent.

All 26 groups overlap CLOSED positions only — zero overlap with
the 3 currently-open positions (XLI / XLB / AAPL).

## Guards

- Skip any group whose canonical already has `exit_time` populated.
  Defensive — never overwrite real exit data (e.g., a stop_loss fill
  recorded by `_close_position`).
- Skip any group overlapping a non-terminal `positions` row.
- Pick the highest-id closed stub when multiple exist (alpaca_backfill
  output, most recently UPDATEd).

## Tests (11 new)

`trading_bot/tests/test_repair_trades_dedupe.py`:

- `test_find_*` — flags only canonical-open + stub-closed pattern;
  skips already-closed canonical, no-closed-stub, live-position
  overlap; handles 3-row groups.
- `test_merge_copies_exit_columns_and_deletes_stub` — exit columns
  copied, quantity preserved, stub deleted.
- `test_main_dry_run_does_not_mutate` — dry-run is read-only.
- `test_main_apply_merges_and_deletes` — apply mutates, re-apply
  is a no-op.
- `test_main_preserves_total_pnl_across_repair` — invariant test
  protecting `daily_summaries`.
- `test_main_db_missing_returns_nonzero`.

Full suite: 957 passed, 4 skipped (was 946 before — +11 new).
ruff / mypy / live-path guards clean.

## Workflow

`.github/workflows/repair-trades-dedupe.yml`: workflow_dispatch
only, restores the latest bot-db cache, runs the script, recomputes
`daily_summaries` (defense-in-depth, the math doesn't change), and
uploads a `repair-db-<run_id>` artifact for inspection.

## Plan after merge

1. Merge this PR.
2. Dispatch the workflow with `dry_run=true` — confirm 26 groups
   reported.
3. Dispatch with `dry_run=false` — confirm 26 deletes committed.
4. Open follow-up PR removing the script, workflow, and test file.

## Test plan

- [x] 11 new unit tests pass
- [x] Existing 946 tests still pass (957 total)
- [x] Dry-run + apply + idempotent re-run verified against a copy
      of `bot-db-25864292529`
- [x] `SUM(pnl_usd)` invariant verified
- [x] Daily summary aggregates byte-identical pre/post
- [ ] `static-checks` and `coverage` green on CI
- [ ] Live workflow dispatch (post-merge)

Net diff: +709 LOC (script + workflow + tests). Three new files,
zero modified.