### PR TITLE
refactor(config): pure resolve_phase; kill cache side-effect in daily_summaries recompute

### DIFF
--- a/trading_bot/config.py
+++ b/trading_bot/config.py
@@ -124,38 +124,52 @@ class Config:
     # Phase detection
     # -----------------------------------------------------------------------
 
-    def get_phase(self, equity_usd: float | None = None) -> Phase:
-        """Return the current operating phase.
+    def resolve_phase(self, equity_usd: float | None) -> Phase:
+        """Pure phase resolution — NO caching, NO side-effects.
 
-        Resolution order:
+        Resolution order (identical to ``get_phase``):
         1. ``account.phase_override`` (if set to an integer 0-3)
         2. Auto-detect from *equity_usd* against phase thresholds
-        3. If *equity_usd* is ``None`` and no override, default to ``Phase.MICRO``
-        """
-        if self._phase is not None and equity_usd is None:
-            return self._phase
+        3. If *equity_usd* is ``None`` and no override, ``Phase.MICRO``
 
+        Unlike ``get_phase`` this never reads or writes ``self._phase``,
+        so it is safe to call repeatedly with differing equity values
+        without leaking the last result into the shared cache. Callers
+        that need a per-equity answer (e.g. recomputing historical
+        daily_summaries across dates that may straddle phase boundaries)
+        should use this rather than ``get_phase(equity_usd=...)``.
+        """
         override: int | None = self._get("account", "phase_override")
         if override is not None:
-            phase = Phase(int(override))
-            self._phase = phase
-            return phase
+            return Phase(int(override))
 
         if equity_usd is None:
             # No equity supplied and no override -> conservative default
-            self._phase = Phase.MICRO
             return Phase.MICRO
 
         p2_threshold: float = float(self._require("phases", "phase1_to_phase2", "equity_usd"))
         p3_threshold: float = float(self._require("phases", "phase2_to_phase3", "equity_usd"))
 
         if equity_usd >= p3_threshold:
-            phase = Phase.FULL
-        elif equity_usd >= p2_threshold:
-            phase = Phase.SMALL
-        else:
-            phase = Phase.MICRO
+            return Phase.FULL
+        if equity_usd >= p2_threshold:
+            return Phase.SMALL
+        return Phase.MICRO
 
+    def get_phase(self, equity_usd: float | None = None) -> Phase:
+        """Return the current operating phase, caching the first answer.
+
+        Delegates the actual resolution to ``resolve_phase`` (override >
+        equity thresholds > MICRO default) and memoises it in
+        ``self._phase``. A no-arg call after the cache is warm returns the
+        cached value; passing *equity_usd* always re-resolves and updates
+        the cache. For a side-effect-free, per-equity answer use
+        ``resolve_phase`` directly.
+        """
+        if self._phase is not None and equity_usd is None:
+            return self._phase
+
+        phase: Phase = self.resolve_phase(equity_usd)
         self._phase = phase
         return phase
 

--- a/trading_bot/self_improve/recompute_daily_summaries.py
+++ b/trading_bot/self_improve/recompute_daily_summaries.py
@@ -209,15 +209,16 @@ def main(argv: list[str] | None = None) -> int:
                 logger.info("No closed-trade dates in the last %d days.",
                             args.days)
                 return 0
-        # Resolve phase per-date from each row's equity. A bare
-        # ``config.get_phase()`` here would return the load-time default
-        # (MICRO=1) because this process never anchors phase to live
-        # equity the way the main tick does — see recompute_for_dates.
+        # Resolve phase per-date from each row's equity via the pure
+        # ``resolve_phase`` (no cache mutation). A bare ``get_phase()``
+        # here would return the load-time default (MICRO=1) because this
+        # process never anchors phase to live equity the way the main
+        # tick does; ``get_phase(equity_usd=...)`` would work but leaks
+        # the last date's phase into config._phase. See
+        # recompute_for_dates.
         written = recompute_for_dates(
             conn, dates,
-            phase_resolver=lambda equity: config.get_phase(
-                equity_usd=equity
-            ).value,
+            phase_resolver=lambda equity: config.resolve_phase(equity).value,
             dry_run=args.dry_run,
             db_path=db_path,
         )

--- a/trading_bot/tests/test_phase_transitions.py
+++ b/trading_bot/tests/test_phase_transitions.py
@@ -64,6 +64,39 @@ class TestPhaseDetection:
         cfg._phase = None
         assert cfg.get_phase(equity_usd=25000.0) == Phase.FULL
 
+    def test_resolve_phase_does_not_mutate_cache(
+        self, config: Config
+    ) -> None:
+        """``resolve_phase`` is pure: repeated calls with differing equity
+        must never write ``_phase``, so the cache stays exactly as the
+        caller left it. This is what lets the daily_summaries recompute
+        map each date independently from its own equity.
+        """
+        cfg = Config(dict(config._raw))
+        cfg._phase = None  # known starting state
+
+        assert cfg.resolve_phase(500.0) == Phase.MICRO
+        assert cfg.resolve_phase(8_000.0) == Phase.SMALL
+        assert cfg.resolve_phase(100_000.0) == Phase.FULL
+        assert cfg.resolve_phase(None) == Phase.MICRO
+
+        # No call above may have touched the cache.
+        assert cfg._phase is None
+
+    def test_resolve_phase_honors_override(
+        self, raw_config: dict[str, Any]
+    ) -> None:
+        """Override wins over equity in the pure resolver too — equity is
+        ignored entirely when ``phase_override`` is set.
+        """
+        raw = dict(raw_config)
+        raw["account"] = dict(raw["account"])
+        raw["account"]["phase_override"] = 2
+        cfg = Config(raw)
+        # High equity would otherwise resolve FULL; override pins SMALL.
+        assert cfg.resolve_phase(100_000.0) == Phase.SMALL
+        assert cfg.resolve_phase(None) == Phase.SMALL
+
 
 # ---------------------------------------------------------------------------
 # Phase transition criteria (SPEC §phase transitions)

--- a/trading_bot/tests/test_recompute_daily_summaries.py
+++ b/trading_bot/tests/test_recompute_daily_summaries.py
@@ -125,9 +125,7 @@ def test_recompute_stamps_phase_from_equity_not_cached_default(
 
         written = recompute_for_dates(
             conn, ["2026-05-28"],
-            phase_resolver=lambda equity: config.get_phase(
-                equity_usd=equity
-            ).value,
+            phase_resolver=lambda equity: config.resolve_phase(equity).value,
             dry_run=False,
         )
         assert written == 1
@@ -136,6 +134,42 @@ def test_recompute_stamps_phase_from_equity_not_cached_default(
             "SELECT phase FROM daily_summaries WHERE date='2026-05-28'"
         ).fetchone()
     assert row[0] == 3  # FULL, not the cached MICRO=1
+
+
+@pytest.mark.unit
+def test_recompute_resolves_phase_independently_per_date(tmp_db_path, config):
+    """Each date must resolve phase from its OWN equity, not from a value
+    cached by an earlier date in the same run. This is the live-$1k
+    scenario: a 14-day window legitimately straddles phase boundaries as
+    the account grows. ``resolve_phase`` is pure, so order can't leak.
+    """
+    with _conn(tmp_db_path) as conn:
+        # $500 → MICRO(1); $8k → SMALL(2); $100k → FULL(3) under the
+        # config.yaml thresholds ($5k→P2, $20k→P3).
+        _seed_summary(conn, date="2026-05-01", equity=500.0)
+        _seed_summary(conn, date="2026-05-02", equity=8_000.0)
+        _seed_summary(conn, date="2026-05-03", equity=100_000.0)
+        for d in ("2026-05-01", "2026-05-02", "2026-05-03"):
+            _seed_trade(conn, ticker="SPY", exit_date=d, gross=1.0, pnl=1.0)
+        conn.commit()
+
+        # Pass dates in an order that would expose cache leakage if the
+        # resolver weren't pure (descending equity then back up).
+        written = recompute_for_dates(
+            conn, ["2026-05-03", "2026-05-01", "2026-05-02"],
+            phase_resolver=lambda equity: config.resolve_phase(equity).value,
+            dry_run=False,
+        )
+        assert written == 3
+
+        rows = {
+            r[0]: r[1] for r in conn.execute(
+                "SELECT date, phase FROM daily_summaries ORDER BY date"
+            ).fetchall()
+        }
+    assert rows["2026-05-01"] == 1  # MICRO
+    assert rows["2026-05-02"] == 2  # SMALL
+    assert rows["2026-05-03"] == 3  # FULL
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Follow-up to #163, addressing the python-review findings.

## What & why

**HIGH (latent correctness):** #163 resolved each date's phase via `config.get_phase(equity_usd=...)`, which mutates the shared `Config._phase` cache as a side-effect — after a multi-date run the cache is pinned to the *last-processed* date's phase. No production impact today (the daily-review GHA process exits immediately), but a trap if the recompute is ever folded into a longer-lived shared-config context.

**MEDIUM (test gap):** no coverage for a multi-date run straddling phase boundaries — the live-\$1k scenario where a 14-day window legitimately crosses MICRO→SMALL→FULL.

## Change

- Extract **`Config.resolve_phase(equity_usd)`** — a pure resolver with the same order (override > equity thresholds > MICRO default), **no caching, no `_phase` mutation**.
- `get_phase` now delegates to it and keeps its memoisation (behaviour unchanged for all existing callers).
- `recompute_daily_summaries.main()` uses `config.resolve_phase(equity).value` → each date maps purely from its own stored equity, order-independent, and still honours `account.phase_override` (a naive threshold-only closure would have silently dropped override support).

## Tests added
- `test_recompute_resolves_phase_independently_per_date` — seeds \$500/\$8k/\$100k across three dates, recomputes them **out of order**, asserts phase 1/2/3 respectively (would fail under cache-leak).
- `test_resolve_phase_does_not_mutate_cache` — repeated `resolve_phase` calls leave `_phase` untouched.
- `test_resolve_phase_honors_override` — override pins phase regardless of equity in the pure path.

## Verification
- `ruff check` clean
- `mypy --ignore-missing-imports trading_bot/config.py` clean (config.py is on the critical-path mypy gate)
- `vulture --min-confidence 80` clean
- Critical pytest subset: **220 passed**; targeted module tests: 25 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)