### PR TITLE
fix(mean_reversion): add time_stop to prevent indefinite breakeven holds

### DIFF
--- a/trading_bot/strategy/strategies/mean_reversion.py
+++ b/trading_bot/strategy/strategies/mean_reversion.py
@@ -4,14 +4,17 @@ from __future__ import annotations
 
 import logging
 import math
+from datetime import datetime
 from typing import Any
 
 import pandas as pd
 
-from trading_bot.constants import HoldType
+from trading_bot.constants import HoldType, TZ_EASTERN
+from trading_bot.data.holiday_calendar import HolidayCalendar
 from trading_bot.strategy.base import ExitSignal, StrategyBase, StrategyDecision
 from trading_bot.strategy.technical import TechnicalAnalyzer
 from trading_bot.utils import coalesce
+from trading_bot.utils.time import count_trading_days_between
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -84,6 +87,11 @@ class MeanReversionStrategy(StrategyBase):
         self._bb_period: int = int(config.get("bb_period", 20))
         self._bb_std: float = float(config.get("bb_std", 2.0))
         self._bb_lookback_bars: int = int(config.get("bb_lookback_bars", 3))
+        # Time stop: maximum trading-day hold before force-exit.  Prevents
+        # breakeven positions from sitting indefinitely when neither the stop,
+        # target, nor RSI normalisation triggers.  Default 5 trading days
+        # matches ExitManager.check_time_stop's swing default.
+        self._max_hold_days: int = int(config.get("max_hold_days", 5))
 
     @staticmethod
     def _realized_vol_pct(df_daily: pd.DataFrame, lookback_days: int = 20) -> float | None:
@@ -320,6 +328,36 @@ class MeanReversionStrategy(StrategyBase):
             target: float = entry_price * (1.0 + self._take_profit_pct)
             if current_price >= target:
                 return ExitSignal(should_exit=True, reason="take_profit")
+
+        # Time stop — prevent indefinite holds at breakeven.  Counts actual
+        # trading days so weekends / NYSE holidays do not consume the budget.
+        # Fires before the RSI check so a stalled position is always released
+        # within _max_hold_days sessions regardless of RSI state.
+        entry_time_raw: Any = position.get("entry_time")
+        if entry_time_raw is not None:
+            try:
+                entry_dt: datetime = datetime.fromisoformat(str(entry_time_raw))
+                if entry_dt.tzinfo is None:
+                    entry_dt = entry_dt.replace(tzinfo=TZ_EASTERN)
+                now_et: datetime = datetime.now(tz=TZ_EASTERN)
+                cal: HolidayCalendar = HolidayCalendar()
+                elapsed_days: int = count_trading_days_between(
+                    cal,
+                    entry_dt.astimezone(TZ_EASTERN).date(),
+                    now_et.date(),
+                )
+                if elapsed_days >= self._max_hold_days:
+                    logger.info(
+                        "[mean_reversion] time_stop: %s held %d trading days "
+                        "(max=%d) — exiting",
+                        position.get("ticker", "?"), elapsed_days, self._max_hold_days,
+                    )
+                    return ExitSignal(should_exit=True, reason="time_stop")
+            except Exception:
+                logger.warning(
+                    "time_stop check failed for position id=%s",
+                    position.get("id"), exc_info=True,
+                )
 
         # RSI-based exit — fully disabled when let_winners_run is on, so the
         # trailing stop (set up at entry with activation threshold) becomes the

--- a/trading_bot/tests/test_mean_reversion_time_stop.py
+++ b/trading_bot/tests/test_mean_reversion_time_stop.py
@@ -1,0 +1,257 @@
+"""Tests for MeanReversionStrategy.evaluate_exit time_stop logic.
+
+Bug: mean_reversion positions could hold indefinitely at breakeven because
+evaluate_exit had no time_stop.  ExitManager.check_time_stop (5 trading-day
+default) was only wired for legacy/untagged positions, never for
+strategy-tagged positions routed through strategy_manager.check_exits.
+
+These tests pin:
+A. A position held for exactly max_hold_days triggers time_stop.
+B. A position held for fewer than max_hold_days does NOT trigger time_stop.
+C. stop_loss still fires before the time_stop when price is below stop.
+D. take_profit still fires before the time_stop when price is above target.
+E. max_hold_days is configurable from the strategy config dict.
+F. A missing / malformed entry_time does NOT raise — time_stop is skipped.
+G. Weekends are not counted as trading days (calendar-aware).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Any
+from unittest.mock import patch
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from trading_bot.strategy.strategies.mean_reversion import MeanReversionStrategy
+
+ET = ZoneInfo("US/Eastern")
+
+
+def _strategy(config: dict[str, Any] | None = None) -> MeanReversionStrategy:
+    return MeanReversionStrategy(config=config or {})
+
+
+def _position(
+    entry_time: datetime,
+    entry_price: float = 100.0,
+    stop_price: float = 97.0,   # 3% below — safely below current price in most tests
+    target_price: float = 110.0,  # 10% above — safely above current price in most tests
+) -> dict[str, Any]:
+    return {
+        "id": 1,
+        "ticker": "XLF",
+        "entry_time": entry_time.isoformat(),
+        "entry_price": entry_price,
+        "stop_price": stop_price,
+        "target_price": target_price,
+    }
+
+
+def _now_et(**delta_kwargs: Any) -> datetime:
+    """Return a timezone-aware ET datetime offset from a fixed anchor."""
+    # Anchor: a known Thursday trading day (not a holiday).
+    anchor = datetime(2026, 5, 22, 10, 0, 0, tzinfo=ET)
+    return anchor + timedelta(**delta_kwargs)
+
+
+# ---------------------------------------------------------------------------
+# A. time_stop fires at exactly max_hold_days
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_time_stop_fires_at_max_hold_days() -> None:
+    """A position open for exactly max_hold_days trading days triggers time_stop."""
+    strategy = _strategy({"max_hold_days": 3})
+    # Entry 3 trading days before "now".  Mon 2026-05-18 → now Thu 2026-05-21
+    # (Mon=1, Tue=2, Wed=3 trading days elapsed).
+    entry = datetime(2026, 5, 18, 15, 30, 0, tzinfo=ET)
+    now = datetime(2026, 5, 21, 10, 0, 0, tzinfo=ET)  # 3 trading days later
+
+    pos = _position(entry_time=entry, stop_price=90.0, target_price=120.0)
+
+    with patch("trading_bot.strategy.strategies.mean_reversion.datetime") as mock_dt:
+        mock_dt.fromisoformat.side_effect = datetime.fromisoformat
+        mock_dt.now.return_value = now
+
+        signal = strategy.evaluate_exit(
+            position=pos,
+            current_price=100.5,  # between stop and target
+        )
+
+    assert signal.should_exit is True
+    assert signal.reason == "time_stop"
+
+
+# ---------------------------------------------------------------------------
+# B. No time_stop before max_hold_days
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_time_stop_does_not_fire_before_max_hold_days() -> None:
+    """A position open for fewer than max_hold_days does NOT trigger time_stop."""
+    strategy = _strategy({"max_hold_days": 5})
+    # Entry 2 trading days before now
+    entry = datetime(2026, 5, 20, 9, 30, 0, tzinfo=ET)
+    now = datetime(2026, 5, 22, 10, 0, 0, tzinfo=ET)  # 2 trading days later
+
+    pos = _position(entry_time=entry, stop_price=90.0, target_price=120.0)
+
+    with patch("trading_bot.strategy.strategies.mean_reversion.datetime") as mock_dt:
+        mock_dt.fromisoformat.side_effect = datetime.fromisoformat
+        mock_dt.now.return_value = now
+
+        signal = strategy.evaluate_exit(
+            position=pos,
+            current_price=100.5,
+        )
+
+    assert signal.should_exit is False
+
+
+# ---------------------------------------------------------------------------
+# C. stop_loss fires before time_stop
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_stop_loss_fires_before_time_stop() -> None:
+    """stop_loss is checked first and fires even when max_hold_days is exceeded."""
+    strategy = _strategy({"max_hold_days": 1})
+    entry = datetime(2026, 5, 20, 9, 30, 0, tzinfo=ET)
+    now = datetime(2026, 5, 22, 10, 0, 0, tzinfo=ET)  # 2 trading days → past max
+
+    stop = 98.0
+    pos = _position(entry_time=entry, stop_price=stop, target_price=120.0)
+
+    with patch("trading_bot.strategy.strategies.mean_reversion.datetime") as mock_dt:
+        mock_dt.fromisoformat.side_effect = datetime.fromisoformat
+        mock_dt.now.return_value = now
+
+        signal = strategy.evaluate_exit(
+            position=pos,
+            current_price=97.5,  # below stop
+        )
+
+    assert signal.should_exit is True
+    assert signal.reason == "stop_loss"
+
+
+# ---------------------------------------------------------------------------
+# D. take_profit fires before time_stop
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_take_profit_fires_before_time_stop() -> None:
+    """take_profit is checked before time_stop and fires when price exceeds target."""
+    strategy = _strategy({"max_hold_days": 1})
+    entry = datetime(2026, 5, 20, 9, 30, 0, tzinfo=ET)
+    now = datetime(2026, 5, 22, 10, 0, 0, tzinfo=ET)  # 2 days → past max
+
+    target = 110.0
+    pos = _position(entry_time=entry, stop_price=90.0, target_price=target)
+
+    with patch("trading_bot.strategy.strategies.mean_reversion.datetime") as mock_dt:
+        mock_dt.fromisoformat.side_effect = datetime.fromisoformat
+        mock_dt.now.return_value = now
+
+        signal = strategy.evaluate_exit(
+            position=pos,
+            current_price=115.0,  # above target
+        )
+
+    assert signal.should_exit is True
+    assert signal.reason == "take_profit"
+
+
+# ---------------------------------------------------------------------------
+# E. max_hold_days is configurable
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_max_hold_days_configurable() -> None:
+    """max_hold_days read from config overrides the 5-day default."""
+    strategy_short = _strategy({"max_hold_days": 2})
+    strategy_long = _strategy({"max_hold_days": 10})
+
+    assert strategy_short._max_hold_days == 2
+    assert strategy_long._max_hold_days == 10
+
+    # 3 trading days elapsed — fires for max=2, not for max=10
+    entry = datetime(2026, 5, 19, 9, 30, 0, tzinfo=ET)   # Mon
+    now = datetime(2026, 5, 22, 10, 0, 0, tzinfo=ET)     # Thu = 3 trading days
+
+    pos = _position(entry_time=entry, stop_price=90.0, target_price=120.0)
+
+    for strategy, expect_exit in [(strategy_short, True), (strategy_long, False)]:
+        with patch("trading_bot.strategy.strategies.mean_reversion.datetime") as mock_dt:
+            mock_dt.fromisoformat.side_effect = datetime.fromisoformat
+            mock_dt.now.return_value = now
+            sig = strategy.evaluate_exit(position=pos, current_price=100.5)
+        assert sig.should_exit is expect_exit, (
+            f"max_hold_days={strategy._max_hold_days}: expected should_exit={expect_exit}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# F. Missing / malformed entry_time does not raise
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_time_stop_skipped_when_entry_time_missing() -> None:
+    """Absent entry_time silently skips the time_stop; no exception raised."""
+    strategy = _strategy({"max_hold_days": 1})
+    pos: dict[str, Any] = {
+        "id": 99,
+        "ticker": "XLF",
+        "entry_price": 100.0,
+        "stop_price": 90.0,
+        "target_price": 120.0,
+        # entry_time deliberately absent
+    }
+    signal = strategy.evaluate_exit(position=pos, current_price=100.5)
+    # Should return False (no exit) without raising
+    assert signal.should_exit is False
+
+
+@pytest.mark.unit
+def test_time_stop_skipped_when_entry_time_malformed() -> None:
+    """Malformed entry_time string silently skips the time_stop."""
+    strategy = _strategy({"max_hold_days": 1})
+    pos: dict[str, Any] = {
+        "id": 99,
+        "ticker": "XLF",
+        "entry_time": "not-a-real-datetime",
+        "entry_price": 100.0,
+        "stop_price": 90.0,
+        "target_price": 120.0,
+    }
+    signal = strategy.evaluate_exit(position=pos, current_price=100.5)
+    assert signal.should_exit is False
+
+
+# ---------------------------------------------------------------------------
+# G. Weekend days not counted as trading days
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_weekend_not_counted_as_trading_day() -> None:
+    """A Thu→Mon span is 1 trading day (Fri–Sun = 3 calendar days, 0 trading)."""
+    strategy = _strategy({"max_hold_days": 2})
+    # Entry Thu at close; 'now' is Mon morning — only 1 trading day (Mon) elapsed
+    entry = datetime(2026, 5, 21, 15, 45, 0, tzinfo=ET)  # Thursday
+    now = datetime(2026, 5, 25, 9, 35, 0, tzinfo=ET)     # Monday
+
+    pos = _position(entry_time=entry, stop_price=90.0, target_price=120.0)
+
+    with patch("trading_bot.strategy.strategies.mean_reversion.datetime") as mock_dt:
+        mock_dt.fromisoformat.side_effect = datetime.fromisoformat
+        mock_dt.now.return_value = now
+
+        signal = strategy.evaluate_exit(
+            position=pos,
+            current_price=100.5,
+        )
+
+    # 1 trading day < max_hold_days=2 → no exit
+    assert signal.should_exit is False


### PR DESCRIPTION
## Problem

`MeanReversionStrategy.evaluate_exit` had no time_stop. The codebase has a fully-built `ExitManager.check_time_stop` (5 trading-day default, calendar-aware via `HolidayCalendar`) but it is only invoked for **legacy/untagged positions** in `main.py`. Strategy-tagged positions routed through `strategy_manager.check_exits` call `strategy.evaluate_exit()` directly and never reach `ExitManager`.

As a result, a mean_reversion position at breakeven — price between stop and target, RSI never recovering above the exit threshold — can hold indefinitely.

**Observed live:** XLF entered 2026-05-19 at \$51.31, stop \$50.55, target \$53.88. Still open 3+ trading days later (2026-05-22 end of day) with no exit triggered. XLRE (entered 2026-05-21) also accumulating days.

## Fix

Add a calendar-aware time_stop check directly in `evaluate_exit`:

- Reads `entry_time` from the position dict, parses it as an ISO datetime.
- Counts elapsed **trading days** via `count_trading_days_between` — the same helper `ExitManager` already uses, so weekends and NYSE holidays don't consume the budget.
- Defaults to `max_hold_days=5` (matches `ExitManager.check_time_stop` swing default), configurable from the strategy's config dict.
- Fires **after** stop_loss and take_profit (higher priority) and **before** the RSI normalisation check.
- Gracefully skips (logs a warning) if `entry_time` is absent or unparseable — never raises.

## Tests

8 new unit tests in `test_mean_reversion_time_stop.py`:
- A: fires at exactly `max_hold_days`
- B: does not fire before `max_hold_days`
- C: stop_loss fires first when price is below stop
- D: take_profit fires first when price is above target
- E: `max_hold_days` is configurable from config
- F: missing `entry_time` skips time_stop without raising
- F2: malformed `entry_time` skips time_stop without raising
- G: weekends are not counted as trading days

## Test plan
- [ ] All 965 existing tests pass (verified locally)
- [ ] 8 new time_stop tests pass
- [ ] XLF and XLRE positions will be force-exited next time elapsed trading days >= 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)