### PR TITLE
fix(recovery): defer exit-in-flight rows instead of writing reconciliation_mismatch

### DIFF
--- a/trading_bot/gateway/recovery.py
+++ b/trading_bot/gateway/recovery.py
@@ -36,6 +36,25 @@ _DEFAULT_EOD_FLATTEN_TIME: str = "15:55"
 # branch. Override via config.recovery.fresh_entry_grace_minutes.
 _DEFAULT_FRESH_ENTRY_GRACE_MINUTES: int = 10
 
+# Position statuses that indicate an exit order is already on the
+# broker book. When Alpaca shows no position for a ticker in one of
+# these states AND the corresponding alpaca_*_order_id is set, defer
+# the close to `_check_order_statuses` — it will poll the order_id,
+# detect the fill, and write the real exit_price/exit_reason/pnl onto
+# the trades row. Without this defer, recovery races
+# `_check_order_statuses` on the same tick and clobbers the proper
+# exit attribution with 'reconciliation_mismatch' + NULL pnl
+# (regression observed 2026-05-15 — see PR #140).
+_EXIT_IN_FLIGHT_STATUSES: frozenset[str] = frozenset(
+    {"CLOSING", "STOP_ACTIVE", "TRAILING_ACTIVE"}
+)
+_EXIT_ORDER_ID_COLUMNS: tuple[str, ...] = (
+    "alpaca_exit_order_id",
+    "alpaca_stop_order_id",
+    "alpaca_trail_order_id",
+    "alpaca_target_order_id",
+)
+
 
 @dataclass
 class RecoveryResult:
@@ -48,6 +67,13 @@ class RecoveryResult:
     positions_created: list[str] = field(default_factory=list)
     positions_closed_mismatch: list[str] = field(default_factory=list)
     positions_deferred_fresh: list[str] = field(default_factory=list)
+    # Rows whose status indicates an exit order is already on the broker
+    # book (CLOSING, STOP_ACTIVE, TRAILING_ACTIVE) and that order_id is
+    # non-NULL. Deferring lets the next tick's `_check_order_statuses`
+    # poll the order and write the real exit_price/exit_reason/pnl
+    # rather than recovery clobbering the trades row with
+    # 'reconciliation_mismatch' + NULL pnl.
+    positions_deferred_exit_inflight: list[str] = field(default_factory=list)
     quantities_updated: list[str] = field(default_factory=list)
     stops_placed: list[str] = field(default_factory=list)
     stale_orders_cancelled: list[str] = field(default_factory=list)
@@ -87,6 +113,11 @@ class RecoveryResult:
             lines.append(
                 f"Deferred fresh DB-only positions (Alpaca lag): "
                 f"{', '.join(self.positions_deferred_fresh)}"
+            )
+        if self.positions_deferred_exit_inflight:
+            lines.append(
+                f"Deferred DB-only positions (exit in flight): "
+                f"{', '.join(self.positions_deferred_exit_inflight)}"
             )
         if self.quantities_updated:
             lines.append(f"Updated quantities: {', '.join(self.quantities_updated)}")
@@ -279,6 +310,37 @@ class StateRecovery:
                 )
                 result.positions_deferred_fresh.append(ticker)
                 continue
+            # Exit-in-flight defer: if the DB row indicates an exit
+            # order is on the broker (CLOSING / STOP_ACTIVE /
+            # TRAILING_ACTIVE) and has a non-NULL order_id to poll,
+            # defer the close. `_check_order_statuses` (later in the
+            # same tick — see main.tick step 6) will pull the filled
+            # order from Alpaca and write the real
+            # exit_price/exit_reason/pnl onto the trades row.
+            #
+            # Without this defer, recovery wins the race and writes
+            # `exit_reason='reconciliation_mismatch'` with NULL pnl,
+            # silently dropping the realized P&L from
+            # `daily_summaries`. Observed 2026-05-15 — see PR #140.
+            status_val: str = str(db_row.get("status", "") or "")
+            if status_val in _EXIT_IN_FLIGHT_STATUSES:
+                tracked_oid: str | None = None
+                tracked_col: str | None = None
+                for col in _EXIT_ORDER_ID_COLUMNS:
+                    val = db_row.get(col)
+                    if val:
+                        tracked_oid = str(val)
+                        tracked_col = col
+                        break
+                if tracked_oid is not None:
+                    logger.info(
+                        "DB has position %s (status=%s, %s=%s) not on "
+                        "Alpaca — deferring to order-status poll for "
+                        "exit attribution",
+                        ticker, status_val, tracked_col, tracked_oid,
+                    )
+                    result.positions_deferred_exit_inflight.append(ticker)
+                    continue
             logger.warning(
                 "DB has position %s not in Alpaca - marking CLOSED",
                 ticker,

--- a/trading_bot/tests/test_state_recovery.py
+++ b/trading_bot/tests/test_state_recovery.py
@@ -239,6 +239,163 @@ class TestStateRecovery:
         assert "PLTR" not in result.positions_deferred_fresh
 
     @pytest.mark.asyncio
+    async def test_db_position_closing_with_exit_order_deferred(
+        self, tmp_db_path: str, mock_notifier
+    ) -> None:
+        """Regression for 2026-05-15 reconciliation_mismatch overwrite.
+
+        Sequence observed in production:
+          1. Tick 1 (09:30 ET): strategy fires market exit → submits to
+             Alpaca, sets `positions.status='CLOSING'` and writes the
+             returned order_id to `alpaca_exit_order_id`. Order fills
+             within the same tick.
+          2. Tick 2 (09:35 ET): recovery loads positions where status
+             NOT IN ('CLOSED','ENTRY_FAILED'), sees CLOSING row whose
+             ticker is no longer on Alpaca, and writes
+             `exit_reason='reconciliation_mismatch'` with NULL
+             exit_price/pnl — clobbering the proper exit attribution
+             the next-step `_check_order_statuses` was about to write.
+
+        Fix: when status indicates an exit-in-flight AND the row has
+        a non-NULL alpaca_*_order_id to poll, defer the close to
+        `_check_order_statuses` so it can write the real exit row.
+        """
+        conn = sqlite3.connect(tmp_db_path)
+        conn.execute(
+            """INSERT INTO positions
+               (ticker, exchange, currency, quantity, entry_price,
+                entry_time, status, hold_type, phase, strategy_id,
+                alpaca_exit_order_id)
+               VALUES (?,?,?,?,?,?,?,?,?,?,?)""",
+            (
+                "SPY", "NASDAQ", "USD", 1, 700.0,
+                (datetime.now(ET) - timedelta(hours=1)).isoformat(),
+                "CLOSING", "swing", 1, "overnight_drift",
+                "broker-exit-order-id",
+            ),
+        )
+        conn.commit()
+        conn.close()
+
+        gw = self._make_gateway(positions=[])
+        recovery = _make_recovery(
+            gw, tmp_db_path, mock_notifier,
+            now=datetime.now(ET) + timedelta(hours=1),
+        )
+        result = await recovery.recover()
+
+        assert "SPY" in result.positions_deferred_exit_inflight, (
+            "CLOSING + exit_order_id must defer to _check_order_statuses "
+            "instead of writing reconciliation_mismatch"
+        )
+        assert "SPY" not in result.positions_closed_mismatch
+
+        conn = sqlite3.connect(tmp_db_path)
+        row = conn.execute(
+            "SELECT status FROM positions WHERE ticker='SPY'"
+        ).fetchone()
+        conn.close()
+        assert row[0] == "CLOSING", (
+            "deferred row must remain CLOSING so the next tick's "
+            "_check_order_statuses can transition it to CLOSED with "
+            "real exit_price/pnl"
+        )
+
+    @pytest.mark.asyncio
+    async def test_db_position_stop_active_with_stop_order_deferred(
+        self, tmp_db_path: str, mock_notifier
+    ) -> None:
+        """STOP_ACTIVE with a stop_order_id: a broker-side stop almost
+        certainly filled when Alpaca no longer shows the position. Defer
+        so `_check_order_statuses` writes `exit_reason='stop_loss'` with
+        the real exit_price, not reconciliation_mismatch with NULL pnl.
+        """
+        conn = sqlite3.connect(tmp_db_path)
+        conn.execute(
+            """INSERT INTO positions
+               (ticker, exchange, currency, quantity, entry_price,
+                entry_time, status, hold_type, phase, strategy_id,
+                alpaca_stop_order_id)
+               VALUES (?,?,?,?,?,?,?,?,?,?,?)""",
+            (
+                "AAPL", "NASDAQ", "USD", 1, 200.0,
+                (datetime.now(ET) - timedelta(hours=2)).isoformat(),
+                "STOP_ACTIVE", "swing", 1, "mean_reversion",
+                "broker-stop-order-id",
+            ),
+        )
+        conn.commit()
+        conn.close()
+
+        gw = self._make_gateway(positions=[])
+        recovery = _make_recovery(
+            gw, tmp_db_path, mock_notifier,
+            now=datetime.now(ET) + timedelta(hours=1),
+        )
+        result = await recovery.recover()
+
+        assert "AAPL" in result.positions_deferred_exit_inflight
+        assert "AAPL" not in result.positions_closed_mismatch
+
+    @pytest.mark.asyncio
+    async def test_db_position_exit_inflight_without_order_id_falls_through(
+        self, tmp_db_path: str, mock_notifier
+    ) -> None:
+        """Defence-in-depth: a row in an exit-in-flight status but with
+        NULL order_id can't be reconciled by `_check_order_statuses`
+        (no order to poll). Fall through to reconciliation_mismatch
+        rather than deferring indefinitely. Pre-PR (a) emergency stops
+        would land in this shape; post-PR (a) they shouldn't.
+        """
+        conn = sqlite3.connect(tmp_db_path)
+        conn.execute(
+            """INSERT INTO positions
+               (ticker, exchange, currency, quantity, entry_price,
+                entry_time, status, hold_type, phase, strategy_id)
+               VALUES (?,?,?,?,?,?,?,?,?,?)""",
+            (
+                "MSFT", "NASDAQ", "USD", 1, 400.0,
+                (datetime.now(ET) - timedelta(hours=1)).isoformat(),
+                "STOP_ACTIVE", "swing", 1, "mean_reversion",
+            ),
+        )
+        conn.commit()
+        conn.close()
+
+        gw = self._make_gateway(positions=[])
+        recovery = _make_recovery(
+            gw, tmp_db_path, mock_notifier,
+            now=datetime.now(ET) + timedelta(hours=1),
+        )
+        result = await recovery.recover()
+
+        assert "MSFT" not in result.positions_deferred_exit_inflight, (
+            "no order_id means nothing to poll — must not defer"
+        )
+        assert "MSFT" in result.positions_closed_mismatch
+
+    @pytest.mark.asyncio
+    async def test_db_position_open_status_not_deferred(
+        self, tmp_db_path: str, mock_notifier
+    ) -> None:
+        """Sanity check: POSITION_OPEN (not exit-in-flight) still
+        reconciles to mismatch when the broker doesn't show the
+        position. The defer only applies to exit-in-flight statuses.
+        """
+        conn = sqlite3.connect(tmp_db_path)
+        _insert_db_position(conn, "GOOGL")
+        conn.close()
+
+        gw = self._make_gateway(positions=[])
+        recovery = _make_recovery(
+            gw, tmp_db_path, mock_notifier,
+            now=datetime.now(ET) + timedelta(hours=1),
+        )
+        result = await recovery.recover()
+        assert "GOOGL" in result.positions_closed_mismatch
+        assert "GOOGL" not in result.positions_deferred_exit_inflight
+
+    @pytest.mark.asyncio
     async def test_quantity_mismatch_updated(
         self, tmp_db_path: str, mock_notifier
     ) -> None:


### PR DESCRIPTION
## Summary

- \`_reconcile\` wrote \`exit_reason='reconciliation_mismatch'\` + NULL pnl whenever a DB row was missing from Alpaca, even when the row's status indicated an exit order was already in flight at the broker
- That clobbered the proper exit attribution the next step (\`_check_order_statuses\`) was about to write, dropping realized P&L from \`daily_summaries\`
- Fix: defer rows in \`{CLOSING, STOP_ACTIVE, TRAILING_ACTIVE}\` with non-NULL \`alpaca_*_order_id\` to \`_check_order_statuses\`

## Observed regression

**2026-05-15:** SPY/QQQ overnight_drift + XLB mean_reversion exits all booked with NULL pnl on the trades row, even though the strategy market exits succeeded at the broker and \`virtual_portfolio\` recorded the P&L.

\`\`\`
13:30:38 [INFO] order_manager: Strategy exit submitted: SELL 0.7093 XLB @ MARKET (reason=stop_loss)
13:30:38 [INFO] virtual_portfolio: [mean_reversion] Exit recorded: 0.7093 shares @ $51.02, P&L=$-0.70
13:30:38 [INFO] order_manager: Strategy exit submitted: SELL 0.1362 SPY @ MARKET (reason=overnight_exit)
13:30:38 [INFO] virtual_portfolio: [overnight_drift] Exit recorded: 0.1362 shares @ $741.16, P&L=$-0.98
13:30:40 [INFO] order_manager: Strategy exit submitted: SELL 0.0967 QQQ @ MARKET (reason=overnight_exit)
13:30:40 [INFO] virtual_portfolio: [overnight_drift] Exit recorded: 0.0967 shares @ $709.74, P&L=$-1.04
\`\`\`

But the trades-table snapshot from later in the day:

\`\`\`
178|XLB|...|2026-05-15T09:35:33|reconciliation_mismatch||...
181|SPY|...|2026-05-15T09:35:33|reconciliation_mismatch||...
182|QQQ|...|2026-05-15T09:35:33|reconciliation_mismatch||...
\`\`\`

Equity moved correctly (-\$4.01 reflecting -\$2.72 realized + mark-to-market drift on new entries), but \`daily_summaries\` reported \$0 net.

## Root cause

[trading_bot/main.py:287](trading_bot/main.py:287) runs \`state_recovery.recover()\` (step 4) **before** \`order_manager._check_order_statuses()\` (step 6). When tick 1 submitted the exit and tick 2 ran:

1. Recovery saw \`status=CLOSING\` but ticker no longer on Alpaca → \`_close_db_position(\"reconciliation_mismatch\")\`
2. \`_check_order_statuses\` then polled the exit order_id, saw \"filled\", tried to write the real exit row — but recovery had already stamped reconciliation_mismatch first

## Fix

In \`_reconcile\`, before falling through to mismatch:

\`\`\`python
if status_val in _EXIT_IN_FLIGHT_STATUSES:  # CLOSING/STOP_ACTIVE/TRAILING_ACTIVE
    tracked_oid = ... # any of alpaca_exit_order_id, alpaca_stop_order_id, ...
    if tracked_oid is not None:
        result.positions_deferred_exit_inflight.append(ticker)
        continue
\`\`\`

The next-step \`_check_order_statuses\` polls the order_id and writes the proper exit_price/exit_reason/pnl. If the order is somehow gone from Alpaca too, \`_check_order_statuses\` clears the order_id and the next tick's recovery sees status-with-NULL-order_id → falls through to mismatch as before. Self-healing.

## Test plan

- [x] New test: \`test_db_position_closing_with_exit_order_deferred\` — CLOSING + exit_order_id defers
- [x] New test: \`test_db_position_stop_active_with_stop_order_deferred\` — STOP_ACTIVE + stop_order_id defers
- [x] New test: \`test_db_position_exit_inflight_without_order_id_falls_through\` — defensive fallback when no order_id (without PR #139 nothing would heal)
- [x] New test: \`test_db_position_open_status_not_deferred\` — POSITION_OPEN still closes as mismatch (regression check on existing behavior)
- [x] All 31 existing recovery tests still pass (35 total with new ones)
- [x] Adjacent test files all pass — 106 total

## Companion PR

PR #139 (emergency-stop order_id persistence) handles the upstream case where order_ids never made it onto the row in the first place. Together they close the class of bugs where a real broker fill ends up with NULL exit attribution.