### PR TITLE
chore(strategies): config-source-of-truth + defensive cleanups from active-strategy review

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -661,6 +661,11 @@ multi_strategy:
       bb_period: 20
       bb_std: 2.0
       bb_lookback_bars: 3
+      # Strategy-level time stop: force-exit a position that has neither
+      # stopped, hit target, nor normalised after this many trading days.
+      # Distinct from exit_swing.max_hold_days (used by ExitManager); this
+      # one is read by MeanReversionStrategy.evaluate_exit directly.
+      max_hold_days: 5
 
     trend_following:
       # DISABLED 2026-04-28 (kept disabled after evening walkforward).

--- a/trading_bot/strategy/strategies/mean_reversion.py
+++ b/trading_bot/strategy/strategies/mean_reversion.py
@@ -7,6 +7,7 @@ import math
 from datetime import datetime
 from typing import Any
 
+import numpy as np
 import pandas as pd
 
 from trading_bot.constants import HoldType, TZ_EASTERN
@@ -17,6 +18,9 @@ from trading_bot.utils import coalesce
 from trading_bot.utils.time import count_trading_days_between
 
 logger: logging.Logger = logging.getLogger(__name__)
+
+# Trading days per year — annualisation factor for realized volatility.
+_TRADING_DAYS_PER_YEAR: int = 252
 
 
 class MeanReversionStrategy(StrategyBase):
@@ -104,14 +108,13 @@ class MeanReversionStrategy(StrategyBase):
         """
         if df_daily is None or len(df_daily) < lookback_days + 1:
             return None
-        import numpy as np
         closes = df_daily["close"].astype(float).dropna()
         if len(closes) < lookback_days + 1:
             return None
         log_returns = np.log(closes / closes.shift(1)).dropna().iloc[-lookback_days:]
         if len(log_returns) < lookback_days // 2:
             return None
-        vol = float(log_returns.std() * (252 ** 0.5) * 100)
+        vol = float(log_returns.std() * (_TRADING_DAYS_PER_YEAR ** 0.5) * 100)
         return vol if vol > 0 else None
 
     def _adaptive_rsi_oversold(self, df_daily: pd.DataFrame) -> tuple[float, str]:

--- a/trading_bot/strategy/strategies/overnight_drift.py
+++ b/trading_bot/strategy/strategies/overnight_drift.py
@@ -40,11 +40,13 @@ class OvernightDriftStrategy(StrategyBase):
             **kwargs,
         )
         self._max_positions: int = int(config.get("max_positions", 1))
-        # Entry window — last bar of the session. Default 15:45-15:55 ET
-        # brackets the 15:50 wind-down of intraday sleeves while still
-        # leaving room to fire once per day.
-        entry_start_str: str = str(config.get("entry_window_start", "15:45"))
-        entry_end_str: str = str(config.get("entry_window_end", "15:55"))
+        # Entry window — last bar of the session. Defaults match the live
+        # config.yaml (15:40-15:45 ET): the entry must fire BEFORE the
+        # 15:50 wind-down, since the backtester skips new entries once
+        # wind-down starts. The defaults exist so a config-missing
+        # deployment does not silently widen the window into wind-down.
+        entry_start_str: str = str(config.get("entry_window_start", "15:40"))
+        entry_end_str: str = str(config.get("entry_window_end", "15:45"))
         self._entry_window_start: time = _parse_time(entry_start_str)
         self._entry_window_end: time = _parse_time(entry_end_str)
         # Disaster stop on the overnight leg. The anomaly has positive
@@ -130,7 +132,6 @@ class OvernightDriftStrategy(StrategyBase):
         df_5min: pd.DataFrame | None = None,
         df_daily: pd.DataFrame | None = None,
     ) -> ExitSignal:
-        entry_price: float = float(position.get("entry_price", 0))
         stop_price: float = float(coalesce(position, "stop_price", 0))
 
         # Disaster stop — redundant with the backtester's intrabar stop
@@ -178,7 +179,6 @@ class OvernightDriftStrategy(StrategyBase):
                 use_market_order=True,
             )
 
-        _ = entry_price  # silence unused-warning in linters
         return ExitSignal(should_exit=False)
 
     def get_max_positions(self) -> int:
@@ -214,7 +214,11 @@ def _to_et_datetime(ts: Any) -> datetime | None:
         try:
             return dt.astimezone(TZ_EASTERN)
         except Exception:
-            return dt
+            # Returning the un-converted (non-ET) datetime would silently
+            # skew every wall-clock window/date check downstream. Callers
+            # all handle None, so propagate that instead.
+            logger.warning("Failed to convert %r to US/Eastern", dt, exc_info=True)
+            return None
     return dt
 
 

--- a/trading_bot/tests/test_overnight_drift.py
+++ b/trading_bot/tests/test_overnight_drift.py
@@ -1,0 +1,89 @@
+"""Tests for the overnight_drift strategy and its time-zone helpers.
+
+Focus: the config-driven entry window defaults and the ``_to_et_datetime``
+coercion, both of which gate when entries fire and when next-morning exits
+are detected. A wrong-timezone value here silently breaks the wall-clock
+window checks, so the behaviour is pinned explicitly.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, time, timezone
+
+import pandas as pd
+import pytest
+
+from trading_bot.constants import TZ_EASTERN
+from trading_bot.strategy.strategies.overnight_drift import (
+    OvernightDriftStrategy,
+    _position_entry_date,
+    _to_et_datetime,
+)
+
+
+@pytest.mark.unit
+class TestEntryWindowDefaults:
+    def test_default_window_matches_production_and_precedes_winddown(self) -> None:
+        """Regression: config-less defaults must be 15:40-15:45 ET — the
+        live config.yaml values — so a config-missing deployment never
+        widens the window into the 15:50 wind-down (an entry submitted
+        during/after wind-down has too little time to fill before close).
+        """
+        strategy = OvernightDriftStrategy(config={})
+        assert strategy._entry_window_start == time(15, 40)
+        assert strategy._entry_window_end == time(15, 45)
+        # Whole window strictly before the 15:50 wind-down start.
+        assert strategy._entry_window_end < time(15, 50)
+
+    def test_config_overrides_window(self) -> None:
+        strategy = OvernightDriftStrategy(
+            config={"entry_window_start": "15:30", "entry_window_end": "15:35"},
+        )
+        assert strategy._entry_window_start == time(15, 30)
+        assert strategy._entry_window_end == time(15, 35)
+
+
+@pytest.mark.unit
+class TestToEtDatetime:
+    def test_utc_aware_converts_to_eastern(self) -> None:
+        # 20:40 UTC == 16:40 EDT on a summer date.
+        utc_dt = datetime(2026, 5, 26, 20, 40, tzinfo=timezone.utc)
+        et = _to_et_datetime(utc_dt)
+        assert et is not None
+        assert et.tzinfo is not None
+        assert et.hour == 16 and et.minute == 40
+
+    def test_naive_is_treated_as_already_eastern(self) -> None:
+        naive = datetime(2026, 5, 26, 15, 45)
+        et = _to_et_datetime(naive)
+        assert et == naive  # unchanged (backtest convention)
+
+    def test_pandas_timestamp_converts(self) -> None:
+        ts = pd.Timestamp("2026-05-26 20:40", tz="UTC")
+        et = _to_et_datetime(ts)
+        assert et is not None
+        assert et.hour == 16 and et.minute == 40
+
+    def test_none_and_non_datetime_return_none(self) -> None:
+        assert _to_et_datetime(None) is None
+        assert _to_et_datetime("not-a-datetime") is None
+        assert _to_et_datetime(12345) is None
+
+
+@pytest.mark.unit
+class TestPositionEntryDate:
+    def test_et_aware_iso_string_keeps_eastern_calendar_date(self) -> None:
+        """A 15:45 ET entry is the SAME calendar day in its own offset —
+        the exit gate (``bar_date > entry_date``) must not roll it forward
+        a day. Confirms the recent review's 'extra-day hold' concern is a
+        non-issue for the real entry window.
+        """
+        pos = {"entry_time": "2026-05-26T15:45:41.544069-04:00"}
+        assert _position_entry_date(pos) == date(2026, 5, 26)
+
+    def test_et_aware_datetime_object(self) -> None:
+        pos = {"entry_time": datetime(2026, 5, 26, 15, 45, tzinfo=TZ_EASTERN)}
+        assert _position_entry_date(pos) == date(2026, 5, 26)
+
+    def test_missing_entry_time_returns_none(self) -> None:
+        assert _position_entry_date({}) is None


### PR DESCRIPTION
Acts on the **verified, worth-doing** findings from the python-review of the two `enabled: true` sleeves (`mean_reversion`, `overnight_drift`). I re-checked every finding against the code before implementing — **none of these changes alter signal logic.**

## Dismissed as false positives (verified, not changed)
- **"`_position_entry_date` holds positions an extra day (UTC↔ET)"** — `datetime.date()` reads the date in the value's *own* offset; it never converts to UTC. Live stores ET-aware timestamps, and a 15:45 ET entry is 20:45 UTC = same calendar day regardless. Not a re-emergence of the #114 orphan bug. Pinned by a new test.
- **"Bollinger `std(ddof=0)` causes backtest optimism"** — the backtester invokes the strategy's *own* `evaluate_entry`, so the same `ddof=0` runs in both backtest and live. Zero divergence.

## Changes (all behaviour-preserving)
**overnight_drift.py**
- Align config-less entry-window defaults to the live values (`15:40-15:45 ET`) + fix the stale `15:45-15:55` docstring. Old defaults straddled the 15:50 wind-down → a config-missing deploy could submit entries too late to fill. Production unaffected (config.yaml always sets these).
- `_to_et_datetime`: on conversion failure, **log + return `None`** instead of silently returning the un-converted (non-ET) datetime, which would skew every downstream wall-clock check. All callers already handle `None`.
- Remove dead `entry_price` local (kept alive only by a `_ = entry_price` linter silencer).

**mean_reversion.py**
- Hoist `import numpy as np` to module level (was re-imported on every vol-regime call).
- Name the `252` annualisation factor → `_TRADING_DAYS_PER_YEAR`.

**config.yaml**
- Add strategy-level `max_hold_days: 5` to the `mean_reversion` block. It was hardcoded-by-omission via `config.get(..., 5)`; the only `max_hold_days` in the file was under `exit_swing` (a different consumer) — a real source-of-truth trap. Value equals the prior default → no behaviour change.

## Tests
- New `test_overnight_drift.py` (9 tests): entry-window defaults incl. the `<15:50` wind-down invariant; `_to_et_datetime` coercion (UTC→ET, naive passthrough, `None` for non-datetime); `_position_entry_date` keeps the ET calendar date for a 15:45 ET entry.

## Verification
- ruff ✓, mypy `--ignore-missing-imports` ✓, vulture ✓ on both strategy files
- 220 critical tests pass; 9 new unit tests pass

Not done (out of scope / not worth the blast radius): `_compute_shares` int-return is gated on `use_risk_sizing=False` (prod uses `True`), and fixing it touches `base.py` (all strategies + critical-path mypy gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)