### PR TITLE
fix(self_improve): stamp daily_summaries.phase from equity, not cached MICRO default

### DIFF
--- a/trading_bot/self_improve/recompute_daily_summaries.py
+++ b/trading_bot/self_improve/recompute_daily_summaries.py
@@ -23,7 +23,7 @@ import sqlite3
 import sys
 from datetime import date, datetime, timedelta
 from pathlib import Path
-from typing import Iterable
+from typing import Callable, Iterable
 
 from trading_bot.config import Config
 from trading_bot.constants import TZ_EASTERN
@@ -94,12 +94,22 @@ def recompute_for_dates(
     conn: sqlite3.Connection,
     dates: Iterable[str],
     *,
-    phase: int,
+    phase_resolver: Callable[[float], int],
     dry_run: bool,
     db_path: str | None = None,
 ) -> int:
     """Recompute ``daily_summaries`` rows for ``dates``. Returns the
     number of rows written (or that would be written, in dry-run).
+
+    ``phase_resolver`` maps a date's ``account_equity_usd`` to its
+    operating phase. It MUST be equity-driven: this script runs in the
+    daily-review process, which never calls
+    ``main.py::_refresh_phase_from_equity``, so a bare
+    ``Config.get_phase()`` would return the load-time default
+    (``Phase.MICRO`` = 1) and stamp every recomputed row phase=1 —
+    overwriting the correct phase the live tick wrote. Resolving per-date
+    from the row's own equity keeps the ``phase`` column self-consistent
+    with the equity being written. See ``main`` for the canonical wiring.
 
     ``db_path`` is required when ``conn`` is in-memory or otherwise opaque
     to ``PerformanceCalculator`` (which opens its own read connection).
@@ -139,7 +149,7 @@ def recompute_for_dates(
             "avg_win_usd": metrics.get("avg_win"),
             "avg_loss_usd": metrics.get("avg_loss"),
             "profit_factor": metrics.get("profit_factor"),
-            "phase": phase,
+            "phase": phase_resolver(equity),
             "us_trades": metrics.get("us_trades", 0),
             "notes": "recomputed:post_backfill",
         }
@@ -199,9 +209,15 @@ def main(argv: list[str] | None = None) -> int:
                 logger.info("No closed-trade dates in the last %d days.",
                             args.days)
                 return 0
+        # Resolve phase per-date from each row's equity. A bare
+        # ``config.get_phase()`` here would return the load-time default
+        # (MICRO=1) because this process never anchors phase to live
+        # equity the way the main tick does — see recompute_for_dates.
         written = recompute_for_dates(
             conn, dates,
-            phase=config.get_phase().value,
+            phase_resolver=lambda equity: config.get_phase(
+                equity_usd=equity
+            ).value,
             dry_run=args.dry_run,
             db_path=db_path,
         )

--- a/trading_bot/tests/test_recompute_daily_summaries.py
+++ b/trading_bot/tests/test_recompute_daily_summaries.py
@@ -84,7 +84,8 @@ def test_recompute_overwrites_stale_zeros_with_real_metrics(tmp_db_path):
         conn.commit()
 
         written = recompute_for_dates(
-            conn, ["2026-04-30"], phase=3, dry_run=False,
+            conn, ["2026-04-30"], phase_resolver=lambda _equity: 3,
+            dry_run=False,
         )
         assert written == 1
 
@@ -100,6 +101,44 @@ def test_recompute_overwrites_stale_zeros_with_real_metrics(tmp_db_path):
 
 
 @pytest.mark.unit
+def test_recompute_stamps_phase_from_equity_not_cached_default(
+    tmp_db_path, config,
+):
+    """Regression: the daily-review process never anchors phase to live
+    equity (no ``_refresh_phase_from_equity``), so a bare
+    ``config.get_phase()`` returns the load-time default MICRO=1. Before
+    the fix, recompute stamped every row phase=1, clobbering the correct
+    phase the live tick wrote. The phase_resolver must derive phase from
+    the row's own equity instead.
+    """
+    # Baseline: the equity-less cached phase IS the MICRO default that
+    # used to leak into every recomputed row.
+    assert config.get_phase().value == 1
+
+    with _conn(tmp_db_path) as conn:
+        # $100k equity → Phase.FULL (3) under config.yaml thresholds
+        # ($5k→P2, $20k→P3).
+        _seed_summary(conn, date="2026-05-28", equity=100_000.0)
+        _seed_trade(conn, ticker="SPY", exit_date="2026-05-28",
+                    gross=1.0, pnl=1.0)
+        conn.commit()
+
+        written = recompute_for_dates(
+            conn, ["2026-05-28"],
+            phase_resolver=lambda equity: config.get_phase(
+                equity_usd=equity
+            ).value,
+            dry_run=False,
+        )
+        assert written == 1
+
+        row = conn.execute(
+            "SELECT phase FROM daily_summaries WHERE date='2026-05-28'"
+        ).fetchone()
+    assert row[0] == 3  # FULL, not the cached MICRO=1
+
+
+@pytest.mark.unit
 def test_recompute_skips_dates_with_no_existing_summary(tmp_db_path):
     """Without an existing daily_summaries row we have no
     account_equity_usd to write — the column is NOT NULL. Skip rather
@@ -110,7 +149,8 @@ def test_recompute_skips_dates_with_no_existing_summary(tmp_db_path):
         conn.commit()
 
         written = recompute_for_dates(
-            conn, ["2026-04-29"], phase=3, dry_run=False,
+            conn, ["2026-04-29"], phase_resolver=lambda _equity: 3,
+            dry_run=False,
         )
         assert written == 0
 
@@ -129,7 +169,8 @@ def test_recompute_dry_run_makes_no_writes(tmp_db_path):
         conn.commit()
 
         written = recompute_for_dates(
-            conn, ["2026-05-01"], phase=3, dry_run=True,
+            conn, ["2026-05-01"], phase_resolver=lambda _equity: 3,
+            dry_run=True,
         )
         assert written == 1
 


### PR DESCRIPTION
## Problem

The `phase` column in `daily_summaries` was being silently corrupted to `1` (MICRO) for every recent row. Spotted on the 2026-05-28 row (phase=1 at ~\$100k equity, which should be FULL/3).

**Root cause — confirmed via logs + DB inspection:**
- The live tick saves the summary correctly. Run 26599408171 (5/28 20:10 UTC) logged `Phase refresh: MICRO -> FULL (equity=\$100013.39)` then `Daily summary saved for 2026-05-28` → wrote phase=**3**.
- The 21:30 UTC daily-review job (`recompute_daily_summaries --days 14`) then **overwrote** it. That process never calls `main.py::_refresh_phase_from_equity`, so its bare `config.get_phase()` (no equity) returned the load-time default `Phase.MICRO`=1, and `INSERT OR REPLACE` stamped phase=1 over all 14 recomputed rows (all carry `notes='recomputed:post_backfill'`).

## Impact

- **Trading: none.** The live tick anchors phase to equity before any sizing/risk decision; P&L, equity, trade counts all recompute correctly.
- **Latent correctness bug for live:** `performance.py::get_phase_progress()` counts `WHERE phase = ?` in `daily_summaries` to gate phase 1→2→3 promotions. On the paper \$100k account this is moot (pinned at max phase 3), but on the live \$1k account it would corrupt the day-counting that drives phased growth.

## Fix

Replace the static `phase: int` param to `recompute_for_dates` with a `phase_resolver: Callable[[float], int]` and resolve phase **per-date from each row's own `account_equity_usd`** (already fetched in the loop). `main()` wires `lambda equity: config.get_phase(equity_usd=equity).value`.

Re-running the daily-review job over `--days 14` will **self-heal** the already-corrupted rows.

## Test plan

- [x] New regression test `test_recompute_stamps_phase_from_equity_not_cached_default`: asserts recompute stamps phase=3 at \$100k equity even when `config.get_phase()` (cached, equity-less) is MICRO=1.
- [x] Existing 4 recompute tests updated to the new resolver signature — all pass.
- [x] `ruff check` clean, `vulture --min-confidence 80` clean.
- [x] Critical pytest subset: 220 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)