### PR TITLE
fix(recovery): persist alpaca_stop_order_id after emergency stop placement

### DIFF
--- a/trading_bot/gateway/recovery.py
+++ b/trading_bot/gateway/recovery.py
@@ -421,10 +421,98 @@ class StateRecovery:
             )
             # Alpaca SDK is sync — offload to a worker thread so we don't
             # block the event loop on the HTTP submit.
-            await asyncio.to_thread(self._gw.client.submit_order, order_data=request)
-            logger.info("Emergency stop placed for %s: %s %.6f @ stop %.2f", ticker, side.value, order_qty, stop_price)
+            order = await asyncio.to_thread(
+                self._gw.client.submit_order, order_data=request,
+            )
+            stop_order_id: str = str(getattr(order, "id", "") or "")
+            logger.info(
+                "Emergency stop placed for %s: %s %.6f @ stop %.2f (id=%s)",
+                ticker, side.value, order_qty, stop_price,
+                stop_order_id or "?",
+            )
+            # Without this writeback, ``positions.alpaca_stop_order_id``
+            # stays NULL and every subsequent tick sees the position as
+            # naked → places another emergency stop → accumulates broker-
+            # side stops the bot has no record of. When one of those
+            # untracked stops eventually fills, `_check_order_statuses`
+            # has no ``order_id`` to poll, so recovery later writes
+            # ``exit_reason='reconciliation_mismatch'`` with NULL
+            # exit_price/pnl, losing the realized P&L attribution.
+            if stop_order_id:
+                self._persist_emergency_stop_id(
+                    ticker, stop_order_id, stop_price,
+                )
         except Exception:
             logger.exception("Failed to place emergency stop for %s", ticker)
+
+    def _persist_emergency_stop_id(
+        self,
+        ticker: str,
+        stop_order_id: str,
+        stop_price: float,
+    ) -> None:
+        """Write the broker-side stop order_id back onto the DB row.
+
+        Targets the unique non-terminal positions row for ``ticker`` that
+        is currently missing an ``alpaca_stop_order_id``. ``stop_price``
+        is only written when the existing value is NULL — recovery's
+        default-stop-pct calculation must not clobber a strategy-set
+        target. Multi-row matches log a warning rather than mass-update,
+        so a schema accident never blindly applies one order_id to
+        multiple positions.
+        """
+        now: str = datetime.now(tz=ET).isoformat()
+        conn: sqlite3.Connection = sqlite3.connect(self._db_path)
+        try:
+            try:
+                with conn:
+                    cur = conn.execute(
+                        """SELECT id FROM positions
+                            WHERE ticker = ?
+                              AND status NOT IN ('CLOSED', 'ENTRY_FAILED')
+                              AND alpaca_stop_order_id IS NULL""",
+                        (ticker,),
+                    )
+                    rows = cur.fetchall()
+                    if not rows:
+                        logger.warning(
+                            "Emergency stop persistence: no matching "
+                            "POSITION row for %s with NULL "
+                            "alpaca_stop_order_id — stop_order_id=%s "
+                            "left at broker but untracked",
+                            ticker, stop_order_id,
+                        )
+                        return
+                    if len(rows) > 1:
+                        logger.warning(
+                            "Emergency stop persistence: %d non-terminal "
+                            "rows for %s — refusing to write stop_order_id "
+                            "to all; manual reconciliation needed",
+                            len(rows), ticker,
+                        )
+                        return
+                    position_id: int = int(rows[0][0])
+                    conn.execute(
+                        """UPDATE positions
+                            SET alpaca_stop_order_id = ?,
+                                stop_price = COALESCE(stop_price, ?),
+                                updated_at = ?
+                            WHERE id = ?""",
+                        (stop_order_id, stop_price, now, position_id),
+                    )
+                    logger.info(
+                        "Emergency stop persisted: %s position_id=%d "
+                        "stop_order_id=%s stop_price=%.4f",
+                        ticker, position_id, stop_order_id, stop_price,
+                    )
+            except sqlite3.OperationalError:
+                logger.warning(
+                    "Could not persist emergency stop_order_id for %s "
+                    "(stop_order_id=%s)",
+                    ticker, stop_order_id,
+                )
+        finally:
+            conn.close()
 
     async def _cancel_stale_entry_orders(
         self,

--- a/trading_bot/tests/test_state_recovery.py
+++ b/trading_bot/tests/test_state_recovery.py
@@ -295,6 +295,144 @@ class TestStateRecovery:
         gw.client.submit_order.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_emergency_stop_persists_order_id_to_db(
+        self, tmp_db_path: str, mock_notifier,
+    ) -> None:
+        """Regression for 2026-05-15 untracked-emergency-stop bug.
+
+        ``_place_emergency_stop`` submitted a stop to Alpaca and dropped
+        the returned order_id on the floor, leaving
+        ``positions.alpaca_stop_order_id`` NULL forever. Every subsequent
+        tick saw the position as naked, accumulated broker-side stops,
+        and when one finally filled, recovery wrote
+        ``exit_reason='reconciliation_mismatch'`` with NULL exit_price/
+        pnl — wiping the realized-P&L attribution from
+        ``daily_summaries``.
+
+        Fix: capture ``order.id`` from ``submit_order`` and write it
+        back via ``_persist_emergency_stop_id``.
+        """
+        conn = sqlite3.connect(tmp_db_path)
+        position_id = _insert_db_position(conn, "PLTR", qty=100, entry_price=10.0)
+        conn.close()
+
+        pos = _alpaca_position("PLTR", qty=100, avg_entry_price=10.0)
+        gw = self._make_gateway(positions=[pos], orders=[])
+        # Mock the broker's submit_order to return an order with an id —
+        # the real Alpaca SDK does this; the prior mock setup was lenient
+        # enough that the dropped return value went unnoticed.
+        submitted_order = MagicMock()
+        submitted_order.id = "broker-stop-id-xyz"
+        gw.client.submit_order = MagicMock(return_value=submitted_order)
+
+        mid_session = datetime(2026, 5, 11, 11, 0, tzinfo=ET)
+        recovery = _make_recovery(
+            gw, tmp_db_path, mock_notifier, now=mid_session,
+        )
+        result = await recovery.recover()
+        assert "PLTR" in result.stops_placed
+
+        conn = sqlite3.connect(tmp_db_path)
+        row = conn.execute(
+            "SELECT alpaca_stop_order_id, stop_price FROM positions "
+            "WHERE id = ?",
+            (position_id,),
+        ).fetchone()
+        conn.close()
+        assert row is not None
+        assert row[0] == "broker-stop-id-xyz", (
+            "emergency stop's order_id must be persisted so "
+            "_check_order_statuses can poll for fills cleanly"
+        )
+        # 2% default stop_loss_pct applied to entry $10.00.
+        assert row[1] == pytest.approx(9.80, abs=1e-6)
+
+    @pytest.mark.asyncio
+    async def test_emergency_stop_does_not_clobber_existing_stop_price(
+        self, tmp_db_path: str, mock_notifier,
+    ) -> None:
+        """When a strategy already set a custom stop_price on the row,
+        the emergency-stop writeback must preserve it (COALESCE).
+
+        Recovery's stop price comes from a generic default-pct config and
+        is intentionally a fallback. If a strategy chose a tighter or
+        looser stop, that intent must survive the writeback — otherwise
+        every emergency-stop placement would silently retune the row to
+        the default.
+        """
+        conn = sqlite3.connect(tmp_db_path)
+        cur = conn.execute(
+            """INSERT INTO positions
+               (ticker, exchange, currency, quantity, entry_price,
+                entry_time, status, stop_price, hold_type, phase,
+                strategy_id)
+               VALUES (?,?,?,?,?,?,?,?,?,?,?)""",
+            (
+                "PLTR", "NASDAQ", "USD", 100, 10.0,
+                datetime.now(ET).isoformat(),
+                "POSITION_OPEN", 9.50, "swing", 1, "mr",
+            ),
+        )
+        position_id = cur.lastrowid
+        conn.commit()
+        conn.close()
+
+        pos = _alpaca_position("PLTR", qty=100, avg_entry_price=10.0)
+        gw = self._make_gateway(positions=[pos], orders=[])
+        submitted_order = MagicMock()
+        submitted_order.id = "broker-stop-id-xyz"
+        gw.client.submit_order = MagicMock(return_value=submitted_order)
+
+        mid_session = datetime(2026, 5, 11, 11, 0, tzinfo=ET)
+        recovery = _make_recovery(
+            gw, tmp_db_path, mock_notifier, now=mid_session,
+        )
+        await recovery.recover()
+
+        conn = sqlite3.connect(tmp_db_path)
+        row = conn.execute(
+            "SELECT alpaca_stop_order_id, stop_price FROM positions "
+            "WHERE id = ?",
+            (position_id,),
+        ).fetchone()
+        conn.close()
+        assert row[0] == "broker-stop-id-xyz"
+        assert row[1] == pytest.approx(9.50, abs=1e-6), (
+            "strategy-set stop_price 9.50 must survive; recovery's "
+            "default 9.80 must not overwrite"
+        )
+
+    @pytest.mark.asyncio
+    async def test_emergency_stop_persistence_handles_missing_db_row(
+        self, tmp_db_path: str, mock_notifier,
+    ) -> None:
+        """If the broker has a position with no DB row, recovery first
+        creates a row via ``_create_db_position`` and then places a
+        stop. The persistence writeback must succeed against that
+        freshly-created row.
+        """
+        pos = _alpaca_position("PLTR", qty=100, avg_entry_price=10.0)
+        gw = self._make_gateway(positions=[pos], orders=[])
+        submitted_order = MagicMock()
+        submitted_order.id = "broker-stop-id-xyz"
+        gw.client.submit_order = MagicMock(return_value=submitted_order)
+
+        mid_session = datetime(2026, 5, 11, 11, 0, tzinfo=ET)
+        recovery = _make_recovery(
+            gw, tmp_db_path, mock_notifier, now=mid_session,
+        )
+        result = await recovery.recover()
+        assert "PLTR" in result.positions_created
+        assert "PLTR" in result.stops_placed
+
+        conn = sqlite3.connect(tmp_db_path)
+        row = conn.execute(
+            "SELECT alpaca_stop_order_id FROM positions WHERE ticker='PLTR'"
+        ).fetchone()
+        conn.close()
+        assert row is not None and row[0] == "broker-stop-id-xyz"
+
+    @pytest.mark.asyncio
     async def test_stop_verify_skipped_at_close_of_day_tick(
         self, tmp_db_path: str, mock_notifier
     ) -> None:


### PR DESCRIPTION
## Summary

- `recovery._place_emergency_stop` submitted a stop order to Alpaca and discarded the returned order_id, leaving `positions.alpaca_stop_order_id` NULL forever
- Every subsequent tick saw the position as naked, accumulated broker-side stops the bot had no record of, and when one filled, recovery wrote \`exit_reason='reconciliation_mismatch'\` with NULL exit_price/pnl — wiping realized-P&L attribution
- Fix: capture \`order.id\` and write back via new \`_persist_emergency_stop_id\` helper

## Observed regression

**2026-05-15:** SPY/QQQ overnight_drift and XLB mean_reversion exits all booked with NULL pnl despite the broker recording fills correctly. Equity moved -\$4.01 (XLB -\$0.70, SPY -\$0.98, QQQ -\$1.04 = -\$2.72 realized + mark-to-market drift) but \`daily_summaries\` reported \$0 net.

Root cause traced via GHA bot run [25920477881](https://github.com/alex5imon/ai-broker/actions/runs/25920477881) — the 09:30 ET tick after market open. \`recovery._verify_stop_orders\` placed emergency stops for AAPL/QQQ/SPY/XLB/XLI but never persisted any of the order IDs.

\`\`\`
[INFO] recovery: Emergency stop placed for AAPL: sell 0.082800 @ stop 292.33
[INFO] recovery: Emergency stop placed for QQQ: sell 0.096700 @ stop 706.07
...
[WARNING] stop_reconciler: 5 naked position(s) of 5 checked   ← still naked!
\`\`\`

Confirmed in DB snapshot: all 5 open positions show \`alpaca_stop_order_id IS NULL\`.

## Fix details

- Capture \`order.id\` from \`submit_order\` (line 424)
- Write back via new helper \`_persist_emergency_stop_id\` keyed on ticker + status NOT IN ('CLOSED','ENTRY_FAILED') + \`alpaca_stop_order_id IS NULL\`
- Refuses to mass-update when multiple non-terminal rows for a ticker exist — logs a warning instead so a schema accident never spreads a single order_id across positions
- \`stop_price\` written only when NULL (COALESCE) so a strategy-set stop survives recovery's default-pct fallback

## Test plan

- [x] New test: \`test_emergency_stop_persists_order_id_to_db\` — basic writeback
- [x] New test: \`test_emergency_stop_does_not_clobber_existing_stop_price\` — COALESCE preserves strategy-set stop
- [x] New test: \`test_emergency_stop_persistence_handles_missing_db_row\` — works against rows created in this same recover() pass via \`_create_db_position\`
- [x] All 34 existing recovery tests still pass
- [x] Adjacent test files (order_manager_lifecycle, order_state_machine, V11 migration) all pass — 105 total

## Follow-up

PR (b) follows: protect CLOSING / STOP_ACTIVE rows from the reconciliation_mismatch overwrite race that clobbers proper exit attribution on the next tick. Independent fix; this PR alone stops the bleeding.