### PR TITLE
fix(env): refuse to start when ALPACA_API_KEY mismatches ALPACA_ENV intent (#147)

### DIFF
--- a/trading_bot/env.py
+++ b/trading_bot/env.py
@@ -10,6 +10,28 @@ process should use.  This module loads ``.env`` (without overriding existing
 env vars, so CI secrets always win) and exports the chosen pair as the legacy
 ``ALPACA_API_KEY`` / ``ALPACA_SECRET_KEY`` names that the rest of the codebase
 already reads — keeping a single runtime contract for both local and CI.
+
+Authoritative-not-advisory contract (issue #147)
+-------------------------------------------------
+``ALPACA_ENV`` together with the canonical ``ALPACA_{PAPER,LIVE}_KEY_ID`` pair
+is the source of truth.  Previously a stray ``ALPACA_API_KEY`` exported from a
+shell or a local ``.env`` would silently short-circuit selection and displace
+the canonical pair — making ``ALPACA_ENV`` merely advisory.  Disjoint
+paper/live key spaces meant a wrong key just 401'd, so this was fail-safe at
+the API layer; but with a live account in play, confused-deputy operator error
+becomes a real risk vector.
+
+Now: if ``ALPACA_API_KEY`` is set but does **not** match the canonical key for
+the selected environment (it matches the *other* environment's key, or matches
+neither while a canonical pair is configured), the resolver logs ``CRITICAL``
+and refuses for the remainder of the process — it scrubs the legacy names from
+``os.environ`` and hands back empty credentials.  ``GatewayConnection.connect()``
+reads ``os.environ`` directly and returns ``False`` on empty credentials, so the
+tick aborts; CLI callers see the empty return value and exit non-zero.
+
+A directly-set ``ALPACA_API_KEY`` is still honored when **no** canonical key id
+is configured at all — the documented local-dev path (see ``CLAUDE.md``), where
+there is no canonical pair to displace.
 """
 
 from __future__ import annotations
@@ -19,6 +41,40 @@ import os
 
 logger: logging.Logger = logging.getLogger(__name__)
 
+# Process-wide refuse latch.  A credential mismatch is a fatal misconfiguration:
+# once tripped we stay refused for the rest of the process so that a single
+# import-time ``resolve_alpaca_env()`` (see ``trading_bot/__init__.py``) keeps
+# *both* the live tick (``GatewayConnection`` reads ``os.environ``) and any CLI
+# re-invocation (reads the return value) from proceeding on bad credentials.
+_GUARD_TRIPPED: bool = False
+
+
+def _reset_env_guard() -> None:
+    """Test hook: clear the process-wide refuse latch."""
+    global _GUARD_TRIPPED
+    _GUARD_TRIPPED = False
+
+
+def _scrub_legacy_env() -> None:
+    """Remove the legacy credential names so the refusal reaches every reader."""
+    os.environ.pop("ALPACA_API_KEY", None)
+    os.environ.pop("ALPACA_SECRET_KEY", None)
+
+
+def _refuse(env: str, detail: str, is_paper: bool) -> tuple[str, str, bool]:
+    """Trip the guard, scrub the legacy names, and return the empty sentinel."""
+    global _GUARD_TRIPPED
+    _GUARD_TRIPPED = True
+    _scrub_legacy_env()
+    logger.critical(
+        "ALPACA_API_KEY does not match the ALPACA_ENV=%s credential pair (%s). "
+        "Refusing to start: a stray ALPACA_API_KEY must not displace the "
+        "canonical ALPACA_PAPER_KEY_ID / ALPACA_LIVE_KEY_ID pair. Unset "
+        "ALPACA_API_KEY / ALPACA_SECRET_KEY or correct ALPACA_ENV before retry.",
+        env, detail,
+    )
+    return "", "", is_paper
+
 
 def resolve_alpaca_env() -> tuple[str, str, bool]:
     """Resolve Alpaca credentials based on ``ALPACA_ENV``.
@@ -27,6 +83,9 @@ def resolve_alpaca_env() -> tuple[str, str, bool]:
     ``ALPACA_SECRET_KEY`` in ``os.environ`` if they are not already populated.
     Missing keys are returned as empty strings — callers decide whether to
     error out (CI/live runs) or proceed (offline backtests).
+
+    A credential mismatch (see module docstring) returns empty strings and
+    latches the process into a refusing state.
     """
     try:
         from dotenv import load_dotenv
@@ -37,18 +96,52 @@ def resolve_alpaca_env() -> tuple[str, str, bool]:
     env: str = os.environ.get("ALPACA_ENV", "paper").strip().lower()
     is_paper: bool = env != "live"
 
-    if os.environ.get("ALPACA_API_KEY") and os.environ.get("ALPACA_SECRET_KEY"):
-        return (
-            os.environ["ALPACA_API_KEY"],
-            os.environ["ALPACA_SECRET_KEY"],
-            is_paper,
-        )
+    # Already refused earlier this process — stay refused.
+    if _GUARD_TRIPPED:
+        _scrub_legacy_env()
+        return "", "", is_paper
 
+    paper_key: str = os.environ.get("ALPACA_PAPER_KEY_ID", "")
+    live_key: str = os.environ.get("ALPACA_LIVE_KEY_ID", "")
+    expected_key: str = paper_key if is_paper else live_key
+    other_key: str = live_key if is_paper else paper_key
+
+    legacy_key: str = os.environ.get("ALPACA_API_KEY", "")
+    legacy_secret: str = os.environ.get("ALPACA_SECRET_KEY", "")
+
+    if legacy_key and legacy_secret:
+        # A directly-set ALPACA_API_KEY is authoritative ONLY when it matches
+        # the canonical key for the selected env.  This is also the steady
+        # state on any second call within a process: the resolver re-exports
+        # the chosen pair under these names below.
+        if expected_key and legacy_key == expected_key:
+            return legacy_key, legacy_secret, is_paper
+
+        # Matches the *other* environment's key — classic confused deputy
+        # (e.g. ALPACA_API_KEY == ALPACA_LIVE_KEY_ID while ALPACA_ENV=paper).
+        if other_key and legacy_key == other_key:
+            wrong_env: str = "live" if is_paper else "paper"
+            return _refuse(
+                env,
+                f"it is the {wrong_env} key while ALPACA_ENV selects {env}",
+                is_paper,
+            )
+
+        # A canonical pair is configured for some env but the legacy key
+        # matches neither — a stray export displacing the canonical pair.
+        if expected_key or other_key:
+            return _refuse(env, "it matches neither configured key pair", is_paper)
+
+        # No canonical key ids configured at all: honor the directly-set
+        # ALPACA_API_KEY (documented local-dev path — nothing to displace).
+        return legacy_key, legacy_secret, is_paper
+
+    # No legacy override → select the canonical pair for ALPACA_ENV.
     if is_paper:
-        key: str = os.environ.get("ALPACA_PAPER_KEY_ID", "")
+        key: str = paper_key
         secret: str = os.environ.get("ALPACA_PAPER_SECRET", "")
     else:
-        key = os.environ.get("ALPACA_LIVE_KEY_ID", "")
+        key = live_key
         secret = os.environ.get("ALPACA_LIVE_SECRET", "")
 
     if key and secret:

--- a/trading_bot/tests/test_env_and_gateway.py
+++ b/trading_bot/tests/test_env_and_gateway.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from trading_bot.env import resolve_alpaca_env
+from trading_bot.env import _reset_env_guard, resolve_alpaca_env
 from trading_bot.gateway.connection import GatewayConnection
 
 
@@ -28,7 +28,11 @@ def _isolate_env(monkeypatch):
         "ALPACA_LIVE_SECRET",
     ):
         monkeypatch.delenv(var, raising=False)
+    # The refuse latch is process-wide; clear it so a mismatch test does not
+    # leak a refusing state into the next test.
+    _reset_env_guard()
     yield
+    _reset_env_guard()
 
 
 def test_resolve_alpaca_env_paper_default(monkeypatch):
@@ -51,13 +55,80 @@ def test_resolve_alpaca_env_live_uses_live_pair(monkeypatch):
     assert (key, secret, is_paper) == ("lk1", "ls1", False)
 
 
-def test_resolve_alpaca_env_existing_legacy_keys_short_circuit(monkeypatch):
-    """If ALPACA_API_KEY/SECRET_KEY are already set, those win."""
-    monkeypatch.setenv("ALPACA_API_KEY", "preset-k")
-    monkeypatch.setenv("ALPACA_SECRET_KEY", "preset-s")
-    monkeypatch.setenv("ALPACA_PAPER_KEY_ID", "should-be-ignored")
-    key, secret, _ = resolve_alpaca_env()
-    assert (key, secret) == ("preset-k", "preset-s")
+def test_resolve_alpaca_env_legacy_matches_selected_pair_proceeds(monkeypatch):
+    """ALPACA_API_KEY that matches the env-selected key id is honored silently.
+
+    This is the steady state after the resolver re-exports the chosen pair.
+    """
+    monkeypatch.setenv("ALPACA_ENV", "paper")
+    monkeypatch.setenv("ALPACA_PAPER_KEY_ID", "pk1")
+    monkeypatch.setenv("ALPACA_PAPER_SECRET", "ps1")
+    monkeypatch.setenv("ALPACA_API_KEY", "pk1")
+    monkeypatch.setenv("ALPACA_SECRET_KEY", "ps1")
+    key, secret, is_paper = resolve_alpaca_env()
+    assert (key, secret, is_paper) == ("pk1", "ps1", True)
+
+
+def test_resolve_alpaca_env_legacy_matches_other_pair_refuses(monkeypatch, caplog):
+    """ALPACA_API_KEY == the *other* env's key id → refuse (confused deputy)."""
+    monkeypatch.setenv("ALPACA_ENV", "paper")
+    monkeypatch.setenv("ALPACA_PAPER_KEY_ID", "pk1")
+    monkeypatch.setenv("ALPACA_PAPER_SECRET", "ps1")
+    monkeypatch.setenv("ALPACA_LIVE_KEY_ID", "lk1")
+    # Operator accidentally exported the LIVE key while ALPACA_ENV=paper.
+    monkeypatch.setenv("ALPACA_API_KEY", "lk1")
+    monkeypatch.setenv("ALPACA_SECRET_KEY", "ls1")
+    with caplog.at_level("CRITICAL"):
+        key, secret, is_paper = resolve_alpaca_env()
+    assert (key, secret, is_paper) == ("", "", True)
+    assert any(r.levelname == "CRITICAL" for r in caplog.records)
+    # Legacy names scrubbed so GatewayConnection (reads os.environ) sees nothing.
+    assert "ALPACA_API_KEY" not in os.environ
+    assert "ALPACA_SECRET_KEY" not in os.environ
+
+
+def test_resolve_alpaca_env_legacy_matches_neither_pair_refuses(monkeypatch, caplog):
+    """ALPACA_API_KEY matches neither configured pair → refuse (stray export)."""
+    monkeypatch.setenv("ALPACA_ENV", "paper")
+    monkeypatch.setenv("ALPACA_PAPER_KEY_ID", "pk1")
+    monkeypatch.setenv("ALPACA_PAPER_SECRET", "ps1")
+    monkeypatch.setenv("ALPACA_API_KEY", "stray-key")
+    monkeypatch.setenv("ALPACA_SECRET_KEY", "stray-secret")
+    with caplog.at_level("CRITICAL"):
+        key, secret, is_paper = resolve_alpaca_env()
+    assert (key, secret, is_paper) == ("", "", True)
+    assert any(r.levelname == "CRITICAL" for r in caplog.records)
+    assert "ALPACA_API_KEY" not in os.environ
+
+
+def test_resolve_alpaca_env_refuse_latches_for_process(monkeypatch):
+    """Once refused, a subsequent call stays refused even if the env is fixed.
+
+    Models the import-time resolve()-then-CLI-resolve() sequence: a stray key
+    detected at import must not silently recover on a second call.
+    """
+    monkeypatch.setenv("ALPACA_ENV", "paper")
+    monkeypatch.setenv("ALPACA_PAPER_KEY_ID", "pk1")
+    monkeypatch.setenv("ALPACA_PAPER_SECRET", "ps1")
+    monkeypatch.setenv("ALPACA_API_KEY", "lk1")  # stray
+    monkeypatch.setenv("ALPACA_SECRET_KEY", "ls1")
+    assert resolve_alpaca_env() == ("", "", True)
+    # _refuse scrubbed the stray names; without the latch the canonical pair
+    # would now be re-exported. The latch must keep us refused.
+    assert resolve_alpaca_env() == ("", "", True)
+
+
+def test_resolve_alpaca_env_direct_key_without_canonical_pair_proceeds(monkeypatch):
+    """Documented local-dev path: only ALPACA_API_KEY set, no canonical pair.
+
+    There is nothing to displace, so the direct key is honored.
+    """
+    # No-op load_dotenv so the project's real .env can't leak a canonical pair.
+    monkeypatch.setattr("dotenv.load_dotenv", lambda *a, **k: False)
+    monkeypatch.setenv("ALPACA_API_KEY", "direct-k")
+    monkeypatch.setenv("ALPACA_SECRET_KEY", "direct-s")
+    key, secret, is_paper = resolve_alpaca_env()
+    assert (key, secret, is_paper) == ("direct-k", "direct-s", True)
 
 
 def test_resolve_alpaca_env_missing_returns_empty(monkeypatch):


### PR DESCRIPTION
Closes #147.

## Problem

`resolve_alpaca_env()` early-returned any `ALPACA_API_KEY` / `ALPACA_SECRET_KEY` pair regardless of whether those values came from the env-selected canonical pair. That made `ALPACA_ENV` **semantically advisory rather than authoritative** — a stray `ALPACA_API_KEY` export from a shell or `.env` could silently displace the canonical `ALPACA_{PAPER,LIVE}_KEY_ID` pair. Fail-safe today (Alpaca's disjoint paper/live key spaces just 401), but with the live flip imminent on a \$1k account, confused-deputy operator error becomes a real risk vector.

## Change

`ALPACA_ENV` + the canonical key pair is now the source of truth:

- `ALPACA_API_KEY` matches the **selected** env's key id → proceed silently (this is also the steady state, since the resolver re-exports the chosen pair under these names).
- `ALPACA_API_KEY` matches the **other** env's key id → `CRITICAL` + refuse.
- `ALPACA_API_KEY` matches **neither**, *while a canonical pair is configured* → `CRITICAL` + refuse (stray export).
- `ALPACA_API_KEY` set with **no** canonical key id configured → honored (documented local-dev path; nothing to displace).
- `ALPACA_API_KEY` unset → unchanged (select from `ALPACA_{PAPER,LIVE}_*` per `ALPACA_ENV`).

### How the refusal is fatal

`GatewayConnection.__init__` reads `os.environ` directly and `connect()` returns `False` on empty credentials. On refusal the resolver scrubs `ALPACA_API_KEY`/`ALPACA_SECRET_KEY` from `os.environ` (→ tick aborts) **and** sets a process-wide latch so a CLI re-invocation after the import-time `resolve_alpaca_env()` (`trading_bot/__init__.py:7`) cannot silently recover to the canonical pair. CLI tools see the empty return value and exit non-zero.

## Design note

The acceptance criteria say "matches neither → refuse." I scoped that to *"...while a canonical pair is configured"* so the **documented direct-key local-dev path** (`CLAUDE.md`: "a local .env can use either pair") is preserved — when no canonical pair exists there is nothing to displace. This fully closes the stated threat (displacement of the canonical pair, which is always present in CI/live) without breaking offline/local direct-key use.

## Test plan

- [x] `resolve_alpaca_env` covers all four cases + the latch + the direct-key path (`trading_bot/tests/test_env_and_gateway.py`)
- [x] Pre-existing `test_resolve_alpaca_env_existing_legacy_keys_short_circuit` (which encoded the old "stray key wins" bug) replaced with the new refusal behavior
- [x] Full suite green: `1017 passed, 4 skipped`
- [x] `ruff` + `mypy` clean on changed files
- [x] No GHA workflow changes needed — existing repo secrets satisfy the matching case

🤖 Generated with [Claude Code](https://claude.com/claude-code)