### PR TITLE
fix(execution): attribute filled standalone stop on POSITION_OPEN as stop_loss (#3)

### DIFF
--- a/trading_bot/execution/order_manager.py
+++ b/trading_bot/execution/order_manager.py
@@ -597,9 +597,13 @@ class OrderManager:
             # naked overnight (XLC carried unprotected on 2026-05-29). Poll
             # the recorded stop here; if it's dead, clear the id so the
             # recovery branch below re-attaches a fresh stop this same tick.
-            # A 'filled' status is intentionally NOT handled here — that is a
-            # clean exit and is attributed separately; clearing it would be
-            # wrong. Only dead-but-not-filled statuses are cleared.
+            # Two outcomes are handled: a 'filled' stop is a genuine
+            # stop_loss exit (attribute it cleanly — pre-fix the
+            # POSITION_OPEN poll never checked, so the fill went
+            # unattributed and the next state-recovery pass swept it as
+            # reconciliation_mismatch with NULL pnl: NVDA/XLF/XLB on
+            # 2026-05-29). A canceled/expired/rejected stop is dead — clear
+            # the id so the recovery branch below re-attaches a fresh one.
             if (
                 active.status == PositionStatus.POSITION_OPEN
                 and active.alpaca_stop_order_id is not None
@@ -614,7 +618,33 @@ class OrderManager:
                     stop_status: str = (
                         getattr(stop_order.status, "value", "") or ""
                     ).lower()
-                    if stop_status in ("canceled", "expired", "rejected"):
+                    if stop_status == "filled":
+                        stop_exit_price: float = float(
+                            stop_order.filled_avg_price or 0
+                        )
+                        logger.info(
+                            "Standalone stop FILLED: %s @ %.4f reason=%s "
+                            "(trade_id=%d)",
+                            active.ticker, stop_exit_price,
+                            ExitReason.STOP_LOSS.value, trade_id,
+                        )
+                        await self._cancel_other_exits(
+                            trade_id, active, stop_oid,
+                        )
+                        await self._close_position(
+                            trade_id, active, stop_exit_price,
+                            ExitReason.STOP_LOSS.value,
+                        )
+                        stop_pnl: float = (
+                            (stop_exit_price - active.entry_price)
+                            * active.filled_shares
+                        )
+                        await self._notifier.position_closed(
+                            ticker=active.ticker, pnl=stop_pnl,
+                            hold_time="",
+                            exit_reason=ExitReason.STOP_LOSS.value,
+                        )
+                    elif stop_status in ("canceled", "expired", "rejected"):
                         logger.warning(
                             "Standalone stop %s for %s is %s while position is "
                             "POSITION_OPEN — clearing dead id so it re-attaches "

--- a/trading_bot/gateway/recovery.py
+++ b/trading_bot/gateway/recovery.py
@@ -323,7 +323,23 @@ class StateRecovery:
             # silently dropping the realized P&L from
             # `daily_summaries`. Observed 2026-05-15 — see PR #140.
             status_val: str = str(db_row.get("status", "") or "")
-            if status_val in _EXIT_IN_FLIGHT_STATUSES:
+            # Defer to the order-status poll for clean exit attribution when
+            # the row is exit-in-flight (CLOSING/STOP_ACTIVE/TRAILING_ACTIVE)
+            # OR POSITION_OPEN with a tracked standalone stop. The latter
+            # covers mean_reversion / overnight_drift / opening_range_breakout,
+            # whose protective stop lives on a POSITION_OPEN row (they never
+            # transition to STOP_ACTIVE). When that stop fills between ticks,
+            # recovery would otherwise win the race and stamp
+            # reconciliation_mismatch with NULL pnl — observed 2026-05-29 on
+            # ORB's NVDA/XLF/XLB. The fresh-entry grace above already shields
+            # just-opened rows, so a POSITION_OPEN row that is flat at the
+            # broker past the grace window is genuinely closed; deferring lets
+            # _check_order_statuses attribute the filled stop as stop_loss.
+            defer_for_attribution: bool = status_val in _EXIT_IN_FLIGHT_STATUSES or (
+                status_val == "POSITION_OPEN"
+                and bool(db_row.get("alpaca_stop_order_id"))
+            )
+            if defer_for_attribution:
                 tracked_oid: str | None = None
                 tracked_col: str | None = None
                 for col in _EXIT_ORDER_ID_COLUMNS:

--- a/trading_bot/tests/test_standalone_stop_lifecycle_117.py
+++ b/trading_bot/tests/test_standalone_stop_lifecycle_117.py
@@ -902,21 +902,22 @@ class TestFailureModeA_StopCancelledOnPositionOpen:
         assert row[1] == "stop-fresh-1"
 
     @pytest.mark.asyncio
-    async def test_filled_standalone_stop_on_position_open_not_cleared(
+    async def test_filled_standalone_stop_on_position_open_closes_as_stop_loss(
         self, config, tmp_db_path: str, mock_notifier
     ) -> None:
-        """A 'filled' standalone stop must NOT be treated as dead/cleared by
-        the re-arm path — that is a genuine exit (attributed elsewhere).
-        Clearing it would spawn a duplicate stop on a closed position."""
+        """A 'filled' standalone stop on a POSITION_OPEN row is a genuine
+        stop_loss exit and must be attributed cleanly (NOT re-armed, NOT
+        left for the state-recovery sweep to stamp reconciliation_mismatch
+        with NULL pnl — the NVDA/XLF/XLB path on 2026-05-29)."""
         om = _make_om(config, tmp_db_path, mock_notifier)
         _set_market_open(om)
 
         trade_id = om._create_position_record(
-            _entry("XLC", shares=0.1402, price=116.368)
+            _entry("NVDA", shares=0.4575, price=216.935)
         )
         om._update_position_status(trade_id, PositionStatus.POSITION_OPEN)
-        om._update_position_field(trade_id, "quantity", 0.1402)
-        om._update_position_field(trade_id, "entry_price", 116.368)
+        om._update_position_field(trade_id, "quantity", 0.4575)
+        om._update_position_field(trade_id, "entry_price", 216.935)
         om._update_position_field(trade_id, "alpaca_stop_order_id", "stop-filled")
 
         submits: list = []
@@ -928,13 +929,30 @@ class TestFailureModeA_StopCancelledOnPositionOpen:
         om._gw.client.submit_order = MagicMock(side_effect=_submit)
         om._gw.client.get_orders = MagicMock(return_value=[])
         om._gw.client.get_order_by_id = MagicMock(
-            side_effect=lambda oid: _alpaca_order(oid, "filled", 0.1402, 114.62)
+            side_effect=lambda oid: _alpaca_order(oid, "filled", 0.4575, 212.85)
         )
 
         await om._check_order_statuses()
 
-        # No re-arm submission — the re-arm path only clears dead-but-not-
-        # filled statuses.
+        # No re-arm submission — a filled stop is an exit, not a dead stop.
         assert len(submits) == 0
-        active = om._active_orders[trade_id]
-        assert active.alpaca_stop_order_id == "stop-filled"
+        # Closing removes the trade from the in-memory active map.
+        assert trade_id not in om._active_orders
+
+        conn = sqlite3.connect(tmp_db_path)
+        try:
+            pos = conn.execute(
+                "SELECT status FROM positions WHERE id = ?", (trade_id,),
+            ).fetchone()
+            trade = conn.execute(
+                "SELECT exit_reason, exit_price FROM trades "
+                "WHERE exit_reason IS NOT NULL ORDER BY id DESC LIMIT 1",
+            ).fetchone()
+        finally:
+            conn.close()
+        assert pos[0] == PositionStatus.CLOSED.value
+        # Clean stop_loss attribution with a real exit price — not
+        # reconciliation_mismatch / NULL.
+        assert trade is not None
+        assert trade[0] == "stop_loss"
+        assert trade[1] == pytest.approx(212.85)

--- a/trading_bot/tests/test_state_recovery.py
+++ b/trading_bot/tests/test_state_recovery.py
@@ -378,12 +378,12 @@ class TestStateRecovery:
     async def test_db_position_open_status_not_deferred(
         self, tmp_db_path: str, mock_notifier
     ) -> None:
-        """Sanity check: POSITION_OPEN (not exit-in-flight) still
-        reconciles to mismatch when the broker doesn't show the
-        position. The defer only applies to exit-in-flight statuses.
+        """POSITION_OPEN WITHOUT a tracked stop still reconciles to
+        mismatch when the broker doesn't show the position — there's no
+        stop order to poll, so deferring would be indefinite.
         """
         conn = sqlite3.connect(tmp_db_path)
-        _insert_db_position(conn, "GOOGL")
+        _insert_db_position(conn, "GOOGL")  # no alpaca_stop_order_id
         conn.close()
 
         gw = self._make_gateway(positions=[])
@@ -394,6 +394,45 @@ class TestStateRecovery:
         result = await recovery.recover()
         assert "GOOGL" in result.positions_closed_mismatch
         assert "GOOGL" not in result.positions_deferred_exit_inflight
+
+    @pytest.mark.asyncio
+    async def test_db_position_open_with_stop_order_deferred(
+        self, tmp_db_path: str, mock_notifier
+    ) -> None:
+        """POSITION_OPEN WITH a standalone stop_order_id must defer.
+        Standalone-stop sleeves (mean_reversion / overnight_drift /
+        opening_range_breakout) never leave POSITION_OPEN, so when their
+        protective stop fills between ticks the row must defer to the
+        order-status poll for clean stop_loss attribution — not be swept
+        to reconciliation_mismatch with NULL pnl (the NVDA/XLF/XLB path
+        on 2026-05-29).
+        """
+        conn = sqlite3.connect(tmp_db_path)
+        conn.execute(
+            """INSERT INTO positions
+               (ticker, exchange, currency, quantity, entry_price,
+                entry_time, status, hold_type, phase, strategy_id,
+                alpaca_stop_order_id)
+               VALUES (?,?,?,?,?,?,?,?,?,?,?)""",
+            (
+                "NVDA", "NASDAQ", "USD", 1, 216.9,
+                (datetime.now(ET) - timedelta(hours=2)).isoformat(),
+                "POSITION_OPEN", "intraday", 3, "opening_range_breakout",
+                "orb-stop-order-id",
+            ),
+        )
+        conn.commit()
+        conn.close()
+
+        gw = self._make_gateway(positions=[])
+        recovery = _make_recovery(
+            gw, tmp_db_path, mock_notifier,
+            now=datetime.now(ET) + timedelta(hours=1),
+        )
+        result = await recovery.recover()
+
+        assert "NVDA" in result.positions_deferred_exit_inflight
+        assert "NVDA" not in result.positions_closed_mismatch
 
     @pytest.mark.asyncio
     async def test_quantity_mismatch_updated(


### PR DESCRIPTION
**Fix 3 of 3** from the ORB-first-day investigation. Builds on #169 (#1).

## Problem
Standalone protective stops for `mean_reversion` / `overnight_drift` / `opening_range_breakout` live on a row that stays **`POSITION_OPEN`**. When such a stop fills between ticks, the exit was mis-attributed as `reconciliation_mismatch` (NULL P&L until the nightly backfill) because:

1. **State recovery runs first in the tick** and its exit-in-flight **defer** (PR #140) only covered `CLOSING`/`STOP_ACTIVE`/`TRAILING_ACTIVE` — **not `POSITION_OPEN`**. So recovery won the race and swept it.
2. `_check_order_statuses` **never polled the standalone stop** for `POSITION_OPEN` rows, so even without the race the fill went unattributed.

**Observed live 2026-05-29:** ORB's NVDA/XLF/XLB stops filled hours after entry and all landed as `reconciliation_mismatch`.

## Fix (two composing parts)
- **recovery:** defer a `POSITION_OPEN` row to the order poll when it carries a tracked `alpaca_stop_order_id`. The fresh-entry grace above already shields just-opened rows, so a `POSITION_OPEN` row flat at the broker past the grace window is genuinely closed → safe to defer for clean attribution.
- **order_manager:** in the `POSITION_OPEN` standalone-stop poll added by #169, handle a `filled` status — close the position cleanly as `stop_loss` with the real fill price, instead of leaving it for the recovery sweep.

Together: a filled standalone stop now attributes `stop_loss` + real `exit_price`/`pnl` at tick time, not `reconciliation_mismatch` + NULL.

## Tests
- recovery **defers** `POSITION_OPEN`+stop; still **sweeps** `POSITION_OPEN` without a stop (nothing to poll).
- a **filled** standalone stop on `POSITION_OPEN` → position CLOSED, trades row `exit_reason='stop_loss'` with the real exit price.
- ruff / mypy (critical-path gate) / live-path guard clean; 222 critical tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)