### PR TITLE
ci: one-shot recompute-summaries maintenance workflow (heal historical phase rows)

### DIFF
--- a/.github/workflows/recompute-summaries.yml
+++ b/.github/workflows/recompute-summaries.yml
@@ -1,0 +1,75 @@
+name: recompute-summaries
+
+# One-shot maintenance job: recompute daily_summaries rows from the trades
+# table over a chosen window, against the live cached SQLite DB, and persist
+# the result back to the cache so the next bot tick picks it up.
+#
+# Why this exists separately from daily-review: daily-review runs the full
+# self-improvement agent (backfill + backtest + draft-PR) and recomputes only
+# a fixed 14-day window. This job does ONLY the recompute, over an
+# operator-chosen window — useful to heal older rows (e.g. a phase column
+# that was stamped wrong before PR #163/#164) without firing the research
+# agent or opening a spurious report PR.
+#
+# SAFETY: run ONLY outside the bot's operating window (bot.yml cron is
+# `*/5 13-21 * * 1-5` UTC). A bot tick saves its own `bot-db-<run_id>` cache
+# every 5 min; if this job runs concurrently, the next tick's save would
+# clobber the heal. Dispatch before 13:00 UTC or after ~22:00 UTC on a
+# weekday, or on a weekend.
+
+on:
+  workflow_dispatch:
+    inputs:
+      days:
+        description: "Recompute the last N days that have closed trades."
+        required: false
+        default: "30"
+
+concurrency:
+  group: recompute-summaries
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  recompute:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install deps
+        run: pip install -r requirements.txt
+
+      - name: Restore SQLite DB
+        # Read the latest bot DB and write back under the same prefix so the
+        # next bot.yml tick restores the healed rows (most-recent cache wins).
+        uses: actions/cache@v5
+        with:
+          path: trading_bot/data/trading_bot.db*
+          key: bot-db-${{ github.run_id }}
+          restore-keys: |
+            bot-db-
+
+      - name: Recompute daily_summaries
+        env:
+          BOT_LOG_DIR: logs
+        run: |
+          python -m trading_bot.self_improve.recompute_daily_summaries \
+            --days "${{ github.event.inputs.days || '30' }}"
+
+      - name: Upload DB for inspection
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: recompute-db-${{ github.run_id }}
+          path: trading_bot/data/trading_bot.db*
+          retention-days: 30
+          if-no-files-found: warn


### PR DESCRIPTION
## Why

PRs #163/#164 fixed the `daily_summaries.phase` stamping bug, and the nightly `daily-review` re-stamps the **last 14 days**. But rows **older than 14 days** (≈5/12–5/14) were stamped `phase=1` by an earlier wide recompute and have no path to self-heal.

Dispatching `daily-review` manually would heal them, but it also fires the full self-improvement agent (backfill + backtest) and opens a spurious draft report PR. This adds a focused, dispatch-only job that does **only** the recompute, over an operator-chosen window.

## How it works

- `workflow_dispatch` with a `days` input (default 30).
- Restores the live `bot-db-*` cache, runs `recompute_daily_summaries --days N`, and the post-job `actions/cache` save persists the healed DB under a fresh `bot-db-<run_id>` — which the next bot tick restores (`restore-keys: bot-db-`, most-recent wins).
- Uploads the resulting DB as an artifact for verification.

Post-#164, the recompute resolves phase per-row from each date's stored equity (pure `resolve_phase`), so a wider window simply re-stamps the correct value.

## Safety (documented in-file)

Must run **outside** the bot's operating window (`bot.yml` cron `*/5 13-21 * * 1-5` UTC). A bot tick saves its own `bot-db-<run_id>` every 5 min; a concurrent repair would be clobbered by the next tick. Intended use: dispatch before 13:00 UTC / after ~22:00 UTC on a weekday, or on a weekend.

## Plan after merge
Dispatch with `days=30` during the current safe pre-market window (it's ~09:20 UTC, no tick until 13:00 UTC), then verify the artifact shows `phase=3` across the recent rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)