### PR TITLE
fix(exit): persist exit_reason across ticks; write pnl_usd in close

### DIFF
--- a/trading_bot/constants.py
+++ b/trading_bot/constants.py
@@ -196,4 +196,4 @@ def ticker_market(ticker: str) -> Market:
 # Schema version — must match the DB migration target
 # ---------------------------------------------------------------------------
 
-SCHEMA_VERSION: int = 13
+SCHEMA_VERSION: int = 14

--- a/trading_bot/db/migrations.py
+++ b/trading_bot/db/migrations.py
@@ -455,6 +455,62 @@ def _migration_v13(conn: sqlite3.Connection) -> None:
     logger.info("Applied migration V13: idx_trades_ticker_entry_time")
 
 
+def _migration_v14(conn: sqlite3.Connection) -> None:
+    """V14: add ``positions.exit_reason`` + backfill legacy NULL ``trades.pnl_usd``.
+
+    Two related correctness fixes uncovered 2026-05-18:
+
+    1. **``positions.exit_reason``** — pre-V14 the strategy-supplied
+       exit reason (e.g. ``overnight_exit``) lived only on the
+       in-memory ``_ActiveOrder``. Because each tick rebuilds
+       ``_active_orders`` from ``positions``, the reason was lost
+       across the tick boundary that separates ``place_exit`` from the
+       eventual fill — fills then defaulted to ``strategy_exit`` in
+       ``trades``. Adding a persisted column lets the next tick
+       rehydrate the real reason. The companion code change in
+       ``OrderManager`` writes/clears this column alongside
+       ``alpaca_exit_order_id`` and reads it during hydration.
+
+    2. **``trades.pnl_usd`` backfill** — ``_close_position`` wrote
+       ``gross_pnl`` / ``net_pnl`` but forgot ``pnl_usd``, so every
+       live exit produced a row with ``pnl_usd IS NULL``. Downstream
+       readers (``performance.calculate_daily_metrics``,
+       ``repo.get_daily_pnl_usd`` powering the daily-loss circuit
+       breaker, ``main._save_daily_summary``) all key off ``pnl_usd``
+       and silently classified those exits as neither win nor loss
+       (and the daily-loss limit saw $0.00 P&L regardless of actual
+       drawdown). The companion code change writes ``pnl_usd`` going
+       forward. This backfill heals the rows the bug already produced
+       — bounded to ``exit_time IS NOT NULL`` so it can't accidentally
+       overwrite open positions, and to ``pnl_usd IS NULL`` so it's a
+       no-op on rerun.
+
+    Idempotent. Fresh installs via ``_SCHEMA_SQL`` already have the
+    column; the backfill UPDATE matches zero rows on a clean DB.
+    """
+    rows = conn.execute("PRAGMA table_info(positions)").fetchall()
+    if not any(r[1] == "exit_reason" for r in rows):
+        conn.execute(
+            "ALTER TABLE positions ADD COLUMN exit_reason TEXT"
+        )
+
+    conn.execute(
+        "UPDATE trades SET pnl_usd = net_pnl "
+        "WHERE pnl_usd IS NULL "
+        "  AND net_pnl IS NOT NULL "
+        "  AND exit_time IS NOT NULL"
+    )
+
+    conn.execute(
+        "INSERT OR REPLACE INTO schema_version (version, description) "
+        "VALUES (14, "
+        "'V14 schema - positions.exit_reason + trades.pnl_usd backfill')"
+    )
+    logger.info(
+        "Applied migration V14: positions.exit_reason + trades.pnl_usd backfill"
+    )
+
+
 _MIGRATIONS: list[tuple[int, str, MigrationFn]] = [
     (4, "V4 schema - multi-market adaptive trading bot", _migration_v4),
     (5, "V5 schema - multi-strategy Alpaca trading bot", _migration_v5),
@@ -469,6 +525,8 @@ _MIGRATIONS: list[tuple[int, str, MigrationFn]] = [
      _migration_v12),
     (13, "V13 schema - idx_trades_ticker_entry_time for hydration JOIN",
      _migration_v13),
+    (14, "V14 schema - positions.exit_reason + trades.pnl_usd backfill",
+     _migration_v14),
 ]
 
 

--- a/trading_bot/db/schema.py
+++ b/trading_bot/db/schema.py
@@ -80,6 +80,14 @@ CREATE TABLE IF NOT EXISTS positions (
     -- stateless tick can rehydrate the pending exit instead of
     -- re-evaluating and double-submitting. Added in V11.
     alpaca_exit_order_id TEXT,
+    -- The strategy-supplied reason for the in-flight exit
+    -- (``overnight_exit``, ``stop_loss``, etc.). Set in lockstep with
+    -- ``alpaca_exit_order_id``. Pre-V14 this lived only on the
+    -- in-memory ``_ActiveOrder`` and was lost across the tick that
+    -- placed the exit and the tick that observed the fill — so every
+    -- strategy-driven exit landed in ``trades`` as ``strategy_exit``
+    -- regardless of the real reason. Added in V14.
+    exit_reason     TEXT,
     highest_price   REAL,
     strategy_id     TEXT NOT NULL,
     updated_at      TEXT NOT NULL DEFAULT (datetime('now'))

--- a/trading_bot/execution/order_manager.py
+++ b/trading_bot/execution/order_manager.py
@@ -291,6 +291,18 @@ class OrderManager:
                 if "alpaca_exit_order_id" in row_keys
                 else None
             )
+            # exit_reason added in V14. Pre-V14 the in-memory
+            # ``_ActiveOrder.exit_reason`` was set in ``place_exit``
+            # but never persisted, so the fill-detection tick rebuilt
+            # the dict from the DB with ``exit_reason=None`` and the
+            # fallback ``"strategy_exit"`` won (regression observed
+            # 2026-05-18: overnight_drift exits landed as
+            # ``strategy_exit`` instead of ``overnight_exit``).
+            exit_reason_persisted: str | None = (
+                row["exit_reason"]
+                if "exit_reason" in row_keys
+                else None
+            )
 
             db_trade_id_raw = row["db_trade_id"]
             db_trade_id: int | None = (
@@ -306,6 +318,7 @@ class OrderManager:
                 alpaca_target_order_id=row["alpaca_target_order_id"],
                 alpaca_trail_order_id=row["alpaca_trail_order_id"],
                 alpaca_exit_order_id=exit_oid,
+                exit_reason=exit_reason_persisted,
                 status=status,
                 entry_shares=float(row["quantity"] or 0),
                 filled_shares=float(row["quantity"] or 0)
@@ -689,8 +702,15 @@ class OrderManager:
                         # so the next tick re-evaluates the exit
                         # condition cleanly instead of seeing a stale
                         # alpaca_exit_order_id and refusing to act.
+                        # V14+: clear the persisted ``exit_reason`` in
+                        # the same step or the next ``place_exit`` would
+                        # inherit the old reason if it raced ahead of
+                        # the new assignment.
                         self._update_position_field(
                             trade_id, "alpaca_exit_order_id", None,
+                        )
+                        self._update_position_field(
+                            trade_id, "exit_reason", None,
                         )
                         self._update_position_status(
                             trade_id, PositionStatus.STOP_ACTIVE,
@@ -1185,8 +1205,14 @@ class OrderManager:
                 # row still STOP_ACTIVE with the order id
                 # set, which the next tick's rehydration handles
                 # gracefully. V11+: column lives on positions table.
+                # Persist ``exit_reason`` in the same step (V14+) so the
+                # fill-detection tick can rehydrate it instead of
+                # falling back to ``"strategy_exit"``.
                 self._update_position_field(
                     matching_trade_id, "alpaca_exit_order_id", order_id,
+                )
+                self._update_position_field(
+                    matching_trade_id, "exit_reason", reason,
                 )
                 self._update_position_status(
                     matching_trade_id, PositionStatus.CLOSING,
@@ -1321,8 +1347,14 @@ class OrderManager:
                     matching_active.exit_reason = reason
                 # V11+: persist exit order_id before status flip so a
                 # crash between the two writes is recoverable from DB.
+                # V14+: persist ``exit_reason`` in the same step so the
+                # fill-detection tick uses the real reason instead of
+                # the ``"strategy_exit"`` fallback.
                 self._update_position_field(
                     matching_trade_id, "alpaca_exit_order_id", order_id,
+                )
+                self._update_position_field(
+                    matching_trade_id, "exit_reason", reason,
                 )
                 self._update_position_status(
                     matching_trade_id, PositionStatus.CLOSING,
@@ -1818,14 +1850,26 @@ class OrderManager:
         else:
             try:
                 with contextlib.closing(sqlite3.connect(self._db_path)) as conn:
+                    # ``pnl_usd`` must be written in lockstep with
+                    # ``net_pnl`` — downstream readers
+                    # (``performance.calculate_daily_metrics``,
+                    # ``repo.get_daily_pnl_usd``, the daily-loss
+                    # circuit breaker, ``_save_daily_summary``) key off
+                    # ``pnl_usd`` and silently treat NULL as zero,
+                    # which classified every live exit as neither win
+                    # nor loss and zeroed the daily-loss circuit's view
+                    # of realised P&L. The bot is commission-free so
+                    # gross/net/pnl_usd are equal at close time.
                     cur = conn.execute(
                         "UPDATE trades SET exit_time = ?, exit_price = ?, "
-                        "exit_reason = ?, gross_pnl = ?, net_pnl = ? "
+                        "exit_reason = ?, gross_pnl = ?, net_pnl = ?, "
+                        "pnl_usd = ? "
                         "WHERE id = ?",
                         (
                             now_str,
                             exit_price,
                             exit_reason,
+                            gross_pnl,
                             gross_pnl,
                             gross_pnl,
                             db_trade_id,
@@ -1999,7 +2043,7 @@ class OrderManager:
         for col in (
             "status", "alpaca_order_id", "alpaca_stop_order_id",
             "alpaca_target_order_id", "alpaca_trail_order_id",
-            "alpaca_exit_order_id", "oca_group",
+            "alpaca_exit_order_id", "exit_reason", "oca_group",
             "quantity", "entry_price", "stop_price", "target_price",
             "trailing_active", "trailing_distance", "highest_price",
         )

--- a/trading_bot/tests/test_exit_persistence_v14.py
+++ b/trading_bot/tests/test_exit_persistence_v14.py
@@ -1,0 +1,253 @@
+"""V14 cross-tick exit-reason persistence + ``_close_position`` writes ``pnl_usd``.
+
+Companion to V11 (alpaca_exit_order_id). Pre-V14 the strategy-supplied
+``reason`` for an in-flight strategy exit lived only on the in-memory
+``_ActiveOrder.exit_reason``. Because each stateless tick rebuilds
+``_active_orders`` from ``positions``, the reason vaporized between
+the tick that placed the exit and the tick that observed the fill —
+the fill-detection branch then defaulted to ``"strategy_exit"``.
+
+Regression observed 2026-05-18: both SPY and QQQ overnight_drift
+exits (held over Friday's close) wrote ``exit_reason='strategy_exit'``
+into trades instead of the correct ``'overnight_exit'``.
+
+Tests pin:
+
+1. ``place_exit`` persists ``exit_reason`` to the positions row.
+2. ``_hydrate_active_orders`` reads it back into ``_ActiveOrder``.
+3. Rollback (cancel/expire/reject) clears the persisted column.
+4. ``_close_position`` writes ``pnl_usd`` alongside ``net_pnl`` —
+   downstream daily-loss / daily-summary readers depend on
+   ``pnl_usd`` and silently treat NULL as zero.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from unittest.mock import MagicMock
+
+import pytest
+
+from trading_bot.constants import PositionStatus, TZ_EASTERN
+from trading_bot.execution.order_manager import (
+    EntryDecision,
+    OrderManager,
+    _ActiveOrder,
+)
+
+pytestmark = pytest.mark.critical
+
+ET = TZ_EASTERN
+
+
+def _make_om(config, db_path: str, notifier) -> OrderManager:
+    gw = MagicMock()
+    gw.client = MagicMock()
+    return OrderManager(gw, config, notifier, db_path)
+
+
+def _entry(ticker: str = "SPY") -> EntryDecision:
+    return EntryDecision(
+        ticker=ticker,
+        exchange="US",
+        side="BUY",
+        shares=10,
+        limit_price=100.0,
+        stop_price=98.0,
+        target_price=104.0,
+        hold_type="intraday",
+        sector="Information Technology",
+        phase=1,
+        sentiment_score=0.2,
+        signals="test",
+        currency="USD",
+        strategy_id="overnight_drift",
+        trail_pct=None,
+        trail_activation_price=None,
+    )
+
+
+def _seed_open_position(om: OrderManager, ticker: str = "SPY") -> int:
+    trade_id = om._create_position_record(_entry(ticker))
+    om._active_orders[trade_id] = _ActiveOrder(
+        trade_id=trade_id,
+        ticker=ticker,
+        exchange="US",
+        alpaca_entry_order_id="entry-1",
+        alpaca_stop_order_id="stop-1",
+        alpaca_target_order_id="target-1",
+        status=PositionStatus.STOP_ACTIVE,
+        entry_shares=10.0,
+        filled_shares=10.0,
+        entry_price=100.0,
+        stop_price=98.0,
+        target_price=104.0,
+        hold_type="intraday",
+        strategy_id="overnight_drift",
+        db_trade_id=trade_id,
+    )
+    om._update_position_status(trade_id, PositionStatus.STOP_ACTIVE)
+    return trade_id
+
+
+def _stub_alpaca_exit_submit(om: OrderManager, exit_id: str = "exit-1") -> None:
+    om._gw.client.get_orders = MagicMock(return_value=[])
+    om._gw.client.cancel_order_by_id = MagicMock()
+    submitted = MagicMock()
+    submitted.id = exit_id
+    om._gw.client.submit_order = MagicMock(return_value=submitted)
+
+
+@pytest.mark.asyncio
+async def test_place_exit_persists_exit_reason(
+    config, tmp_db_path: str, mock_notifier,
+):
+    """After successful place_exit, positions.exit_reason holds the
+    strategy-supplied reason — not just the in-memory _ActiveOrder.
+    This is the invariant that survives the tick boundary between
+    place_exit and fill detection."""
+    om = _make_om(config, tmp_db_path, mock_notifier)
+    trade_id = _seed_open_position(om)
+    _stub_alpaca_exit_submit(om, exit_id="alp-exit-overnight")
+
+    order_id = await om.place_exit(
+        ticker="SPY", qty=10, reason="overnight_exit",
+    )
+    assert order_id == "alp-exit-overnight"
+    assert om._active_orders[trade_id].exit_reason == "overnight_exit"
+
+    conn = sqlite3.connect(tmp_db_path)
+    try:
+        row = conn.execute(
+            "SELECT exit_reason FROM positions WHERE id = ?",
+            (trade_id,),
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row[0] == "overnight_exit", (
+        "place_exit must persist exit_reason so the fill-detection "
+        "tick can rehydrate it instead of defaulting to strategy_exit"
+    )
+
+
+@pytest.mark.asyncio
+async def test_hydrate_recovers_exit_reason_after_restart(
+    config, tmp_db_path: str, mock_notifier,
+):
+    """Simulate the tick boundary: place_exit on OM_a, then build OM_b
+    against the same DB. The new OM must rehydrate exit_reason."""
+    om_a = _make_om(config, tmp_db_path, mock_notifier)
+    trade_id = _seed_open_position(om_a)
+    _stub_alpaca_exit_submit(om_a, exit_id="alp-exit-rehydrate")
+    await om_a.place_exit(ticker="SPY", qty=10, reason="overnight_exit")
+
+    om_b = _make_om(config, tmp_db_path, mock_notifier)
+    assert om_b._active_orders == {}
+    om_b._hydrate_active_orders()
+
+    active = om_b._active_orders[trade_id]
+    assert active.exit_reason == "overnight_exit", (
+        "hydration must restore the persisted exit_reason so fill "
+        "detection writes 'overnight_exit' to trades, not 'strategy_exit'"
+    )
+    assert active.alpaca_exit_order_id == "alp-exit-rehydrate"
+    assert active.status == PositionStatus.CLOSING
+
+
+@pytest.mark.asyncio
+async def test_cancel_rollback_clears_persisted_exit_reason(
+    config, tmp_db_path: str, mock_notifier,
+):
+    """On cancel/expire/reject the persisted exit_reason must also be
+    cleared, mirroring the alpaca_exit_order_id rollback. Otherwise the
+    next place_exit could race ahead of the new reason assignment and
+    the fill would inherit the stale value."""
+    om = _make_om(config, tmp_db_path, mock_notifier)
+    trade_id = _seed_open_position(om)
+    _stub_alpaca_exit_submit(om, exit_id="alp-exit-to-cancel")
+    await om.place_exit(ticker="SPY", qty=10, reason="overnight_exit")
+
+    conn = sqlite3.connect(tmp_db_path)
+    try:
+        assert conn.execute(
+            "SELECT exit_reason FROM positions WHERE id = ?",
+            (trade_id,),
+        ).fetchone()[0] == "overnight_exit"
+    finally:
+        conn.close()
+
+    canceled = MagicMock()
+    canceled.id = "alp-exit-to-cancel"
+    canceled.status = MagicMock()
+    canceled.status.value = "canceled"
+    canceled.filled_qty = 0
+    canceled.filled_avg_price = 0
+    om._gw.client.get_order_by_id = MagicMock(return_value=canceled)
+    om._gw.client.get_orders = MagicMock(return_value=[])
+
+    await om._check_order_statuses()
+
+    assert om._active_orders[trade_id].exit_reason is None
+    assert om._active_orders[trade_id].alpaca_exit_order_id is None
+    conn = sqlite3.connect(tmp_db_path)
+    try:
+        row = conn.execute(
+            "SELECT exit_reason, alpaca_exit_order_id FROM positions WHERE id = ?",
+            (trade_id,),
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row[0] is None, "DB column must be cleared on rollback"
+    assert row[1] is None
+
+
+@pytest.mark.asyncio
+async def test_close_position_writes_pnl_usd(
+    config, tmp_db_path: str, mock_notifier,
+):
+    """``_close_position`` must populate ``trades.pnl_usd`` in lockstep
+    with ``net_pnl``. Downstream readers (daily-loss circuit breaker,
+    performance.calculate_daily_metrics, _save_daily_summary) all key
+    off ``pnl_usd`` and silently treat NULL as zero. The 2026-05-18
+    regression stamped four trades with pnl_usd=NULL — the daily
+    summary then reported wins=0/losses=0 despite three real losers
+    and one real winner, and the daily-loss circuit saw $0 P&L.
+    """
+    om = _make_om(config, tmp_db_path, mock_notifier)
+    trade_id = _seed_open_position(om)
+    _stub_alpaca_exit_submit(om, exit_id="alp-exit-pnl")
+    await om.place_exit(ticker="SPY", qty=10, reason="overnight_exit")
+
+    # Simulate broker reporting the exit FILLED via _check_order_statuses.
+    filled = MagicMock()
+    filled.id = "alp-exit-pnl"
+    filled.status = MagicMock()
+    filled.status.value = "filled"
+    filled.filled_qty = 10
+    filled.filled_avg_price = 99.50  # 0.50 loss/share × 10 = -5.00
+    om._gw.client.get_order_by_id = MagicMock(return_value=filled)
+    om._gw.client.get_orders = MagicMock(return_value=[])
+
+    await om._check_order_statuses()
+
+    conn = sqlite3.connect(tmp_db_path)
+    try:
+        row = conn.execute(
+            "SELECT net_pnl, pnl_usd, exit_reason "
+            "FROM trades WHERE id = ?",
+            (trade_id,),
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert row is not None, "trades row must exist after close"
+    net_pnl, pnl_usd, exit_reason = row
+    assert net_pnl == pytest.approx(-5.0)
+    assert pnl_usd is not None, (
+        "pnl_usd must be written by _close_position — leaving it NULL "
+        "breaks the daily-loss circuit and daily summaries"
+    )
+    assert pnl_usd == pytest.approx(net_pnl)
+    assert exit_reason == "overnight_exit", (
+        "exit_reason must propagate through the fill-detection path"
+    )

--- a/trading_bot/tests/test_migration_v14_exit_reason_and_pnl_backfill.py
+++ b/trading_bot/tests/test_migration_v14_exit_reason_and_pnl_backfill.py
@@ -1,0 +1,243 @@
+"""Tests for V14: add ``positions.exit_reason`` + backfill ``trades.pnl_usd``.
+
+V14 addresses two correctness bugs uncovered 2026-05-18:
+
+1. ``positions.exit_reason`` — pre-V14 the strategy-supplied exit
+   reason lived only on the in-memory ``_ActiveOrder``; the next tick
+   rehydrated from DB with ``exit_reason=None`` and fell back to
+   ``"strategy_exit"``. Overnight_drift exits then landed as
+   ``strategy_exit`` instead of ``overnight_exit``.
+2. ``trades.pnl_usd`` backfill — ``_close_position`` wrote
+   ``gross_pnl``/``net_pnl`` but forgot ``pnl_usd``. Downstream readers
+   (performance metrics, daily-loss circuit breaker) key off
+   ``pnl_usd`` and treat NULL as zero. This migration heals already-
+   stamped rows; the companion code change writes ``pnl_usd`` going
+   forward.
+
+These tests pin:
+
+A. Fresh DB at SCHEMA_VERSION has both columns + clean trades table.
+B. Pre-V14 DB upgraded by ``_migration_v14`` adds the column and
+   backfills NULL pnl_usd from net_pnl on closed trades.
+C. The backfill is bounded: open trades (exit_time IS NULL) are
+   untouched, and rows that already had pnl_usd are not overwritten.
+D. The migration is idempotent.
+E. SELECT * exposes the new column so OrderManager hydration sees it.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from trading_bot.constants import SCHEMA_VERSION
+from trading_bot.db.migrations import _migration_v14, run_migrations
+
+
+def _column_names(conn: sqlite3.Connection, table: str) -> set[str]:
+    return {row[1] for row in conn.execute(f"PRAGMA table_info({table})")}
+
+
+@pytest.fixture
+def db_at_v13(tmp_path: Path) -> Path:
+    """Build a DB at V13 so we can drive _migration_v14 directly."""
+    db = tmp_path / "v13.db"
+    run_migrations(str(db))
+    conn = sqlite3.connect(str(db))
+    try:
+        conn.execute("DELETE FROM schema_version WHERE version >= 14")
+        if "exit_reason" in _column_names(conn, "positions"):
+            conn.execute("ALTER TABLE positions DROP COLUMN exit_reason")
+        conn.commit()
+    finally:
+        conn.close()
+    return db
+
+
+@pytest.mark.unit
+def test_fresh_db_at_target_version_has_exit_reason_column(tmp_path: Path) -> None:
+    db = tmp_path / "fresh.db"
+    run_migrations(str(db))
+    conn = sqlite3.connect(str(db))
+    try:
+        cols = _column_names(conn, "positions")
+        version = conn.execute(
+            "SELECT MAX(version) FROM schema_version"
+        ).fetchone()[0]
+    finally:
+        conn.close()
+    assert "exit_reason" in cols
+    assert version == SCHEMA_VERSION
+
+
+@pytest.mark.unit
+def test_v14_adds_exit_reason_column_on_existing_db(db_at_v13: Path) -> None:
+    conn = sqlite3.connect(str(db_at_v13))
+    try:
+        conn.execute(
+            "INSERT INTO positions (ticker, exchange, currency, quantity, "
+            "entry_price, entry_time, status, hold_type, phase, strategy_id) "
+            "VALUES ('SPY','NYSE','USD',10,100.0,'2026-05-15T10:00:00-04:00',"
+            "'POSITION_OPEN','intraday',1,'overnight_drift')"
+        )
+        conn.commit()
+        assert "exit_reason" not in _column_names(conn, "positions")
+
+        _migration_v14(conn)
+        conn.commit()
+
+        cols = _column_names(conn, "positions")
+        assert "exit_reason" in cols
+        row = conn.execute(
+            "SELECT ticker, exit_reason FROM positions"
+        ).fetchone()
+        assert row == ("SPY", None), "backfilled rows must default to NULL"
+
+        version = conn.execute(
+            "SELECT MAX(version) FROM schema_version"
+        ).fetchone()[0]
+        assert version == 14
+    finally:
+        conn.close()
+
+
+@pytest.mark.unit
+def test_v14_backfills_null_pnl_usd_from_net_pnl(db_at_v13: Path) -> None:
+    """The 2026-05-18 bug stamped four closed trades with
+    ``net_pnl`` populated but ``pnl_usd IS NULL``. V14 heals them."""
+    conn = sqlite3.connect(str(db_at_v13))
+    try:
+        # Mimic the post-bug shape: closed trade, net_pnl set,
+        # pnl_usd NULL. (Other columns set so the row is valid.)
+        conn.execute(
+            "INSERT INTO trades (ticker, exchange, currency, side, "
+            "entry_time, entry_price, quantity, exit_time, exit_price, "
+            "exit_reason, gross_pnl, net_pnl, pnl_usd, hold_type, phase, "
+            "strategy_id) "
+            "VALUES ('SPY','NYSE','USD','BUY',"
+            "'2026-05-15T15:45:00-04:00',740.22,1,"
+            "'2026-05-18T09:35:00-04:00',739.57,"
+            "'strategy_exit',-0.65,-0.65,NULL,'swing',1,'overnight_drift')"
+        )
+        conn.commit()
+
+        _migration_v14(conn)
+        conn.commit()
+
+        row = conn.execute(
+            "SELECT net_pnl, pnl_usd FROM trades WHERE ticker='SPY'"
+        ).fetchone()
+        assert row[0] == pytest.approx(-0.65)
+        assert row[1] == pytest.approx(-0.65), (
+            "V14 must copy net_pnl into NULL pnl_usd"
+        )
+    finally:
+        conn.close()
+
+
+@pytest.mark.unit
+def test_v14_backfill_skips_open_trades(db_at_v13: Path) -> None:
+    """Open trades (no exit_time) must keep pnl_usd NULL — they have
+    no realized P&L yet, and overwriting from net_pnl (which is also
+    NULL on open rows) would still leave NULL but conceptually we
+    don't touch them at all."""
+    conn = sqlite3.connect(str(db_at_v13))
+    try:
+        conn.execute(
+            "INSERT INTO trades (ticker, exchange, currency, side, "
+            "entry_time, entry_price, quantity, "
+            "gross_pnl, net_pnl, pnl_usd, hold_type, phase, strategy_id) "
+            "VALUES ('QQQ','NASDAQ','USD','BUY',"
+            "'2026-05-18T15:45:00-04:00',704.65,1,"
+            "NULL,NULL,NULL,'swing',1,'overnight_drift')"
+        )
+        conn.commit()
+
+        _migration_v14(conn)
+        conn.commit()
+
+        row = conn.execute(
+            "SELECT exit_time, pnl_usd FROM trades WHERE ticker='QQQ'"
+        ).fetchone()
+        assert row[0] is None
+        assert row[1] is None, "open trades must keep pnl_usd NULL"
+    finally:
+        conn.close()
+
+
+@pytest.mark.unit
+def test_v14_backfill_does_not_overwrite_existing_pnl_usd(db_at_v13: Path) -> None:
+    """Rows that already have a non-NULL pnl_usd (e.g. backfilled by
+    self_improve.alpaca_backfill, or written by post-V14 code) must
+    survive untouched even if pnl_usd disagrees with net_pnl."""
+    conn = sqlite3.connect(str(db_at_v13))
+    try:
+        conn.execute(
+            "INSERT INTO trades (ticker, exchange, currency, side, "
+            "entry_time, entry_price, quantity, exit_time, exit_price, "
+            "exit_reason, gross_pnl, net_pnl, pnl_usd, hold_type, phase, "
+            "strategy_id) "
+            "VALUES ('XLI','NYSE','USD','BUY',"
+            "'2026-05-12T11:45:00-04:00',173.01,1,"
+            "'2026-05-18T09:45:00-04:00',170.35,"
+            "'strategy_exit',-2.66,-2.66,-2.50,'swing',1,'mean_reversion')"
+        )
+        conn.commit()
+
+        _migration_v14(conn)
+        conn.commit()
+
+        row = conn.execute(
+            "SELECT net_pnl, pnl_usd FROM trades WHERE ticker='XLI'"
+        ).fetchone()
+        assert row[0] == pytest.approx(-2.66)
+        assert row[1] == pytest.approx(-2.50), (
+            "V14 must not overwrite a pre-existing pnl_usd value"
+        )
+    finally:
+        conn.close()
+
+
+@pytest.mark.unit
+def test_v14_is_idempotent(db_at_v13: Path) -> None:
+    conn = sqlite3.connect(str(db_at_v13))
+    try:
+        _migration_v14(conn)
+        conn.commit()
+        _migration_v14(conn)
+        conn.commit()
+
+        rows = conn.execute("PRAGMA table_info(positions)").fetchall()
+        cols = [r for r in rows if r[1] == "exit_reason"]
+        assert len(cols) == 1
+    finally:
+        conn.close()
+
+
+@pytest.mark.unit
+def test_exit_reason_appears_in_select_star(tmp_path: Path) -> None:
+    """OrderManager._hydrate_active_orders does SELECT *. The new
+    column must materialize without explicit query changes."""
+    db = tmp_path / "fresh.db"
+    run_migrations(str(db))
+    conn = sqlite3.connect(str(db))
+    conn.row_factory = sqlite3.Row
+    try:
+        conn.execute(
+            "INSERT INTO positions (ticker, exchange, currency, quantity, "
+            "entry_price, entry_time, status, hold_type, phase, strategy_id, "
+            "alpaca_exit_order_id, exit_reason) "
+            "VALUES ('SPY','NYSE','USD',1,740.22,'2026-05-15T15:45:00-04:00',"
+            "'CLOSING','swing',1,'overnight_drift','alp-1','overnight_exit')"
+        )
+        conn.commit()
+
+        row = conn.execute(
+            "SELECT * FROM positions WHERE ticker='SPY'"
+        ).fetchone()
+        assert "exit_reason" in row.keys()
+        assert row["exit_reason"] == "overnight_exit"
+    finally:
+        conn.close()


### PR DESCRIPTION
## Summary

Two correctness bugs uncovered while inspecting 2026-05-18 trading state:

### Bug 1 — `overnight_drift` exits regressed to `strategy_exit`

Today's two `overnight_drift` exits (SPY + QQQ rolling off Friday) wrote `exit_reason='strategy_exit'` to `trades`, even though `overnight_drift.py:166` clearly emits `reason=\"overnight_exit\"`. Per `memory/overnight_drift_exit_orphans.md`, [PR #114](https://github.com/alex5imon/ai-broker/pull/114) was supposed to make these land as `overnight_exit`; today was the first real post-PR exit and it regressed.

**Root cause:** `place_exit` set `matching_active.exit_reason = reason` in memory and persisted **only** `alpaca_exit_order_id` to the DB. The fill-detection branch runs on a later tick with a freshly rehydrated `_active_orders` dict (stateless tick model). Hydration reads from `positions`, which had no `exit_reason` column, so the rehydrated `_ActiveOrder.exit_reason` was `None` and the fallback `\"strategy_exit\"` in `order_manager.py:638` won.

### Bug 2 — `daily_summaries` reported 0 wins / 0 losses on 4 non-zero-pnl trades

| date | trades | wins | losses | net |
|---|---|---|---|---|
| 5-14 | 4 | **4** | 0 | +4.75 |
| 5-15 | 3 | 0 | **3** | −2.73 |
| 5-18 | 4 | **0** | **0** | −1.05 |

**Root cause:** `_close_position` wrote `gross_pnl` and `net_pnl` but **forgot `pnl_usd`**. Every downstream reader keys off `pnl_usd` and silently treats `NULL` as 0:
- `performance.calculate_daily_metrics` (`reporting/performance.py:94`) — classified all 4 trades as neither win nor loss
- `repo.get_daily_pnl_usd` (`db/repository.py:793`) — **the daily-loss circuit breaker** sees $0.00 realised P&L regardless of actual drawdown
- `main._save_daily_summary` — wrote wins=0/losses=0

The 5-14/5-15 rows in the table above have `notes='recomputed:post_backfill'` — they were healed by `self_improve.alpaca_backfill`, which **does** write `pnl_usd`. Live exits had been getting silently corrupted the whole time.

## What this PR ships

**V14 migration** (`positions.exit_reason` + idempotent `trades.pnl_usd` backfill):
- `ALTER TABLE positions ADD COLUMN exit_reason TEXT`
- `UPDATE trades SET pnl_usd = net_pnl WHERE pnl_usd IS NULL AND net_pnl IS NOT NULL AND exit_time IS NOT NULL` — heals today's 4 stale rows; bounded to closed trades; no-op on rerun.

**`OrderManager` changes:**
- `place_exit` / `place_limit_exit` now write `exit_reason` in lockstep with `alpaca_exit_order_id`.
- `_hydrate_active_orders` restores `exit_reason` from the row.
- The cancel/expire/reject rollback branch clears the persisted `exit_reason` in addition to `alpaca_exit_order_id`.
- `_close_position` now writes `pnl_usd` alongside `gross_pnl`/`net_pnl`. Commission-free bot, so all three are equal at close time.

## Test plan

- [x] V14 migration: idempotent; backfill bounded to closed trades; pre-existing `pnl_usd` not overwritten; column appears in `SELECT *`. (7 tests)
- [x] `place_exit` persists `exit_reason`; new OM rehydrates it across tick boundary; cancel/reject rollback clears it. (3 tests)
- [x] `_close_position` writes `pnl_usd` after a strategy-driven exit fills. (1 test)
- [x] Full suite: `pytest trading_bot/tests/ -q` → **968 passed**.

## Memory updates

Future me: this PR is the second-class follow-on to PR #114. The orphan was real but `exit_reason` carried the same architectural smell (in-memory only) and broke separately. Whenever an `_ActiveOrder` field has cross-tick semantics, audit `positions` schema + hydration in the same change.