### PR TITLE
fix(mean_reversion): time_stop must use bar time, not wall-clock (regression from #154)

### DIFF
--- a/trading_bot/strategy/strategies/mean_reversion.py
+++ b/trading_bot/strategy/strategies/mean_reversion.py
@@ -333,13 +333,25 @@ class MeanReversionStrategy(StrategyBase):
         # trading days so weekends / NYSE holidays do not consume the budget.
         # Fires before the RSI check so a stalled position is always released
         # within _max_hold_days sessions regardless of RSI state.
+        #
+        # "Now" is derived from the bar timestamp (``df_5min.index[-1]``)
+        # rather than ``datetime.now()``. This is the *only* source that works
+        # in both live (where the latest bar is ~now) and backtest (where the
+        # latest bar is the historical bar being simulated).  PR #154 used
+        # ``datetime.now()`` unconditionally, which silently broke every
+        # backtest of mean_reversion since 2026-05-23: historical entry_time
+        # vs today's wall-clock made elapsed_days >> max_hold_days on every
+        # trade, so 100% of trades exited via time_stop ~1 bar after entry
+        # (single-pass 5.7yr run: -30% return, 30.8% WR, 2185 trades all
+        # tagged time_stop).  ``datetime.now()`` remains the fallback when
+        # no bars are passed (degraded live-path safety net only).
         entry_time_raw: Any = position.get("entry_time")
         if entry_time_raw is not None:
             try:
                 entry_dt: datetime = datetime.fromisoformat(str(entry_time_raw))
                 if entry_dt.tzinfo is None:
                     entry_dt = entry_dt.replace(tzinfo=TZ_EASTERN)
-                now_et: datetime = datetime.now(tz=TZ_EASTERN)
+                now_et: datetime = _bar_time_or_now(df_5min)
                 cal: HolidayCalendar = HolidayCalendar()
                 elapsed_days: int = count_trading_days_between(
                     cal,
@@ -375,3 +387,22 @@ class MeanReversionStrategy(StrategyBase):
 
     def get_max_positions(self) -> int:
         return self._max_positions
+
+
+def _bar_time_or_now(df_5min: pd.DataFrame | None) -> datetime:
+    """Return the timestamp of the last bar in ``df_5min`` (ET-localised),
+    or ``datetime.now(tz=ET)`` if no bars are available.
+
+    The bar timestamp is the correct "now" for any time-based exit check —
+    in live the latest bar IS approximately now, in backtest the latest
+    bar IS the simulation's current instant.  ``datetime.now()`` as the
+    primary clock is a backtest-breaker (see time_stop block).
+    """
+    if df_5min is not None and len(df_5min) > 0:
+        ts: Any = df_5min.index[-1]
+        dt: Any = ts.to_pydatetime() if hasattr(ts, "to_pydatetime") else ts
+        if isinstance(dt, datetime):
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=TZ_EASTERN)
+            return dt.astimezone(TZ_EASTERN)
+    return datetime.now(tz=TZ_EASTERN)

--- a/trading_bot/strategy/strategies/mean_reversion.py
+++ b/trading_bot/strategy/strategies/mean_reversion.py
@@ -395,8 +395,8 @@ def _bar_time_or_now(df_5min: pd.DataFrame | None) -> datetime:
 
     The bar timestamp is the correct "now" for any time-based exit check —
     in live the latest bar IS approximately now, in backtest the latest
-    bar IS the simulation's current instant.  ``datetime.now()`` as the
-    primary clock is a backtest-breaker (see time_stop block).
+    bar IS the simulation's current instant.  ``datetime.now(tz=ET)`` as
+    the primary clock is a backtest-breaker (see time_stop block).
     """
     if df_5min is not None and len(df_5min) > 0:
         ts: Any = df_5min.index[-1]

--- a/trading_bot/tests/test_mean_reversion_time_stop.py
+++ b/trading_bot/tests/test_mean_reversion_time_stop.py
@@ -22,6 +22,8 @@ from typing import Any
 from unittest.mock import patch
 from zoneinfo import ZoneInfo
 
+import numpy as np
+import pandas as pd
 import pytest
 
 from trading_bot.strategy.strategies.mean_reversion import MeanReversionStrategy
@@ -269,9 +271,6 @@ def test_weekend_not_counted_as_trading_day() -> None:
 # time_stop).  The fix derives "now" from ``df_5min.index[-1]`` when
 # bars are supplied.  These tests pin the new contract — no datetime
 # patching needed.
-
-import numpy as np
-import pandas as pd
 
 
 def _five_min_frame(end_dt: datetime, n_bars: int = 5) -> pd.DataFrame:

--- a/trading_bot/tests/test_mean_reversion_time_stop.py
+++ b/trading_bot/tests/test_mean_reversion_time_stop.py
@@ -255,3 +255,107 @@ def test_weekend_not_counted_as_trading_day() -> None:
 
     # 1 trading day < max_hold_days=2 → no exit
     assert signal.should_exit is False
+
+
+# ---------------------------------------------------------------------------
+# H. Regression: time_stop uses bar timestamp, not datetime.now()
+# ---------------------------------------------------------------------------
+#
+# PR #154 used ``datetime.now()`` unconditionally to compute elapsed
+# trading days.  That silently broke every backtest of mean_reversion:
+# historical entry_time vs today's wall-clock made elapsed_days >>
+# max_hold_days on every trade, so 100% exited via time_stop ~1 bar
+# after entry (single-pass 5.7yr run: -30% / 30.8% WR / 2185 trades all
+# time_stop).  The fix derives "now" from ``df_5min.index[-1]`` when
+# bars are supplied.  These tests pin the new contract — no datetime
+# patching needed.
+
+import numpy as np
+import pandas as pd
+
+
+def _five_min_frame(end_dt: datetime, n_bars: int = 5) -> pd.DataFrame:
+    """Synthetic 5-min frame ending at end_dt (ET-localised)."""
+    idx = pd.date_range(end=pd.Timestamp(end_dt), periods=n_bars, freq="5min")
+    return pd.DataFrame(
+        {
+            "open": np.full(n_bars, 100.0),
+            "high": np.full(n_bars, 100.5),
+            "low": np.full(n_bars, 99.5),
+            "close": np.full(n_bars, 100.0),
+            "volume": np.full(n_bars, 100_000),
+        },
+        index=idx,
+    )
+
+
+@pytest.mark.unit
+def test_time_stop_uses_bar_time_not_wallclock() -> None:
+    """In backtest, ``df_5min.index[-1]`` is the simulated 'now' — not
+    today's wall-clock.  An entry from 2021 evaluated against a 2021 bar
+    must NOT exit via time_stop (because elapsed_days = 0 in bar-space)
+    even though wall-clock elapsed is years.
+    """
+    strategy = _strategy({"max_hold_days": 5})
+    # Historical entry: entry and bar both at the same simulated instant,
+    # so elapsed = 0 trading days.
+    historical_entry = datetime(2021, 3, 15, 10, 0, 0, tzinfo=ET)
+    historical_bar_time = datetime(2021, 3, 15, 10, 5, 0, tzinfo=ET)
+
+    pos = _position(entry_time=historical_entry, stop_price=90.0, target_price=120.0)
+    df_5min = _five_min_frame(end_dt=historical_bar_time)
+
+    # No datetime patching — this is the production code path the
+    # backtester hits.  Pre-fix this returned should_exit=True because
+    # datetime.now() returned today and elapsed_days >> 5.
+    signal = strategy.evaluate_exit(
+        position=pos,
+        current_price=100.0,
+        df_5min=df_5min,
+    )
+
+    assert signal.should_exit is False
+    # Sanity: also confirm reason isn't time_stop in any other branch.
+    assert signal.reason != "time_stop"
+
+
+@pytest.mark.unit
+def test_time_stop_fires_when_bar_time_advances_past_threshold() -> None:
+    """Same historical entry, but the bar is now 6 trading days later.
+    Must fire time_stop based on bar elapsed, regardless of wall-clock.
+    """
+    strategy = _strategy({"max_hold_days": 5})
+    historical_entry = datetime(2021, 3, 15, 10, 0, 0, tzinfo=ET)  # Mon
+    # 6 trading days later: 2021-03-15 (Mon) → 2021-03-23 (Tue) = 6 trading days
+    historical_bar_time = datetime(2021, 3, 23, 10, 5, 0, tzinfo=ET)
+
+    pos = _position(entry_time=historical_entry, stop_price=90.0, target_price=120.0)
+    df_5min = _five_min_frame(end_dt=historical_bar_time)
+
+    signal = strategy.evaluate_exit(
+        position=pos,
+        current_price=100.0,
+        df_5min=df_5min,
+    )
+
+    assert signal.should_exit is True
+    assert signal.reason == "time_stop"
+
+
+@pytest.mark.unit
+def test_time_stop_falls_back_to_wallclock_when_no_bars() -> None:
+    """Without df_5min, the helper falls back to ``datetime.now()`` — the
+    degraded live-path safety net.  Existing tests cover this path; this
+    one just pins that the absence of bars doesn't make the strategy
+    crash.
+    """
+    strategy = _strategy({"max_hold_days": 5})
+    entry = datetime(2026, 5, 18, 10, 0, 0, tzinfo=ET)
+    pos = _position(entry_time=entry, stop_price=90.0, target_price=120.0)
+
+    # Should not raise even without df_5min.
+    signal = strategy.evaluate_exit(position=pos, current_price=100.0)
+    # Either fires (wall-clock far past entry) or doesn't — we just want
+    # no exception and a valid ExitSignal.
+    assert signal is not None
+    assert hasattr(signal, "should_exit")


### PR DESCRIPTION
## Summary

**Production-regression fix.** PR #154 added `time_stop` to `MeanReversionStrategy.evaluate_exit` using `datetime.now(tz=ET)` to compute elapsed trading days. In live this works (because "now" ≈ current bar). **In backtest it silently broke every run** — historical entry_time vs today's wall-clock makes elapsed_days always >> max_hold_days (5), so 100% of trades exit `time_stop` ~1 bar after entry.

## Reproduction (before fix)

Full-period (2020-07-27 → 2026-04-16) single-pass backtest of mean_reversion alone, 13-ETF universe:

```
mean_reversion: 2185 trades, 674 wins (30.8% WR), Final $1748.86 (-30.05%)

Exit reason breakdown:
  time_stop             n=2185  total=$ -751.33  avg=$  -0.34  WR=30.8%
  (all other reasons    n=   0)
```

100% of trades exit `time_stop`, average -$0.34/trade.

## After fix (1y verification, SPY/QQQ/XLF/XLK)

```
mean_reversion: 52 trades, 35 wins (67.3% WR), Return +9.04%
Exit reasons: {'time_stop': 36, 'stop_loss': 7, 'take_profit': 9}
```

WR back in the expected 60-70% band; exit-reason mix matches PR #154's intent (`time_stop` flushes genuinely stalled positions, doesn't preempt every trade).

## Root cause

```python
# Before
now_et: datetime = datetime.now(tz=TZ_EASTERN)
elapsed_days: int = count_trading_days_between(cal, entry_dt.date(), now_et.date())
```

In backtest, `entry_dt = 2021-03-15`, `now_et.date() = 2026-05-24` → elapsed = ~1310 trading days → fires immediately every time.

## Fix

New helper `_bar_time_or_now(df_5min)` returns the timestamp of the latest bar (the simulated "now" in backtest, ~real "now" in live). Falls back to `datetime.now(tz=ET)` only when no bars are supplied — degraded live-path safety net.

`scan_for_entries` and `check_exits` in `strategy_manager.py` always pass `df_5min` to `evaluate_exit`, so the live path always resolves to bar time. The fallback path only triggers in edge cases (sentinel calls, malformed config).

## Test plan

- [x] **All 8 existing time_stop tests still pass** — they patch `datetime.now` and don't pass `df_5min`, so the fallback path covers them
- [x] **3 new regression tests** verify the bar-time path:
  - `test_time_stop_uses_bar_time_not_wallclock` — historical entry + same-day historical bar → no exit (was exit before fix)
  - `test_time_stop_fires_when_bar_time_advances_past_threshold` — same historical entry, bar 6 trading days later → exit fires
  - `test_time_stop_falls_back_to_wallclock_when_no_bars` — pins the fallback path doesn't crash
- [x] **Full suite green**: 1004 passed
- [x] **Live verification (1y backtest)**: mean_reversion WR 67.3% / +9.04% / mixed exit reasons — back to historical baseline

## Impact

- **All mean_reversion backtests since 2026-05-23** (when #154 merged) reported broken numbers.
- **The next scheduled weekly walkforward** (Sunday 22:00 UTC) would have shown a massive degradation in `mean_reversion`'s PF — likely triggering a draft PR from the existing health-check workflow.
- **Live bot is unaffected** — `datetime.now()` in the live path coincides with the bar being processed.

## How this was found

While computing a correlation check between `opening_range_breakout` (PR #156, draft) and `mean_reversion` to size ORB's allocation, mean_reversion came back at -30% / 30.8% WR on the combined run. Memory said mean_reversion's walkforward PF was 1.201 with +33% OOS Return. Re-running mean_reversion alone reproduced the -30%; the exit-reason breakdown (100% time_stop) pointed straight at PR #154.

Closes the diagnostic loop on the `correlation_check.py` exploration in PR #156.