### PR TITLE
fix(execution): re-arm canceled standalone stop on POSITION_OPEN rows (#1)

### DIFF
--- a/trading_bot/execution/order_manager.py
+++ b/trading_bot/execution/order_manager.py
@@ -586,6 +586,53 @@ class OrderManager:
                             exc_info=True,
                         )
 
+            # Issue #117 failure mode A, POSITION_OPEN variant (2026-05-29):
+            # standalone protective stops for mean_reversion / overnight_drift
+            # / opening_range_breakout live on a row that stays POSITION_OPEN
+            # (they never transition to STOP_ACTIVE). The canceled/expired/
+            # rejected handler above only runs for STOP_ACTIVE/TRAILING_ACTIVE,
+            # and the re-attach branch below only fires when the id is already
+            # None — so a standalone stop that the broker cancels (DAY expiry,
+            # external cancel) was healed by NEITHER, leaving the position
+            # naked overnight (XLC carried unprotected on 2026-05-29). Poll
+            # the recorded stop here; if it's dead, clear the id so the
+            # recovery branch below re-attaches a fresh stop this same tick.
+            # A 'filled' status is intentionally NOT handled here — that is a
+            # clean exit and is attributed separately; clearing it would be
+            # wrong. Only dead-but-not-filled statuses are cleared.
+            if (
+                active.status == PositionStatus.POSITION_OPEN
+                and active.alpaca_stop_order_id is not None
+                and active.filled_shares > 0
+            ):
+                stop_oid: str = active.alpaca_stop_order_id
+                try:
+                    stop_order: AlpacaOrder = await asyncio.to_thread(
+                        client.get_order_by_id,  # type: ignore[arg-type]
+                        stop_oid,
+                    )
+                    stop_status: str = (
+                        getattr(stop_order.status, "value", "") or ""
+                    ).lower()
+                    if stop_status in ("canceled", "expired", "rejected"):
+                        logger.warning(
+                            "Standalone stop %s for %s is %s while position is "
+                            "POSITION_OPEN — clearing dead id so it re-attaches "
+                            "this tick (trade_id=%d)",
+                            stop_oid, active.ticker, stop_status, trade_id,
+                        )
+                        self._alpaca_to_trade.pop(stop_oid, None)
+                        active.alpaca_stop_order_id = None
+                        self._update_position_field(
+                            trade_id, "alpaca_stop_order_id", None,
+                        )
+                except Exception:
+                    logger.warning(
+                        "Error checking standalone stop %s for %s "
+                        "(trade_id=%d)",
+                        stop_oid, active.ticker, trade_id, exc_info=True,
+                    )
+
             # Issue #117 failure modes B & C: a position can land in
             # POSITION_OPEN with alpaca_stop_order_id=NULL when
             # _transition_to_open was interrupted between the status flip

--- a/trading_bot/tests/test_standalone_stop_lifecycle_117.py
+++ b/trading_bot/tests/test_standalone_stop_lifecycle_117.py
@@ -826,3 +826,115 @@ class TestStopRecoveryMarketHoursGate:
         # Result depends on wall-clock time; just verify no crash.
         result = await om._inside_market_hours_for_stop_attach()
         assert isinstance(result, bool)
+
+
+# ---------------------------------------------------------------------------
+# Failure mode A, POSITION_OPEN variant — standalone stop cancelled while
+# the row sits in POSITION_OPEN (2026-05-29, XLC)
+# ---------------------------------------------------------------------------
+
+
+class TestFailureModeA_StopCancelledOnPositionOpen:
+    """Standalone protective stops for mean_reversion / overnight_drift /
+    opening_range_breakout live on a row that stays POSITION_OPEN (they
+    never transition to STOP_ACTIVE). On 2026-05-29 XLC's standalone stop
+    was cancelled at the broker; pre-fix the cancelled-stop handler only
+    ran for STOP_ACTIVE/TRAILING_ACTIVE and the re-attach branch only fired
+    on a NULL id, so the position sat naked overnight. The fix polls the
+    standalone stop for POSITION_OPEN rows, clears the dead id, and lets the
+    recovery branch re-attach a fresh stop the same tick.
+    """
+
+    @pytest.mark.asyncio
+    async def test_cancelled_standalone_stop_on_position_open_rearms(
+        self, config, tmp_db_path: str, mock_notifier
+    ) -> None:
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        _set_market_open(om)
+
+        trade_id = om._create_position_record(
+            _entry("XLC", shares=0.1402, price=116.368)
+        )
+        om._update_position_status(trade_id, PositionStatus.POSITION_OPEN)
+        om._update_position_field(trade_id, "quantity", 0.1402)
+        om._update_position_field(trade_id, "entry_price", 116.368)
+        om._update_position_field(trade_id, "stop_price", 114.62)
+        om._update_position_field(trade_id, "alpaca_stop_order_id", "stop-dead")
+
+        submits: list = []
+
+        def _submit(order_data):
+            submits.append(order_data)
+            return _alpaca_order(f"stop-fresh-{len(submits)}", "new")
+
+        om._gw.client.submit_order = MagicMock(side_effect=_submit)
+        om._gw.client.get_orders = MagicMock(return_value=[])
+
+        def _get_order_by_id(oid: str):
+            if oid == "stop-dead":
+                return _alpaca_order(oid, "canceled")
+            return _alpaca_order(oid, "new")
+
+        om._gw.client.get_order_by_id = MagicMock(side_effect=_get_order_by_id)
+
+        await om._check_order_statuses()
+
+        # Pre-fix: zero submits — POSITION_OPEN + canceled stop fell through
+        # every branch and the position stayed naked.
+        assert len(submits) == 1, (
+            "expected a fresh stop re-attach on the same tick; pre-fix the "
+            "POSITION_OPEN canceled-stop case was healed by no branch"
+        )
+        active = om._active_orders[trade_id]
+        assert active.status == PositionStatus.STOP_ACTIVE
+        assert active.alpaca_stop_order_id == "stop-fresh-1"
+
+        conn = sqlite3.connect(tmp_db_path)
+        try:
+            row = conn.execute(
+                "SELECT status, alpaca_stop_order_id FROM positions "
+                "WHERE id = ?",
+                (trade_id,),
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row[0] == PositionStatus.STOP_ACTIVE.value
+        assert row[1] == "stop-fresh-1"
+
+    @pytest.mark.asyncio
+    async def test_filled_standalone_stop_on_position_open_not_cleared(
+        self, config, tmp_db_path: str, mock_notifier
+    ) -> None:
+        """A 'filled' standalone stop must NOT be treated as dead/cleared by
+        the re-arm path — that is a genuine exit (attributed elsewhere).
+        Clearing it would spawn a duplicate stop on a closed position."""
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        _set_market_open(om)
+
+        trade_id = om._create_position_record(
+            _entry("XLC", shares=0.1402, price=116.368)
+        )
+        om._update_position_status(trade_id, PositionStatus.POSITION_OPEN)
+        om._update_position_field(trade_id, "quantity", 0.1402)
+        om._update_position_field(trade_id, "entry_price", 116.368)
+        om._update_position_field(trade_id, "alpaca_stop_order_id", "stop-filled")
+
+        submits: list = []
+
+        def _submit(order_data):
+            submits.append(order_data)
+            return _alpaca_order(f"stop-fresh-{len(submits)}", "new")
+
+        om._gw.client.submit_order = MagicMock(side_effect=_submit)
+        om._gw.client.get_orders = MagicMock(return_value=[])
+        om._gw.client.get_order_by_id = MagicMock(
+            side_effect=lambda oid: _alpaca_order(oid, "filled", 0.1402, 114.62)
+        )
+
+        await om._check_order_statuses()
+
+        # No re-arm submission — the re-arm path only clears dead-but-not-
+        # filled statuses.
+        assert len(submits) == 0
+        active = om._active_orders[trade_id]
+        assert active.alpaca_stop_order_id == "stop-filled"


### PR DESCRIPTION
**Fix 1 of 3** from the 2026-05-29 ORB-first-day investigation. The only one that's actual unhedged risk.

## Problem
Standalone protective stops for `mean_reversion` / `overnight_drift` / `opening_range_breakout` live on a row that stays **`POSITION_OPEN`** (they never transition to `STOP_ACTIVE`). But:
- the existing #117 canceled-stop handler only runs for `STOP_ACTIVE`/`TRAILING_ACTIVE`, and
- the re-attach recovery branch only fires when `alpaca_stop_order_id IS NULL`.

So a standalone stop the broker **cancels** (DAY expiry, external cancel) on a `POSITION_OPEN` row is healed by **neither** branch — the position sits naked.

**Observed live today:** `XLC` (mean_reversion, swing) carried **overnight with `broker_status=canceled`**. The stop reconciler flagged it (`naked: XLC`) but it's read-only by design, so nothing re-armed it.

## Fix
In `_check_order_statuses`, for `POSITION_OPEN` rows with a recorded `alpaca_stop_order_id` and filled shares, poll the stop. If `canceled`/`expired`/`rejected`, clear the dead id → the existing recovery branch re-attaches a fresh stop the **same tick**. A `filled` status is deliberately **not** cleared (genuine exit; clearing would spawn a duplicate stop on a closed position — that's fix #3's territory, attribution).

## Tests
- `POSITION_OPEN` + canceled standalone stop → re-arms within one tick (pre-fix: zero submits, naked).
- `filled` standalone stop → not cleared.
- ruff / mypy (critical-path gate) / live-path guard clean; 222 critical tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)