### PR TITLE
feat(strategy): per-strategy universe allow-list; constrain ORB to its 13 ETFs (#2)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -791,6 +791,25 @@ multi_strategy:
       risk_per_trade_pct: 0.01     # 1% equity risked per trade
       max_position_pct: 0.33
       fractional_shares: true
+      # Restrict ORB to the 13-ETF basket it was walkforward-validated on.
+      # Without this, at phase 3 the shared watchlist expands to include
+      # individual mega-caps (AAPL/MSFT/NVDA/GOOGL/AMZN/META) that ORB was
+      # never tested on — and they showed up on day one (2026-05-29: ORB
+      # traded MSFT/NVDA, with NVDA among the reconciliation_mismatch rows).
+      universe:
+        - "SPY"
+        - "QQQ"
+        - "XLK"
+        - "XLF"
+        - "XLV"
+        - "XLY"
+        - "XLP"
+        - "XLE"
+        - "XLI"
+        - "XLB"
+        - "XLU"
+        - "XLRE"
+        - "XLC"
 
     # Cross-sectional momentum (sleeve #6, issue #44).
     # Ranks the 11 SPDR sector ETFs by trailing total return and holds

--- a/trading_bot/strategy/base.py
+++ b/trading_bot/strategy/base.py
@@ -79,7 +79,9 @@ class StrategyBase(ABC):
         # shared watchlist expands to include individual mega-caps). Empty
         # / unset means "no restriction — trade the whole watchlist".
         raw_universe: Any = config.get("universe")
-        self._universe: frozenset[str] | None = (
+        # Named ``_universe_allowlist`` (not ``_universe``) to avoid colliding
+        # with cross_sectional_momentum's own ``_universe`` ranking set.
+        self._universe_allowlist: frozenset[str] | None = (
             frozenset(str(t).upper() for t in raw_universe)
             if isinstance(raw_universe, (list, tuple)) and raw_universe
             else None
@@ -91,9 +93,9 @@ class StrategyBase(ABC):
         Honours the optional per-strategy ``universe`` allow-list. With no
         allow-list configured, every ticker is allowed (legacy behaviour).
         """
-        if self._universe is None:
+        if self._universe_allowlist is None:
             return True
-        return ticker.upper() in self._universe
+        return ticker.upper() in self._universe_allowlist
 
     @abstractmethod
     def evaluate_entry(

--- a/trading_bot/strategy/base.py
+++ b/trading_bot/strategy/base.py
@@ -72,6 +72,28 @@ class StrategyBase(ABC):
         # in-memory closed-trades buffer instead.
         self._db_path: str | None = db_path
         self._vol_target_config: dict[str, Any] = vol_target_config or {}
+        # Optional per-strategy universe allow-list. When set, this sleeve
+        # only trades tickers in the list — a guard against a sleeve being
+        # run on a wider universe than it was validated on (e.g. ORB was
+        # walkforward-validated on the 13-ETF basket, but at phase 3 the
+        # shared watchlist expands to include individual mega-caps). Empty
+        # / unset means "no restriction — trade the whole watchlist".
+        raw_universe: Any = config.get("universe")
+        self._universe: frozenset[str] | None = (
+            frozenset(str(t).upper() for t in raw_universe)
+            if isinstance(raw_universe, (list, tuple)) and raw_universe
+            else None
+        )
+
+    def allows_ticker(self, ticker: str) -> bool:
+        """Return True if this strategy may trade ``ticker``.
+
+        Honours the optional per-strategy ``universe`` allow-list. With no
+        allow-list configured, every ticker is allowed (legacy behaviour).
+        """
+        if self._universe is None:
+            return True
+        return ticker.upper() in self._universe
 
     @abstractmethod
     def evaluate_entry(

--- a/trading_bot/strategy/strategy_manager.py
+++ b/trading_bot/strategy/strategy_manager.py
@@ -266,6 +266,14 @@ class StrategyManager:
                 if portfolio is None:
                     continue
 
+                # Per-strategy universe guard. A sleeve with a configured
+                # ``universe`` allow-list only trades those tickers — keeps
+                # a sleeve from trading a wider basket than it was validated
+                # on (ORB was walkforward-validated on the 13 ETFs, but the
+                # phase-3 watchlist also includes individual mega-caps).
+                if not strategy.allows_ticker(ticker):
+                    continue
+
                 # Per-strategy consecutive-loss cooldown — sit out the next
                 # tick window after N losing trades in a row.
                 if self._loss_cooldown is not None:

--- a/trading_bot/tests/test_strategies.py
+++ b/trading_bot/tests/test_strategies.py
@@ -158,6 +158,36 @@ class TestTechnicalHelpers:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.unit
+class TestPerStrategyUniverse:
+    """StrategyBase.allows_ticker honours an optional config ``universe``
+    allow-list — the guard that keeps a sleeve (e.g. ORB, validated on the
+    13-ETF basket) from trading the wider phase-3 watchlist."""
+
+    def test_no_universe_allows_everything(self) -> None:
+        strat = MeanReversionStrategy(config=_mr_config())
+        assert strat.allows_ticker("SPY") is True
+        assert strat.allows_ticker("NVDA") is True
+
+    def test_universe_restricts_to_listed_tickers(self) -> None:
+        cfg = {**_mr_config(), "universe": ["SPY", "QQQ", "XLF"]}
+        strat = MeanReversionStrategy(config=cfg)
+        assert strat.allows_ticker("SPY") is True
+        assert strat.allows_ticker("XLF") is True
+        assert strat.allows_ticker("NVDA") is False
+        assert strat.allows_ticker("MSFT") is False
+
+    def test_universe_is_case_insensitive(self) -> None:
+        cfg = {**_mr_config(), "universe": ["spy"]}
+        strat = MeanReversionStrategy(config=cfg)
+        assert strat.allows_ticker("SPY") is True
+
+    def test_empty_universe_means_no_restriction(self) -> None:
+        cfg = {**_mr_config(), "universe": []}
+        strat = MeanReversionStrategy(config=cfg)
+        assert strat.allows_ticker("NVDA") is True
+
+
 class TestMeanReversion:
     def test_no_entry_without_oversold(self) -> None:
         strategy = MeanReversionStrategy(config=_mr_config())


### PR DESCRIPTION
**Fix 2 of 3** from the ORB-first-day investigation.

## Problem
All sleeves run against one shared watchlist. At **phase 3** that's `us_phase3`, which adds individual mega-caps (AAPL/MSFT/NVDA/GOOGL/AMZN/META). ORB was walkforward-validated **only on the 13-ETF basket**, so on day one (2026-05-29) it traded **MSFT and NVDA** — unvalidated, earnings-gap-prone — and NVDA was one of the day's `reconciliation_mismatch` rows.

## Fix
- `StrategyBase` gains an optional **`universe`** allow-list (frozenset parsed from config, case-insensitive; empty/unset = no restriction = legacy behaviour) + `allows_ticker()`.
- `strategy_manager` skips any ticker outside a sleeve's allow-list before evaluating entry.
- ORB's `universe` is set to the 13 ETFs it was validated on.
- `mean_reversion` / `overnight_drift` are **unchanged** (no `universe` key → trade the whole watchlist exactly as before).

## Tests
- `allows_ticker` with/without a list, case-insensitivity, empty-list-means-unrestricted.
- ruff / mypy (base + strategy_manager are on the critical-path gate) / live-path guard clean; 222 critical tests pass.

This is a contained, opt-in mechanism — it only affects sleeves that declare a `universe`, i.e. ORB today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)