### PR TITLE
feat(strategy): cross-sectional momentum sleeve (#44, disabled)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -756,3 +756,43 @@ multi_strategy:
       stop_loss_pct: 0.03
       position_pct: 0.95
       fractional_shares: true
+
+    # Cross-sectional momentum (sleeve #6, issue #44).
+    # Ranks the 11 SPDR sector ETFs by trailing total return and holds
+    # the top N on the first trading day of each month. Daily bars,
+    # monthly cadence — genuinely uncorrelated with the two active
+    # intraday/overnight sleeves.
+    #
+    # SHIPPED DISABLED — regime-matched walkforward A/B per #44 must
+    # clear the acceptance bar (PF >= 1.10 with CI lower bound >= 1.00,
+    # OOS return positive in >= 4 of 6 yearly windows, Sharpe >= 0.40
+    # with positive lower CI, max DD <= 15%) before enabling.
+    #
+    # Live wiring note: the strategy reads universe-wide daily bars
+    # via an injected loader. The default loader hits the local parquet
+    # cache; the live path will need an explicit loader passed through
+    # create_strategies / strategy_manager when this sleeve is enabled.
+    cross_sectional_momentum:
+      enabled: false
+      allocation_usd: 0.0
+      max_positions: 3
+      universe:
+        - XLF
+        - XLK
+        - XLE
+        - XLV
+        - XLI
+        - XLY
+        - XLP
+        - XLU
+        - XLB
+        - XLRE
+        - XLC
+      lookback_days: 126
+      skip_recent_days: 21
+      top_n: 3
+      rebalance_day_of_month: 1
+      rebalance_time_et: "09:35"
+      disaster_stop_pct: 0.15
+      fractional_shares: true
+      position_pct: 0.95

--- a/trading_bot/strategy/strategies/__init__.py
+++ b/trading_bot/strategy/strategies/__init__.py
@@ -13,6 +13,9 @@ from trading_bot.strategy.strategies.overnight_drift import OvernightDriftStrate
 from trading_bot.strategy.strategies.opening_range_breakout import (
     OpeningRangeBreakoutStrategy,
 )
+from trading_bot.strategy.strategies.cross_sectional_momentum import (
+    CrossSectionalMomentumStrategy,
+)
 
 STRATEGY_REGISTRY: dict[str, type[StrategyBase]] = {
     "mean_reversion": MeanReversionStrategy,
@@ -21,6 +24,7 @@ STRATEGY_REGISTRY: dict[str, type[StrategyBase]] = {
     "sentiment_combo": SentimentComboStrategy,
     "overnight_drift": OvernightDriftStrategy,
     "opening_range_breakout": OpeningRangeBreakoutStrategy,
+    "cross_sectional_momentum": CrossSectionalMomentumStrategy,
 }
 
 

--- a/trading_bot/strategy/strategies/cross_sectional_momentum.py
+++ b/trading_bot/strategy/strategies/cross_sectional_momentum.py
@@ -1,0 +1,325 @@
+"""Cross-sectional momentum strategy (sleeve #6, issue #44).
+
+Ranks a universe of sector ETFs by trailing total return and holds the
+top N on a monthly rebalance. Daily bars; monthly cadence; SWING hold
+so the backtester's intraday wind-down does not flatten positions.
+
+Cross-sectional: ranking requires daily bars for the full universe, not
+just the per-ticker frame the framework passes into ``evaluate_entry``.
+A ``universe_daily_loader`` callable is injected in the constructor and
+serves the universe-wide data. The ranking is memoised per rebalance
+date so the per-ticker call loop within one tick only loads the universe
+once.
+
+The strategy lands disabled. A regime-matched walkforward A/B must
+clear the bar in issue #44 before ``enabled: true`` in config.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from datetime import date, datetime, time, timedelta
+from typing import Any
+
+import pandas as pd
+
+from trading_bot.constants import TZ_EASTERN, HoldType
+from trading_bot.data.holiday_calendar import HolidayCalendar
+from trading_bot.strategy.base import ExitSignal, StrategyBase, StrategyDecision
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+UniverseDailyLoader = Callable[[str, date], "pd.DataFrame | None"]
+
+
+def _default_universe_loader(ticker: str, as_of: date) -> pd.DataFrame | None:
+    """Best-effort loader: reads the local daily parquet cache.
+
+    Returns None on any error or cache miss. Callers should inject an
+    explicit loader for production paths (live or backtest with a known
+    data source); the default keeps the strategy importable from the
+    registry without requiring extra wiring.
+    """
+    try:
+        from trading_bot.data_cache import load_cached
+        return load_cached(ticker, as_of, "daily")
+    except Exception:  # noqa: BLE001
+        return None
+
+
+class CrossSectionalMomentumStrategy(StrategyBase):
+    """Hold the top-N momentum names from a sector-ETF universe."""
+
+    def __init__(
+        self,
+        config: dict[str, Any],
+        universe_daily_loader: UniverseDailyLoader | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            strategy_id="cross_sectional_momentum",
+            display_name="Cross-Sectional Momentum",
+            config=config,
+            **kwargs,
+        )
+        self._universe: tuple[str, ...] = tuple(config.get("universe", []))
+        self._lookback_days: int = int(config.get("lookback_days", 126))
+        self._skip_recent_days: int = int(config.get("skip_recent_days", 0))
+        self._top_n: int = int(config.get("top_n", 3))
+        self._max_positions: int = int(config.get("max_positions", self._top_n))
+        self._rebalance_day_of_month: int = int(
+            config.get("rebalance_day_of_month", 1)
+        )
+        self._rebalance_time: time = _parse_time(
+            str(config.get("rebalance_time_et", "09:35"))
+        )
+        self._disaster_stop_pct: float = float(config.get("disaster_stop_pct", 0.15))
+        self._fractional_shares: bool = bool(config.get("fractional_shares", True))
+        self._position_pct: float = float(config.get("position_pct", 0.95))
+
+        self._loader: UniverseDailyLoader = (
+            universe_daily_loader or _default_universe_loader
+        )
+        self._calendar: HolidayCalendar = HolidayCalendar()
+
+        # Memo: (as_of_date, top_n_set)
+        self._ranking_memo: tuple[date, frozenset[str]] | None = None
+
+    # ------------------------------------------------------------------
+    # Entry
+    # ------------------------------------------------------------------
+
+    def evaluate_entry(
+        self,
+        ticker: str,
+        exchange: str,
+        df_5min: pd.DataFrame,
+        df_daily: pd.DataFrame,
+        current_price: float,
+        available_cash: float,
+        sentiment_score: float | None = None,
+    ) -> StrategyDecision | None:
+        if ticker not in self._universe:
+            return None
+        if current_price <= 0 or available_cash <= 0:
+            return None
+        if df_5min is None or len(df_5min) == 0:
+            return None
+
+        bar_dt: datetime | None = _to_et_datetime(df_5min.index[-1])
+        if bar_dt is None:
+            return None
+        today: date = bar_dt.date()
+
+        if not self._is_rebalance_day(today):
+            return None
+        if bar_dt.time() < self._rebalance_time:
+            return None
+
+        top_n: frozenset[str] = self._top_n_for(today)
+        if ticker not in top_n:
+            return None
+
+        slots: int = max(1, self._top_n)
+        max_spend: float = (available_cash * self._position_pct) / slots
+        if max_spend <= 0:
+            return None
+        shares: float = max_spend / current_price
+        if self._fractional_shares:
+            shares = round(shares, 4)
+        else:
+            shares = float(int(shares))
+        min_shares: float = 0.001 if self._fractional_shares else 1.0
+        if shares < min_shares:
+            return None
+
+        stop_price: float = round(current_price * (1.0 - self._disaster_stop_pct), 2)
+
+        logger.info(
+            "[%s] Entry: %s @ $%.2f shares=%.4f stop=$%.2f top_n=%s",
+            self.strategy_id, ticker, current_price, shares, stop_price,
+            sorted(top_n),
+        )
+
+        return StrategyDecision(
+            ticker=ticker,
+            exchange=exchange,
+            direction="long",
+            shares=shares,
+            entry_price=current_price,
+            stop_price=stop_price,
+            target_price=None,
+            trail_pct=None,
+            hold_type=HoldType.SWING,
+            strategy_id=self.strategy_id,
+            signals={
+                "rebalance_date": today.isoformat(),
+                "top_n": sorted(top_n),
+                "lookback_days": self._lookback_days,
+                "skip_recent_days": self._skip_recent_days,
+            },
+            sentiment_score=sentiment_score,
+        )
+
+    # ------------------------------------------------------------------
+    # Exit
+    # ------------------------------------------------------------------
+
+    def evaluate_exit(
+        self,
+        position: dict[str, Any],
+        current_price: float,
+        df_5min: pd.DataFrame | None = None,
+        df_daily: pd.DataFrame | None = None,
+    ) -> ExitSignal:
+        entry_price: float = float(position.get("entry_price", 0.0))
+
+        # Disaster stop always wins, regardless of day-of-month.
+        if entry_price > 0:
+            loss_pct: float = (entry_price - current_price) / entry_price
+            if loss_pct >= self._disaster_stop_pct:
+                return ExitSignal(
+                    should_exit=True,
+                    reason="disaster_stop",
+                    is_emergency=True,
+                    use_market_order=True,
+                )
+
+        if df_5min is None or len(df_5min) == 0:
+            return ExitSignal(should_exit=False)
+
+        bar_dt: datetime | None = _to_et_datetime(df_5min.index[-1])
+        if bar_dt is None:
+            return ExitSignal(should_exit=False)
+        today: date = bar_dt.date()
+        if not self._is_rebalance_day(today):
+            return ExitSignal(should_exit=False)
+        if bar_dt.time() < self._rebalance_time:
+            return ExitSignal(should_exit=False)
+
+        ticker: str | None = position.get("ticker")
+        if ticker is None or ticker not in self._universe:
+            return ExitSignal(should_exit=False)
+
+        top_n: frozenset[str] = self._top_n_for(today)
+        if ticker in top_n:
+            return ExitSignal(should_exit=False)
+
+        return ExitSignal(
+            should_exit=True,
+            reason="rebalance_out",
+            is_emergency=False,
+            use_market_order=True,
+        )
+
+    def get_max_positions(self) -> int:
+        return self._max_positions
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _is_rebalance_day(self, today: date) -> bool:
+        """True iff *today* is the first NYSE trading day of its month."""
+        if not self._calendar.is_trading_day(today):
+            return False
+        probe: date = today - timedelta(days=1)
+        while probe.month == today.month:
+            if self._calendar.is_trading_day(probe):
+                return False
+            probe -= timedelta(days=1)
+        return True
+
+    def _top_n_for(self, today: date) -> frozenset[str]:
+        if self._ranking_memo is not None and self._ranking_memo[0] == today:
+            return self._ranking_memo[1]
+
+        scores: list[tuple[str, float]] = []
+        required_bars: int = self._lookback_days + self._skip_recent_days + 1
+        for ticker in self._universe:
+            df: pd.DataFrame | None = self._loader(ticker, today)
+            if df is None or len(df) < required_bars:
+                continue
+            score: float | None = _lookback_total_return(
+                df, lookback=self._lookback_days, skip_recent=self._skip_recent_days,
+            )
+            if score is None:
+                continue
+            scores.append((ticker, score))
+
+        scores.sort(key=lambda kv: (-kv[1], kv[0]))  # higher return first, ticker tiebreak
+        top: frozenset[str] = frozenset(t for t, _ in scores[: self._top_n])
+
+        self._ranking_memo = (today, top)
+        logger.debug(
+            "[%s] Ranking for %s: %s (top %d of %d)",
+            self.strategy_id, today.isoformat(),
+            [(t, round(s, 4)) for t, s in scores],
+            self._top_n, len(scores),
+        )
+        return top
+
+
+# ---------------------------------------------------------------------------
+# Free helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_time(value: str) -> time:
+    """Parse 'HH:MM' to a ``time``."""
+    parts = value.split(":")
+    if len(parts) != 2:
+        raise ValueError(f"Invalid time string '{value}', expected HH:MM")
+    return time(int(parts[0]), int(parts[1]))
+
+
+def _to_et_datetime(ts: Any) -> datetime | None:
+    """Coerce a bar index value to a US/Eastern ``datetime``."""
+    if ts is None:
+        return None
+    if hasattr(ts, "to_pydatetime"):
+        dt = ts.to_pydatetime()
+    else:
+        dt = ts
+    if not isinstance(dt, datetime):
+        return None
+    if dt.tzinfo is not None:
+        try:
+            return dt.astimezone(TZ_EASTERN)
+        except Exception:  # noqa: BLE001
+            return dt
+    return dt
+
+
+def _lookback_total_return(
+    df: pd.DataFrame,
+    lookback: int,
+    skip_recent: int,
+) -> float | None:
+    """Total return over ``lookback`` bars ending ``skip_recent`` bars ago.
+
+    With ``skip_recent=0`` this is just the trailing ``lookback`` return.
+    With ``skip_recent>0`` the most recent ``skip_recent`` bars are
+    excluded (the standard "skip-most-recent-month" momentum variant).
+
+    Returns None when the frame is too short or the start price is
+    non-positive.
+    """
+    if df is None or "close" not in df.columns:
+        return None
+    closes: pd.Series = df["close"].astype(float).dropna()
+    needed: int = lookback + skip_recent + 1
+    if len(closes) < needed:
+        return None
+    if skip_recent > 0:
+        end_idx: int = -skip_recent - 1
+    else:
+        end_idx = -1
+    start_idx: int = end_idx - lookback
+    start_price: float = float(closes.iloc[start_idx])
+    end_price: float = float(closes.iloc[end_idx])
+    if start_price <= 0:
+        return None
+    return (end_price - start_price) / start_price

--- a/trading_bot/tests/test_cross_sectional_momentum.py
+++ b/trading_bot/tests/test_cross_sectional_momentum.py
@@ -1,0 +1,534 @@
+"""Tests for the cross-sectional momentum strategy (sleeve #6, issue #44)."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
+from typing import Any
+from zoneinfo import ZoneInfo
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from trading_bot.constants import HoldType
+from trading_bot.strategy.strategies.cross_sectional_momentum import (
+    CrossSectionalMomentumStrategy,
+)
+
+
+ET = ZoneInfo("US/Eastern")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _daily_bars(
+    n: int,
+    end_date: date,
+    total_return: float,
+    start_price: float = 100.0,
+) -> pd.DataFrame:
+    """Build n daily bars ending on end_date with a target total return.
+
+    Linear price path — keeps the ranking math trivial and deterministic.
+    """
+    end_price: float = start_price * (1.0 + total_return)
+    prices: np.ndarray = np.linspace(start_price, end_price, n)
+    dates: list[pd.Timestamp] = []
+    # walk backwards from end_date, weekdays only, to give n trading days
+    d = end_date
+    while len(dates) < n:
+        if d.weekday() < 5:
+            dates.append(pd.Timestamp(d, tz=ET))
+        d -= timedelta(days=1)
+    dates.reverse()
+    idx = pd.DatetimeIndex(dates, name="timestamp")
+    return pd.DataFrame(
+        {
+            "open": prices,
+            "high": prices * 1.005,
+            "low": prices * 0.995,
+            "close": prices,
+            "volume": np.full(n, 1_000_000),
+        },
+        index=idx,
+    )
+
+
+def _five_min_bar(ts_et: datetime, close: float = 100.0) -> pd.DataFrame:
+    """Single-row 5-min frame indexed at ts_et (ET, tz-aware)."""
+    return pd.DataFrame(
+        {
+            "open": [close],
+            "high": [close * 1.001],
+            "low": [close * 0.999],
+            "close": [close],
+            "volume": [10_000],
+        },
+        index=pd.DatetimeIndex([pd.Timestamp(ts_et).tz_convert(ET)], name="timestamp"),
+    )
+
+
+def _config(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "enabled": True,
+        "allocation_usd": 1500.0,
+        "max_positions": 2,
+        "universe": ["XLF", "XLK", "XLE", "XLV"],
+        "lookback_days": 60,
+        "skip_recent_days": 0,
+        "top_n": 2,
+        "rebalance_day_of_month": 1,
+        "rebalance_time_et": "09:35",
+        "disaster_stop_pct": 0.15,
+        "fractional_shares": True,
+        "position_pct": 0.95,
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_universe_loader(
+    bars_by_ticker: dict[str, pd.DataFrame],
+) -> Any:
+    """Return a loader callable that ignores the as-of date and just
+    serves the pre-built per-ticker daily frame."""
+
+    def _loader(ticker: str, _as_of: date) -> pd.DataFrame | None:
+        return bars_by_ticker.get(ticker)
+
+    return _loader
+
+
+def _first_trading_day_jan_2026() -> date:
+    # 2026-01-01 is a Thursday and a market holiday; first trading day = Jan 2 (Fri).
+    return date(2026, 1, 2)
+
+
+def _mid_month_2026() -> date:
+    # Mid-January Tuesday — not a rebalance day under day_of_month=1.
+    return date(2026, 1, 13)
+
+
+# ---------------------------------------------------------------------------
+# Rebalance-day gating
+# ---------------------------------------------------------------------------
+
+
+def test_off_rebalance_day_returns_none() -> None:
+    """Non-rebalance days produce no decisions."""
+    mid_month: date = _mid_month_2026()
+    bars: dict[str, pd.DataFrame] = {
+        t: _daily_bars(120, mid_month, total_return=r)
+        for t, r in [("XLF", 0.05), ("XLK", 0.20), ("XLE", -0.02), ("XLV", 0.10)]
+    }
+    strat = CrossSectionalMomentumStrategy(
+        config=_config(), universe_daily_loader=_make_universe_loader(bars),
+    )
+    decision = strat.evaluate_entry(
+        ticker="XLK",
+        exchange="NYSE",
+        df_5min=_five_min_bar(datetime(2026, 1, 13, 9, 35, tzinfo=ET)),
+        df_daily=bars["XLK"],
+        current_price=120.0,
+        available_cash=1500.0,
+    )
+    assert decision is None
+
+
+def test_before_rebalance_time_returns_none() -> None:
+    """Even on a rebalance day, fire only at/after the rebalance time."""
+    reb: date = _first_trading_day_jan_2026()
+    bars: dict[str, pd.DataFrame] = {
+        t: _daily_bars(120, reb, total_return=r)
+        for t, r in [("XLF", 0.05), ("XLK", 0.20), ("XLE", -0.02), ("XLV", 0.10)]
+    }
+    strat = CrossSectionalMomentumStrategy(
+        config=_config(), universe_daily_loader=_make_universe_loader(bars),
+    )
+    decision = strat.evaluate_entry(
+        ticker="XLK",
+        exchange="NYSE",
+        df_5min=_five_min_bar(datetime(2026, 1, 2, 9, 30, tzinfo=ET)),
+        df_daily=bars["XLK"],
+        current_price=120.0,
+        available_cash=1500.0,
+    )
+    assert decision is None
+
+
+def test_ticker_not_in_universe_returns_none() -> None:
+    reb: date = _first_trading_day_jan_2026()
+    bars: dict[str, pd.DataFrame] = {
+        t: _daily_bars(120, reb, total_return=r)
+        for t, r in [("XLF", 0.05), ("XLK", 0.20), ("XLE", -0.02), ("XLV", 0.10)]
+    }
+    strat = CrossSectionalMomentumStrategy(
+        config=_config(), universe_daily_loader=_make_universe_loader(bars),
+    )
+    decision = strat.evaluate_entry(
+        ticker="SPY",  # not in universe
+        exchange="NYSE",
+        df_5min=_five_min_bar(datetime(2026, 1, 2, 9, 35, tzinfo=ET)),
+        df_daily=_daily_bars(120, reb, total_return=0.30),
+        current_price=500.0,
+        available_cash=1500.0,
+    )
+    assert decision is None
+
+
+# ---------------------------------------------------------------------------
+# Ranking math
+# ---------------------------------------------------------------------------
+
+
+def test_top_n_picks_highest_lookback_return() -> None:
+    """Top-N = 2 should pick XLK (+25%) and XLV (+18%), reject XLE/XLF."""
+    reb: date = _first_trading_day_jan_2026()
+    bars: dict[str, pd.DataFrame] = {
+        "XLF": _daily_bars(80, reb, total_return=0.05),
+        "XLK": _daily_bars(80, reb, total_return=0.25),
+        "XLE": _daily_bars(80, reb, total_return=-0.10),
+        "XLV": _daily_bars(80, reb, total_return=0.18),
+    }
+    strat = CrossSectionalMomentumStrategy(
+        config=_config(top_n=2), universe_daily_loader=_make_universe_loader(bars),
+    )
+    ts = datetime(2026, 1, 2, 9, 35, tzinfo=ET)
+
+    # XLK is a winner
+    dec_xlk = strat.evaluate_entry(
+        ticker="XLK", exchange="NYSE",
+        df_5min=_five_min_bar(ts), df_daily=bars["XLK"],
+        current_price=125.0, available_cash=1500.0,
+    )
+    assert dec_xlk is not None
+    assert dec_xlk.ticker == "XLK"
+    assert dec_xlk.hold_type == HoldType.SWING
+    assert dec_xlk.target_price is None
+    assert dec_xlk.trail_pct is None
+
+    # XLF is NOT in top-2
+    dec_xlf = strat.evaluate_entry(
+        ticker="XLF", exchange="NYSE",
+        df_5min=_five_min_bar(ts), df_daily=bars["XLF"],
+        current_price=105.0, available_cash=1500.0,
+    )
+    assert dec_xlf is None
+
+
+def test_skip_recent_month_changes_ranking() -> None:
+    """skip_recent_days=21 should rank on the 60-bar window ending 21 days
+    before today, not the most recent 60 bars."""
+    reb: date = _first_trading_day_jan_2026()
+    # XLK: huge dump in last 21 days but stellar before — should still rank highly
+    # XLV: steady up; should rank below XLK once the dump is skipped.
+    n = 120
+
+    # Build a path: first ~75 bars XLK rises strongly, then last 21 bars crash.
+    def _xlk_path() -> pd.DataFrame:
+        # Concatenate two segments
+        early = _daily_bars(99, reb - timedelta(days=30), total_return=0.40)
+        late = _daily_bars(21, reb, total_return=-0.30, start_price=float(early["close"].iloc[-1]))
+        df = pd.concat([early, late.iloc[1:]])  # drop overlap day
+        # Reindex to last n bars
+        return df.iloc[-n:]
+
+    def _xlv_path() -> pd.DataFrame:
+        return _daily_bars(n, reb, total_return=0.10)
+
+    bars: dict[str, pd.DataFrame] = {
+        "XLF": _daily_bars(n, reb, total_return=0.02),
+        "XLK": _xlk_path(),
+        "XLE": _daily_bars(n, reb, total_return=-0.05),
+        "XLV": _xlv_path(),
+    }
+
+    # Without skip, XLK's last-21-day crash dominates → XLK out, XLV in
+    strat_no_skip = CrossSectionalMomentumStrategy(
+        config=_config(top_n=1, skip_recent_days=0, lookback_days=60),
+        universe_daily_loader=_make_universe_loader(bars),
+    )
+    ts = datetime(2026, 1, 2, 9, 35, tzinfo=ET)
+    dec_no_skip_xlk = strat_no_skip.evaluate_entry(
+        ticker="XLK", exchange="NYSE", df_5min=_five_min_bar(ts),
+        df_daily=bars["XLK"], current_price=100.0, available_cash=1500.0,
+    )
+    dec_no_skip_xlv = strat_no_skip.evaluate_entry(
+        ticker="XLV", exchange="NYSE", df_5min=_five_min_bar(ts),
+        df_daily=bars["XLV"], current_price=100.0, available_cash=1500.0,
+    )
+    assert dec_no_skip_xlk is None
+    assert dec_no_skip_xlv is not None
+
+    # With skip-21, the dump is excluded → XLK's earlier ramp dominates
+    strat_skip = CrossSectionalMomentumStrategy(
+        config=_config(top_n=1, skip_recent_days=21, lookback_days=60),
+        universe_daily_loader=_make_universe_loader(bars),
+    )
+    dec_skip_xlk = strat_skip.evaluate_entry(
+        ticker="XLK", exchange="NYSE", df_5min=_five_min_bar(ts),
+        df_daily=bars["XLK"], current_price=100.0, available_cash=1500.0,
+    )
+    assert dec_skip_xlk is not None
+
+
+def test_ticker_with_insufficient_history_excluded() -> None:
+    """A universe member with < lookback_days bars is excluded from ranking
+    but does not crash, and other members still rank normally."""
+    reb: date = _first_trading_day_jan_2026()
+    bars: dict[str, pd.DataFrame] = {
+        "XLF": _daily_bars(80, reb, total_return=0.05),
+        "XLK": _daily_bars(80, reb, total_return=0.30),
+        # Brand-new ETF — only 10 days of history
+        "XLE": _daily_bars(10, reb, total_return=0.50),
+        "XLV": _daily_bars(80, reb, total_return=0.20),
+    }
+    strat = CrossSectionalMomentumStrategy(
+        config=_config(top_n=2, lookback_days=60),
+        universe_daily_loader=_make_universe_loader(bars),
+    )
+    ts = datetime(2026, 1, 2, 9, 35, tzinfo=ET)
+
+    # XLE has insufficient history → excluded; top-2 = XLK + XLV
+    dec_xle = strat.evaluate_entry(
+        ticker="XLE", exchange="NYSE", df_5min=_five_min_bar(ts),
+        df_daily=bars["XLE"], current_price=100.0, available_cash=1500.0,
+    )
+    assert dec_xle is None
+
+    dec_xlk = strat.evaluate_entry(
+        ticker="XLK", exchange="NYSE", df_5min=_five_min_bar(ts),
+        df_daily=bars["XLK"], current_price=130.0, available_cash=1500.0,
+    )
+    assert dec_xlk is not None
+
+
+def test_universe_loader_returns_none_excludes_ticker() -> None:
+    """If the loader returns None for a universe member, that member is
+    silently excluded from ranking (no crash, no fail-loud)."""
+    reb: date = _first_trading_day_jan_2026()
+    bars: dict[str, pd.DataFrame | None] = {
+        "XLF": _daily_bars(80, reb, total_return=0.05),
+        "XLK": _daily_bars(80, reb, total_return=0.30),
+        "XLE": None,
+        "XLV": _daily_bars(80, reb, total_return=0.20),
+    }
+    strat = CrossSectionalMomentumStrategy(
+        config=_config(top_n=2, lookback_days=60),
+        universe_daily_loader=lambda t, _d: bars.get(t),
+    )
+    ts = datetime(2026, 1, 2, 9, 35, tzinfo=ET)
+    dec_xlk = strat.evaluate_entry(
+        ticker="XLK", exchange="NYSE", df_5min=_five_min_bar(ts),
+        df_daily=bars["XLK"], current_price=130.0, available_cash=1500.0,
+    )
+    assert dec_xlk is not None
+
+
+# ---------------------------------------------------------------------------
+# Sizing & decision shape
+# ---------------------------------------------------------------------------
+
+
+def test_decision_is_slot_aware() -> None:
+    """Per-slot spend = (cash * position_pct) / top_n."""
+    reb: date = _first_trading_day_jan_2026()
+    bars: dict[str, pd.DataFrame] = {
+        t: _daily_bars(80, reb, total_return=r)
+        for t, r in [("XLF", 0.05), ("XLK", 0.25), ("XLE", -0.10), ("XLV", 0.18)]
+    }
+    strat = CrossSectionalMomentumStrategy(
+        config=_config(top_n=2, position_pct=0.95, fractional_shares=True),
+        universe_daily_loader=_make_universe_loader(bars),
+    )
+    ts = datetime(2026, 1, 2, 9, 35, tzinfo=ET)
+    dec = strat.evaluate_entry(
+        ticker="XLK", exchange="NYSE", df_5min=_five_min_bar(ts),
+        df_daily=bars["XLK"], current_price=125.0, available_cash=1500.0,
+    )
+    assert dec is not None
+    # Per-slot budget = 1500 * 0.95 / 2 = 712.5; shares ≈ 712.5 / 125 = 5.7
+    expected_shares = round((1500.0 * 0.95 / 2) / 125.0, 4)
+    assert dec.shares == pytest.approx(expected_shares, rel=1e-4)
+
+
+def test_disaster_stop_set_relative_to_entry() -> None:
+    """Stop price is entry * (1 - disaster_stop_pct), rounded to 2dp."""
+    reb: date = _first_trading_day_jan_2026()
+    bars: dict[str, pd.DataFrame] = {
+        t: _daily_bars(80, reb, total_return=r)
+        for t, r in [("XLF", 0.05), ("XLK", 0.25), ("XLE", -0.10), ("XLV", 0.18)]
+    }
+    strat = CrossSectionalMomentumStrategy(
+        config=_config(top_n=2, disaster_stop_pct=0.15),
+        universe_daily_loader=_make_universe_loader(bars),
+    )
+    ts = datetime(2026, 1, 2, 9, 35, tzinfo=ET)
+    dec = strat.evaluate_entry(
+        ticker="XLK", exchange="NYSE", df_5min=_five_min_bar(ts),
+        df_daily=bars["XLK"], current_price=200.0, available_cash=1500.0,
+    )
+    assert dec is not None
+    assert dec.stop_price == pytest.approx(200.0 * 0.85, abs=0.01)
+
+
+# ---------------------------------------------------------------------------
+# Exit logic
+# ---------------------------------------------------------------------------
+
+
+def test_exit_on_disaster_stop_any_day() -> None:
+    strat = CrossSectionalMomentumStrategy(
+        config=_config(), universe_daily_loader=_make_universe_loader({}),
+    )
+    position = {
+        "ticker": "XLK",
+        "entry_price": 100.0,
+        "stop_price": 85.0,
+        "entry_time": datetime(2026, 1, 2, 9, 35, tzinfo=ET),
+    }
+    sig = strat.evaluate_exit(position=position, current_price=80.0)
+    assert sig.should_exit
+    assert sig.reason == "disaster_stop"
+    assert sig.is_emergency
+    assert sig.use_market_order
+
+
+def test_no_exit_when_in_top_n_and_no_stop_hit() -> None:
+    reb: date = _first_trading_day_jan_2026()
+    bars: dict[str, pd.DataFrame] = {
+        t: _daily_bars(80, reb, total_return=r)
+        for t, r in [("XLF", 0.05), ("XLK", 0.25), ("XLE", -0.10), ("XLV", 0.18)]
+    }
+    strat = CrossSectionalMomentumStrategy(
+        config=_config(top_n=2), universe_daily_loader=_make_universe_loader(bars),
+    )
+    # Touch ranking with an entry call to prime the memo
+    ts = datetime(2026, 1, 2, 9, 35, tzinfo=ET)
+    strat.evaluate_entry(
+        ticker="XLK", exchange="NYSE", df_5min=_five_min_bar(ts),
+        df_daily=bars["XLK"], current_price=125.0, available_cash=1500.0,
+    )
+    position = {
+        "ticker": "XLK",
+        "entry_price": 125.0,
+        "stop_price": 106.25,
+        "entry_time": datetime(2026, 1, 2, 9, 35, tzinfo=ET),
+    }
+    df_5 = _five_min_bar(datetime(2026, 1, 2, 10, 0, tzinfo=ET))
+    sig = strat.evaluate_exit(
+        position=position, current_price=126.0,
+        df_5min=df_5, df_daily=bars["XLK"],
+    )
+    assert not sig.should_exit
+
+
+def test_exit_on_rebalance_day_when_position_drops_out_of_top_n() -> None:
+    """On the next rebalance day, if the held ticker is no longer in top-N,
+    a normal (non-emergency) exit fires."""
+    feb_reb: date = date(2026, 2, 2)  # 2026-02-01 is Sunday → first trading day = Feb 2 (Mon)
+    bars: dict[str, pd.DataFrame] = {
+        "XLF": _daily_bars(80, feb_reb, total_return=0.30),
+        "XLK": _daily_bars(80, feb_reb, total_return=-0.05),  # held but now last
+        "XLE": _daily_bars(80, feb_reb, total_return=0.25),
+        "XLV": _daily_bars(80, feb_reb, total_return=0.18),
+    }
+    strat = CrossSectionalMomentumStrategy(
+        config=_config(top_n=2), universe_daily_loader=_make_universe_loader(bars),
+    )
+    position = {
+        "ticker": "XLK",
+        "entry_price": 125.0,
+        "stop_price": 106.25,
+        "entry_time": datetime(2026, 1, 2, 9, 35, tzinfo=ET),
+    }
+    df_5 = _five_min_bar(datetime(2026, 2, 2, 9, 35, tzinfo=ET))
+    sig = strat.evaluate_exit(
+        position=position, current_price=119.0,
+        df_5min=df_5, df_daily=bars["XLK"],
+    )
+    assert sig.should_exit
+    assert sig.reason == "rebalance_out"
+    assert not sig.is_emergency
+
+
+def test_no_exit_on_rebalance_day_when_still_in_top_n() -> None:
+    feb_reb: date = date(2026, 2, 2)
+    bars: dict[str, pd.DataFrame] = {
+        "XLF": _daily_bars(80, feb_reb, total_return=0.05),
+        "XLK": _daily_bars(80, feb_reb, total_return=0.30),  # still top
+        "XLE": _daily_bars(80, feb_reb, total_return=-0.10),
+        "XLV": _daily_bars(80, feb_reb, total_return=0.20),
+    }
+    strat = CrossSectionalMomentumStrategy(
+        config=_config(top_n=2), universe_daily_loader=_make_universe_loader(bars),
+    )
+    position = {
+        "ticker": "XLK",
+        "entry_price": 125.0,
+        "stop_price": 106.25,
+        "entry_time": datetime(2026, 1, 2, 9, 35, tzinfo=ET),
+    }
+    df_5 = _five_min_bar(datetime(2026, 2, 2, 9, 35, tzinfo=ET))
+    sig = strat.evaluate_exit(
+        position=position, current_price=140.0,
+        df_5min=df_5, df_daily=bars["XLK"],
+    )
+    assert not sig.should_exit
+
+
+# ---------------------------------------------------------------------------
+# Memoization & metadata
+# ---------------------------------------------------------------------------
+
+
+def test_ranking_memoized_within_same_rebalance_date() -> None:
+    """Multiple per-ticker calls on the same date should call the loader
+    universe_size − 1 times total (one batch on first call), not per-ticker."""
+    reb: date = _first_trading_day_jan_2026()
+    bars: dict[str, pd.DataFrame] = {
+        t: _daily_bars(80, reb, total_return=r)
+        for t, r in [("XLF", 0.05), ("XLK", 0.25), ("XLE", -0.10), ("XLV", 0.18)]
+    }
+    call_counter: dict[str, int] = {"n": 0}
+
+    def _counting_loader(t: str, _d: date) -> pd.DataFrame | None:
+        call_counter["n"] += 1
+        return bars.get(t)
+
+    strat = CrossSectionalMomentumStrategy(
+        config=_config(top_n=2), universe_daily_loader=_counting_loader,
+    )
+    ts = datetime(2026, 1, 2, 9, 35, tzinfo=ET)
+
+    # First call — should load all 4 universe members
+    strat.evaluate_entry(
+        ticker="XLK", exchange="NYSE", df_5min=_five_min_bar(ts),
+        df_daily=bars["XLK"], current_price=125.0, available_cash=1500.0,
+    )
+    first_count = call_counter["n"]
+    assert first_count >= 4  # loaded the universe at least once
+
+    # Second call same day — should reuse memo, not reload
+    strat.evaluate_entry(
+        ticker="XLV", exchange="NYSE", df_5min=_five_min_bar(ts),
+        df_daily=bars["XLV"], current_price=118.0, available_cash=1500.0,
+    )
+    assert call_counter["n"] == first_count
+
+
+def test_get_max_positions_returns_config_value() -> None:
+    strat = CrossSectionalMomentumStrategy(
+        config=_config(max_positions=3),
+        universe_daily_loader=_make_universe_loader({}),
+    )
+    assert strat.get_max_positions() == 3
+
+
+def test_registry_includes_cross_sectional_momentum() -> None:
+    from trading_bot.strategy.strategies import STRATEGY_REGISTRY
+    assert "cross_sectional_momentum" in STRATEGY_REGISTRY
+    assert STRATEGY_REGISTRY["cross_sectional_momentum"] is CrossSectionalMomentumStrategy


### PR DESCRIPTION
## Summary

Implements the cross_sectional_momentum sleeve (issue #44) end-to-end:

1. **Strategy** — `trading_bot/strategy/strategies/cross_sectional_momentum.py`. Ranks the 11 SPDR sector ETFs by trailing total return; holds top N on the first NYSE trading day of each month. Daily bars, monthly cadence, `HoldType.SWING`.

2. **Universe loader plumbing** — `StrategyBase` gains `get_universe_tickers()` + `set_universe_daily_loader()` hooks (no-op defaults). `StrategyManager._refresh_universe_loaders` discovers + pre-fetches in parallel via `asyncio.gather(get_daily_bars)` and injects a sync closure-loader. `MultiStrategyBacktester._wire_backtest_universe_loaders` does the same against the local parquet cache. Mirrors live + backtest paths.

3. **Backtester SWING-honor fix** — surfaced during integration. Backtester silently overrode `decision.stop_price`/`target_price`/`trail_pct`/`shares` with ATR-anchored intraday logic for all strategies, which turned my monthly holds into 5-min noise traps. New `_resolve_swing_decision_params` honors strategy decisions when `hold_type == SWING` and explicit risk params are set; INTRADAY strategies keep the existing ATR-override path. Bonus fixes: `_check_trade_exit` was building a `position_dict` without `ticker` (cross-sectional rebalance-out couldn't fire); `backtest_end` force-close used `entry_price` as exit (zeroed all SWING P&L).

4. **A/B walkforward** — `trading_bot/docs/cross_sectional_momentum/ab_walkforward_2026_05_23.md`. 6 yearly windows, 2020-07-27 to 2026-04-16, 13-ETF universe.

   | Criterion | Bar | Actual | Pass |
   |---|---|---|:---:|
   | Portfolio PF | ≥ 1.10 | 2.334 | ✅ |
   | PF 95% CI lower bound | ≥ 1.00 | 1.123 | ✅ |
   | OOS positive windows | ≥ 4 of 6 | 5 of 6 | ✅ |
   | Sharpe (point) | ≥ 0.40 | 0.273 | ❌ |
   | Sharpe CI lower bound | > 0 | 0.041 | ✅ |
   | Max drawdown | ≤ 15% | 13.57% worst window | ✅ |

   **Status: ships disabled.** 3 of 4 hard criteria pass; Sharpe point misses the 0.40 line. Recommendation in the report: re-run with the ticket-spec 126/21 lookback once the daily cache is extended (the A/B used 60/0 to fit the existing 120-row cache files), or take a scope decision on the Sharpe bar for low-turnover monthly strategies. Plumbing + backtester patches have independent value for any future cross-sectional sleeve (#45 pair stat-arb).

## Files

- `trading_bot/strategy/strategies/cross_sectional_momentum.py` — new strategy
- `trading_bot/strategy/strategies/__init__.py` — registry entry
- `trading_bot/strategy/base.py` — universe-aware hooks
- `trading_bot/strategy/strategy_manager.py` — live-path pre-fetch + inject
- `trading_bot/multi_strategy_backtest.py` — backtester loader wiring + SWING-honor + ticker fix + backtest_end mark-to-market
- `trading_bot/tests/test_cross_sectional_momentum.py` — 16 strategy tests
- `trading_bot/tests/test_universe_loader_plumbing.py` — 8 plumbing tests
- `trading_bot/tests/test_backtester_swing_params.py` — 10 backtester-patch tests
- `trading_bot/docs/cross_sectional_momentum/ab_walkforward_2026_05_23.md` — A/B report
- `config.yaml` — disabled sleeve block

## Test plan

- [x] `pytest trading_bot/tests/test_cross_sectional_momentum.py` — 16/16
- [x] `pytest trading_bot/tests/test_universe_loader_plumbing.py` — 8/8
- [x] `pytest trading_bot/tests/test_backtester_swing_params.py` — 10/10
- [x] `pytest` — full suite 1010 passed / 1 skipped
- [x] Smoke backtest H1 2021 single-ticker — +22.37% return after fixes, 8 trades, 87.5% WR
- [x] Full 6-year walkforward A/B — see report
- [ ] **Follow-up A** (before enabling): extend daily cache to support 126+21 lookback, re-run A/B with ticket-spec params
- [ ] **Follow-up B** (before enabling): scope decision on Sharpe acceptance bar for monthly cadence strategies

Closes #44 (implementation, plumbing, A/B); enabling deferred to follow-up.