### PR TITLE
fix(backfill): skip live-closed positions; V15 dedupes phantom rows

### DIFF
--- a/trading_bot/constants.py
+++ b/trading_bot/constants.py
@@ -196,4 +196,4 @@ def ticker_market(ticker: str) -> Market:
 # Schema version — must match the DB migration target
 # ---------------------------------------------------------------------------
 
-SCHEMA_VERSION: int = 14
+SCHEMA_VERSION: int = 15

--- a/trading_bot/db/migrations.py
+++ b/trading_bot/db/migrations.py
@@ -511,6 +511,76 @@ def _migration_v14(conn: sqlite3.Connection) -> None:
     )
 
 
+def _migration_v15(conn: sqlite3.Connection) -> None:
+    """V15: one-shot dedupe of phantom backfill rows shadowing live-closed trades.
+
+    Pre-2026-05-20 the nightly ``alpaca_backfill`` candidate query
+    matched "already backfilled" only by a notes marker that the live
+    ``_close_position`` writer never sets. Every correctly closed
+    position therefore re-entered the candidate set every night; the
+    backfill's UPDATE branch only knew how to UPDATE
+    ``exit_reason='reconciliation_mismatch'`` rows and fell through to
+    INSERT a phantom duplicate with ``exit_reason='manual'`` per
+    correctly-closed position per nightly run.
+
+    The companion code change in ``self_improve/alpaca_backfill.py``
+    tightens ``load_candidates`` so positions with a complete
+    live-closed row are excluded going forward. This migration heals
+    rows the bug already produced — observed 2026-05-15, 2026-05-18,
+    2026-05-19 (5 phantom rows shadowing 5 real exits, inflating
+    ``daily_summaries`` totals by 2×).
+
+    Dedupe criterion: a row whose ``notes`` carries the
+    ``backfill:position:`` marker is deleted iff another trades row
+    exists for the same ``(ticker, strategy_id, substr(entry_time, 1,
+    19))`` that is fully closed (exit_time + exit_price set) and not
+    itself a backfill row. The 19-char ``entry_time`` prefix matches
+    the same precision the backfill's UPDATE branch already uses (per
+    its own comment: "A strategy never opens two positions on the
+    same ticker in the same second").
+
+    Bounded by construction:
+      - Only touches rows already tagged with the backfill marker —
+        original live-closed rows are never the DELETE target.
+      - Requires a non-backfill sibling to exist — backfills that
+        genuinely substitute for a missing live close survive.
+
+    Idempotent: once the phantoms are gone, the DELETE matches zero
+    rows on rerun.
+    """
+    # Marker literal pinned here (not imported) — migrations are
+    # append-only history. If self_improve.alpaca_backfill renames its
+    # marker prefix in the future, this migration's behaviour must
+    # remain identical to the historical run.
+    deleted = conn.execute(
+        """
+        DELETE FROM trades
+         WHERE notes LIKE 'backfill:position:%'
+           AND EXISTS (
+                 SELECT 1 FROM trades t2
+                  WHERE t2.id != trades.id
+                    AND t2.ticker = trades.ticker
+                    AND t2.strategy_id = trades.strategy_id
+                    AND substr(t2.entry_time, 1, 19)
+                        = substr(trades.entry_time, 1, 19)
+                    AND t2.exit_time IS NOT NULL
+                    AND t2.exit_price IS NOT NULL
+                    AND (t2.notes IS NULL
+                         OR t2.notes NOT LIKE 'backfill:position:%')
+               )
+        """
+    ).rowcount
+
+    conn.execute(
+        "INSERT OR REPLACE INTO schema_version (version, description) "
+        "VALUES (15, "
+        "'V15 schema - dedupe phantom backfill rows shadowing live closes')"
+    )
+    logger.info(
+        "Applied migration V15: deleted %d phantom backfill row(s)", deleted,
+    )
+
+
 _MIGRATIONS: list[tuple[int, str, MigrationFn]] = [
     (4, "V4 schema - multi-market adaptive trading bot", _migration_v4),
     (5, "V5 schema - multi-strategy Alpaca trading bot", _migration_v5),
@@ -527,6 +597,8 @@ _MIGRATIONS: list[tuple[int, str, MigrationFn]] = [
      _migration_v13),
     (14, "V14 schema - positions.exit_reason + trades.pnl_usd backfill",
      _migration_v14),
+    (15, "V15 schema - dedupe phantom backfill rows shadowing live closes",
+     _migration_v15),
 ]
 
 

--- a/trading_bot/self_improve/alpaca_backfill.py
+++ b/trading_bot/self_improve/alpaca_backfill.py
@@ -102,11 +102,32 @@ def _parse_iso(value: str | None) -> datetime | None:
 
 
 def load_candidates(conn: sqlite3.Connection) -> list[ClosedPositionRow]:
-    """Closed positions with a strategy_id, not yet backfilled."""
-    # `BACKFILL_MARKER_PREFIX` is a hardcoded module-level constant, not
-    # user input. Concatenating it into the SQL is safe; the alternative
-    # (passing it as a parameter) would require SQLite to recompute the
-    # `||` for every row in the EXISTS subquery.
+    """Closed positions with a strategy_id, not yet backfilled.
+
+    Two exclusion criteria, both via NOT EXISTS:
+
+    1. **Backfill-marker present** — a previous backfill run already
+       repaired (or inserted) this position's trades row, marker set in
+       ``trades.notes``.
+    2. **Live writer already produced a complete row** — the live
+       ``_close_position`` UPDATEs the entry-time trades row in place
+       with a real ``exit_reason`` and populated ``exit_time``/
+       ``exit_price``. Pre-2026-05-20 this case fell through to the
+       backfill INSERT branch (which only knew to UPDATE
+       ``reconciliation_mismatch`` rows) and produced a phantom
+       ``exit_reason='manual'`` duplicate per live-closed position per
+       nightly run. Matched on ``(ticker, strategy_id,
+       substr(entry_time, 1, 19))`` — the same 19-char prefix the
+       backfill INSERT itself uses, tolerant of microsecond drift /
+       writer-vs-reader rounding. ``reconciliation_mismatch`` rows are
+       intentionally left in the candidate set because that's exactly
+       what the backfill is supposed to repair.
+
+    `BACKFILL_MARKER_PREFIX` is a hardcoded module-level constant, not
+    user input. Concatenating it into the SQL is safe; the alternative
+    (passing it as a parameter) would require SQLite to recompute the
+    `||` for every row in the EXISTS subquery.
+    """
     cur = conn.execute(
         f"""
         SELECT p.id, p.ticker, p.exchange, p.currency, p.strategy_id,
@@ -120,6 +141,16 @@ def load_candidates(conn: sqlite3.Connection) -> list[ClosedPositionRow]:
            AND NOT EXISTS (
                  SELECT 1 FROM trades t
                   WHERE t.notes = '{BACKFILL_MARKER_PREFIX}' || p.id
+               )
+           AND NOT EXISTS (
+                 SELECT 1 FROM trades t
+                  WHERE t.ticker = p.ticker
+                    AND t.strategy_id = p.strategy_id
+                    AND substr(t.entry_time, 1, 19) = substr(p.entry_time, 1, 19)
+                    AND t.exit_time IS NOT NULL
+                    AND t.exit_price IS NOT NULL
+                    AND t.exit_reason IS NOT NULL
+                    AND t.exit_reason != 'reconciliation_mismatch'
                )
          ORDER BY p.entry_time
         """  # nosec B608

--- a/trading_bot/tests/test_migration_v15_dedupe_phantom_backfill.py
+++ b/trading_bot/tests/test_migration_v15_dedupe_phantom_backfill.py
@@ -1,0 +1,331 @@
+"""Tests for V15: dedupe phantom backfill rows shadowing live-closed trades.
+
+Bug observed 2026-05-19: every correctly-closed position from
+2026-05-15 / 2026-05-18 / 2026-05-19 had **two** rows in ``trades``:
+one written by the live ``_close_position`` path with the real
+``exit_reason`` (e.g. ``overnight_exit``, ``stop_loss``), and one
+inserted later by ``self_improve.alpaca_backfill`` with
+``exit_reason='manual'`` and the ``backfill:position:`` notes marker.
+
+The phantom doubled every ``daily_summaries`` total.
+
+V15 deletes the phantoms (and only the phantoms): a backfill-marked
+row is removed iff another fully-closed trades row exists for the
+same ``(ticker, strategy_id, substr(entry_time, 1, 19))``.
+
+These tests pin:
+
+A. The 5-row dup pattern from 2026-05-19 is collapsed to 5 single rows.
+B. Backfill rows that genuinely substitute for a missing live close
+   (no non-backfill sibling) survive.
+C. Live-closed rows are never deleted, even when paired with a backfill row.
+D. The migration is idempotent.
+E. Sibling-matching tolerates microsecond drift in entry_time (the
+   live writer / backfill writer agree only to second precision).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from trading_bot.constants import SCHEMA_VERSION
+from trading_bot.db.migrations import _migration_v15, run_migrations
+
+
+@pytest.fixture
+def db_at_v14(tmp_path: Path) -> Path:
+    db = tmp_path / "v14.db"
+    run_migrations(str(db))
+    conn = sqlite3.connect(str(db))
+    try:
+        conn.execute("DELETE FROM schema_version WHERE version >= 15")
+        conn.commit()
+    finally:
+        conn.close()
+    return db
+
+
+def _insert_trade(
+    conn: sqlite3.Connection,
+    *,
+    ticker: str,
+    strategy_id: str,
+    entry_time: str,
+    exit_time: str | None,
+    exit_price: float | None,
+    exit_reason: str | None,
+    notes: str | None,
+    pnl: float | None = -0.50,
+) -> int:
+    cur = conn.execute(
+        """
+        INSERT INTO trades (
+            ticker, exchange, currency, side, entry_time, entry_price,
+            quantity, exit_time, exit_price, exit_reason,
+            gross_pnl, net_pnl, pnl_usd,
+            hold_type, phase, strategy_id, notes
+        ) VALUES (?, 'NYSE', 'USD', 'BUY', ?, 100.0, 1,
+                  ?, ?, ?, ?, ?, ?, 'swing', 1, ?, ?)
+        """,
+        (
+            ticker, entry_time,
+            exit_time, exit_price, exit_reason,
+            pnl, pnl, pnl,
+            strategy_id, notes,
+        ),
+    )
+    return int(cur.lastrowid)
+
+
+@pytest.mark.unit
+def test_fresh_db_at_target_version(tmp_path: Path) -> None:
+    db = tmp_path / "fresh.db"
+    run_migrations(str(db))
+    conn = sqlite3.connect(str(db))
+    try:
+        version = conn.execute(
+            "SELECT MAX(version) FROM schema_version"
+        ).fetchone()[0]
+    finally:
+        conn.close()
+    assert version == SCHEMA_VERSION
+
+
+@pytest.mark.unit
+def test_v15_deletes_phantom_when_live_sibling_exists(db_at_v14: Path) -> None:
+    """The exact pattern observed 2026-05-19: live row with the real
+    exit_reason, plus a backfill row with exit_reason='manual'. V15
+    must keep the live row and remove the phantom."""
+    conn = sqlite3.connect(str(db_at_v14))
+    try:
+        entry = "2026-05-18T15:45:32.965597-04:00"
+        live_id = _insert_trade(
+            conn, ticker="SPY", strategy_id="overnight_drift",
+            entry_time=entry,
+            exit_time="2026-05-19T09:35:34.838039-04:00",
+            exit_price=735.05,
+            exit_reason="overnight_exit",
+            notes=None,
+        )
+        phantom_id = _insert_trade(
+            conn, ticker="SPY", strategy_id="overnight_drift",
+            entry_time=entry,
+            exit_time="2026-05-19T09:30:37.462232-04:00",
+            exit_price=735.05,
+            exit_reason="manual",
+            notes="backfill:position:42",
+        )
+        conn.commit()
+
+        _migration_v15(conn)
+        conn.commit()
+
+        remaining = {
+            r[0] for r in conn.execute("SELECT id FROM trades").fetchall()
+        }
+        assert remaining == {live_id}, (
+            "the phantom must be deleted; the live row must survive"
+        )
+        kept = conn.execute(
+            "SELECT exit_reason FROM trades WHERE id = ?", (live_id,)
+        ).fetchone()
+        assert kept[0] == "overnight_exit"
+        _ = phantom_id  # explicit: we expect the phantom id to be gone
+    finally:
+        conn.close()
+
+
+@pytest.mark.unit
+def test_v15_preserves_backfill_when_no_live_sibling(db_at_v14: Path) -> None:
+    """A position genuinely repaired by backfill (no live-closed
+    counterpart) must NOT be deleted. This is the only legitimate
+    backfill-INSERT case the migration must protect."""
+    conn = sqlite3.connect(str(db_at_v14))
+    try:
+        only_id = _insert_trade(
+            conn, ticker="XLF", strategy_id="mean_reversion",
+            entry_time="2026-05-10T10:00:00-04:00",
+            exit_time="2026-05-10T11:00:00-04:00",
+            exit_price=99.5,
+            exit_reason="manual",
+            notes="backfill:position:99",
+        )
+        conn.commit()
+
+        _migration_v15(conn)
+        conn.commit()
+
+        remaining = {
+            r[0] for r in conn.execute("SELECT id FROM trades").fetchall()
+        }
+        assert remaining == {only_id}, (
+            "a backfill row with no live sibling must survive"
+        )
+    finally:
+        conn.close()
+
+
+@pytest.mark.unit
+def test_v15_tolerates_microsecond_drift_in_entry_time(db_at_v14: Path) -> None:
+    """The live writer captures sub-second timestamps; the backfill
+    writer rounds. V15 must collapse the pair using the 19-char prefix
+    match (YYYY-MM-DDTHH:MM:SS)."""
+    conn = sqlite3.connect(str(db_at_v14))
+    try:
+        live_id = _insert_trade(
+            conn, ticker="QQQ", strategy_id="overnight_drift",
+            entry_time="2026-05-18T15:45:33.085116-04:00",  # microseconds
+            exit_time="2026-05-19T09:35:39.092846-04:00",
+            exit_price=701.61,
+            exit_reason="overnight_exit",
+            notes=None,
+        )
+        _insert_trade(
+            conn, ticker="QQQ", strategy_id="overnight_drift",
+            entry_time="2026-05-18T15:45:33-04:00",  # second precision only
+            exit_time="2026-05-19T09:30:37.606770-04:00",
+            exit_price=701.61,
+            exit_reason="manual",
+            notes="backfill:position:43",
+        )
+        conn.commit()
+
+        _migration_v15(conn)
+        conn.commit()
+
+        remaining = {
+            r[0] for r in conn.execute("SELECT id FROM trades").fetchall()
+        }
+        assert remaining == {live_id}
+    finally:
+        conn.close()
+
+
+@pytest.mark.unit
+def test_v15_does_not_match_across_strategies(db_at_v14: Path) -> None:
+    """Two strategies opening the same ticker at the same second is
+    a corner case but must not cross-match. Matching includes
+    strategy_id."""
+    conn = sqlite3.connect(str(db_at_v14))
+    try:
+        live_id = _insert_trade(
+            conn, ticker="SPY", strategy_id="overnight_drift",
+            entry_time="2026-05-18T15:45:32.965597-04:00",
+            exit_time="2026-05-19T09:35:34-04:00",
+            exit_price=735.05,
+            exit_reason="overnight_exit",
+            notes=None,
+        )
+        phantom_id = _insert_trade(
+            conn, ticker="SPY", strategy_id="mean_reversion",
+            entry_time="2026-05-18T15:45:32.965597-04:00",
+            exit_time="2026-05-19T09:30:37-04:00",
+            exit_price=735.05,
+            exit_reason="manual",
+            notes="backfill:position:55",
+        )
+        conn.commit()
+
+        _migration_v15(conn)
+        conn.commit()
+
+        remaining = {
+            r[0] for r in conn.execute("SELECT id FROM trades").fetchall()
+        }
+        assert remaining == {live_id, phantom_id}, (
+            "phantom must survive: no matching-strategy live sibling"
+        )
+    finally:
+        conn.close()
+
+
+@pytest.mark.unit
+def test_v15_is_idempotent(db_at_v14: Path) -> None:
+    conn = sqlite3.connect(str(db_at_v14))
+    try:
+        entry = "2026-05-18T15:45:32-04:00"
+        _insert_trade(
+            conn, ticker="SPY", strategy_id="overnight_drift",
+            entry_time=entry,
+            exit_time="2026-05-19T09:35-04:00",
+            exit_price=735.05,
+            exit_reason="overnight_exit",
+            notes=None,
+        )
+        _insert_trade(
+            conn, ticker="SPY", strategy_id="overnight_drift",
+            entry_time=entry,
+            exit_time="2026-05-19T09:30-04:00",
+            exit_price=735.05,
+            exit_reason="manual",
+            notes="backfill:position:42",
+        )
+        conn.commit()
+
+        _migration_v15(conn)
+        conn.commit()
+        first_remaining = conn.execute(
+            "SELECT COUNT(*) FROM trades"
+        ).fetchone()[0]
+
+        _migration_v15(conn)
+        conn.commit()
+        second_remaining = conn.execute(
+            "SELECT COUNT(*) FROM trades"
+        ).fetchone()[0]
+
+        assert first_remaining == 1
+        assert second_remaining == 1, "second run must be a no-op"
+    finally:
+        conn.close()
+
+
+@pytest.mark.unit
+def test_v15_handles_2026_05_19_pattern_end_to_end(db_at_v14: Path) -> None:
+    """Reconstruct the actual 5-row dup pattern observed in the live
+    DB on 2026-05-19 and verify V15 collapses it to 5 single rows."""
+    conn = sqlite3.connect(str(db_at_v14))
+    try:
+        # (ticker, strategy, entry_time, real_reason, marker_id)
+        pairs = [
+            ("GOOGL", "mean_reversion",  "2026-05-15T09:40:44-04:00", "stop_loss",      183),
+            ("SPY",   "overnight_drift", "2026-05-15T15:45:32-04:00", "strategy_exit",  184),
+            ("QQQ",   "overnight_drift", "2026-05-15T15:45:32-04:00", "strategy_exit",  185),
+            ("SPY",   "overnight_drift", "2026-05-18T15:45:32-04:00", "overnight_exit", 186),
+            ("QQQ",   "overnight_drift", "2026-05-18T15:45:33-04:00", "overnight_exit", 187),
+        ]
+        live_ids: list[int] = []
+        for ticker, strat, entry, reason, marker in pairs:
+            live_ids.append(_insert_trade(
+                conn, ticker=ticker, strategy_id=strat,
+                entry_time=entry,
+                exit_time=entry.replace("15:45", "09:35").replace("09:40", "10:25"),
+                exit_price=99.0,
+                exit_reason=reason,
+                notes=None,
+            ))
+            _insert_trade(
+                conn, ticker=ticker, strategy_id=strat,
+                entry_time=entry,
+                exit_time=entry.replace("15:45", "09:30").replace("09:40", "10:20"),
+                exit_price=99.0,
+                exit_reason="manual",
+                notes=f"backfill:position:{marker}",
+            )
+        conn.commit()
+        assert conn.execute("SELECT COUNT(*) FROM trades").fetchone()[0] == 10
+
+        _migration_v15(conn)
+        conn.commit()
+
+        remaining = {
+            r[0] for r in conn.execute("SELECT id FROM trades").fetchall()
+        }
+        assert remaining == set(live_ids), (
+            "all 5 phantoms collapsed; all 5 live rows preserved"
+        )
+    finally:
+        conn.close()

--- a/trading_bot/tests/test_self_improve_alpaca_backfill.py
+++ b/trading_bot/tests/test_self_improve_alpaca_backfill.py
@@ -129,6 +129,77 @@ def test_load_candidates_skips_already_backfilled(tmp_db):
     assert load_candidates(tmp_db) == []
 
 
+@pytest.mark.unit
+def test_load_candidates_skips_when_live_writer_already_closed_row(tmp_db):
+    """Regression for 2026-05-19 phantom-dup bug.
+
+    Pre-fix ``load_candidates`` matched "already backfilled" only by
+    the ``backfill:position:`` notes marker. The live
+    ``_close_position`` writer never sets that marker, so every
+    correctly-closed position re-entered the candidate set every
+    night — and the backfill's UPDATE branch only handled
+    ``reconciliation_mismatch`` rows, falling through to INSERT a
+    phantom duplicate with ``exit_reason='manual'``.
+
+    The candidate query must also exclude positions whose entry-time
+    matches an already-complete trades row with a real
+    ``exit_reason``.
+    """
+    entry_time = datetime(2026, 5, 18, 15, 45, 32, tzinfo=TZ_EASTERN)
+    _insert_position(tmp_db, position_id=42, entry_time=entry_time)
+    tmp_db.execute(
+        """
+        INSERT INTO trades (
+            ticker, exchange, currency, side, entry_time, entry_price,
+            quantity, exit_time, exit_price, exit_reason,
+            gross_pnl, net_pnl, pnl_usd,
+            hold_type, phase, strategy_id, notes
+        ) VALUES (
+            'SPY','NYSE','USD','BUY', ?, 100, 10,
+            '2026-05-19T09:35:34-04:00', 99.0, 'overnight_exit',
+            -10, -10, -10, 'swing', 1, 'overnight_drift', NULL
+        )
+        """,
+        (entry_time.isoformat(),),
+    )
+    tmp_db.commit()
+
+    assert load_candidates(tmp_db) == [], (
+        "a position with a complete live-closed row must not be a "
+        "backfill candidate"
+    )
+
+
+@pytest.mark.unit
+def test_load_candidates_still_returns_reconciliation_mismatch_rows(tmp_db):
+    """``reconciliation_mismatch`` rows are exactly what the backfill
+    is supposed to repair — they must stay in the candidate set even
+    though they have an exit_reason set."""
+    entry_time = datetime(2026, 5, 12, 11, 45, 43, tzinfo=TZ_EASTERN)
+    _insert_position(tmp_db, position_id=77, entry_time=entry_time)
+    tmp_db.execute(
+        """
+        INSERT INTO trades (
+            ticker, exchange, currency, side, entry_time, entry_price,
+            quantity, exit_time, exit_price, exit_reason,
+            hold_type, phase, strategy_id, notes
+        ) VALUES (
+            'SPY','NYSE','USD','BUY', ?, 100, 10,
+            NULL, NULL, 'reconciliation_mismatch',
+            'swing', 1, 'overnight_drift', NULL
+        )
+        """,
+        (entry_time.isoformat(),),
+    )
+    tmp_db.commit()
+
+    candidates = load_candidates(tmp_db)
+    assert {c.position_id for c in candidates} == {77}, (
+        "reconciliation_mismatch row should not exclude its position "
+        "from the candidate set"
+    )
+
+
 # ---------------------------------------------------------------------------
 # _infer_exit_reason
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Yesterday's daily summary reported 6 trades / 0W / 6L / **−\$2.01**, but only 3 real exits closed yesterday (GOOGL stop_loss, SPY/QQQ overnight_exit). Each one had a **phantom duplicate** in `trades` with `exit_reason='manual'` and a `backfill:position:` notes marker. Real loss was **−\$1.01**; the summary was double-counting.

Same pattern observed for 2026-05-15 and 2026-05-18 exits — 5 phantom rows total currently in the live DB.

### Root cause

`self_improve/alpaca_backfill.py`:
- `load_candidates` matched \"already backfilled\" only by `t.notes = 'backfill:position:' || p.id`. The live `_close_position` writer never sets that marker, so every correctly-closed position re-entered the candidate set every night.
- `insert_backfilled_trade`'s UPDATE branch only knew to repair `exit_reason='reconciliation_mismatch'` rows. Live-closed rows have a real `exit_reason`, so the UPDATE missed and fell through to INSERT a phantom with `exit_reason='manual'` (the `_infer_exit_reason` default).

Memory note `trades_table_duplicates.md` said this class of bug was resolved 2026-05-14 via PRs #131/#133/#134/#135 — but those fixed an adjacent recovery-path dup; this nightly-backfill dup was a separate offender.

## What this PR ships

**1. `load_candidates` tightened**
Adds a second `NOT EXISTS` clause: skip positions whose `(ticker, strategy_id, substr(entry_time, 1, 19))` already matches a complete trades row with a real `exit_reason`. `reconciliation_mismatch` rows are intentionally still candidates — repairing them is the backfill's actual job.

**2. V15 migration** — one-shot dedupe of phantom rows the bug already stamped:
\`\`\`sql
DELETE FROM trades
 WHERE notes LIKE 'backfill:position:%'
   AND EXISTS (
     SELECT 1 FROM trades t2
      WHERE t2.id != trades.id
        AND t2.ticker = trades.ticker
        AND t2.strategy_id = trades.strategy_id
        AND substr(t2.entry_time, 1, 19) = substr(trades.entry_time, 1, 19)
        AND t2.exit_time IS NOT NULL
        AND t2.exit_price IS NOT NULL
        AND (t2.notes IS NULL OR t2.notes NOT LIKE 'backfill:position:%')
   )
\`\`\`
- Original live rows are never the DELETE target (filter only matches backfill-marker rows).
- Backfills that genuinely substitute for a missing live close survive (requires a non-backfill sibling).
- Idempotent — second run matches zero rows.
- Marker literal pinned inline (not imported) since migrations are append-only history.

After this lands the live DB's 5 phantom rows (ids 190, 191, 195, 196, 197) will be removed by the V15 migration on the next bot tick, restoring correct `daily_summaries` totals (the next `daily-review` recompute will pick up the corrected universe).

## Test plan

- [x] V15 deletes phantom rows when a live sibling exists (the actual 2026-05-19 pattern reconstructed end-to-end).
- [x] V15 preserves backfill rows with no live sibling (genuine repairs untouched).
- [x] V15 tolerates microsecond drift in `entry_time` via the 19-char prefix match.
- [x] V15 does not cross-match across strategies.
- [x] V15 is idempotent.
- [x] `load_candidates` excludes positions with a complete live-closed row.
- [x] `load_candidates` still returns `reconciliation_mismatch` positions.
- [x] Existing 12 backfill tests still pass (no regression to repair path).
- [x] Full suite: `pytest trading_bot/tests/ -q` → **973 passed, 4 skipped**.