### PR TITLE
fix(self_improve): gate flatten_orphans --execute on risk_circuit_state (#148)

### DIFF
--- a/trading_bot/self_improve/flatten_orphans.py
+++ b/trading_bot/self_improve/flatten_orphans.py
@@ -27,6 +27,12 @@ SAFETY:
   - --dry-run is the default. The script prints what it would do and
     exits without touching Alpaca or the DB.
   - --execute is required to actually submit orders.
+  - Risk-circuit gate: with --execute, the script reads risk_circuit_state
+    first and REFUSES if any kill switch is active (is_paused,
+    daily_loss_limit_hit, drawdown_breaker_active, commission_stop_active).
+    This guards against an operator flattening a stale ticker list right
+    after the bot tripped its loss limit. Override with --force-during-halt
+    (logs a WARNING). The halt read is offline, before any broker call.
   - --tickers can scope the run to a subset (default: SPY,XLRE,QQQ).
   - Each ticker runs independently; one failure does not block the rest.
   - Order TIF is chosen from Alpaca's clock:
@@ -37,6 +43,8 @@ Run:
     python -m trading_bot.self_improve.flatten_orphans               # dry-run
     python -m trading_bot.self_improve.flatten_orphans --execute     # send orders
     python -m trading_bot.self_improve.flatten_orphans --tickers QQQ # one only
+    python -m trading_bot.self_improve.flatten_orphans --execute \
+        --force-during-halt    # flatten even while a kill switch is active
 """
 
 from __future__ import annotations
@@ -52,6 +60,7 @@ from typing import Iterable
 from zoneinfo import ZoneInfo
 
 from trading_bot.config import Config
+from trading_bot.db import repository as repo
 from trading_bot.env import resolve_alpaca_env
 from trading_bot.log_setup import setup_logging
 
@@ -61,6 +70,45 @@ ET = ZoneInfo("US/Eastern")
 
 # Default scope. Edit only if reconcile shows different orphans.
 DEFAULT_ORPHAN_TICKERS: tuple[str, ...] = ("SPY", "XLRE", "QQQ")
+
+# Global risk-circuit key. Canonical definition is
+# trading_bot.execution.risk_manager._RISK_STATE_KEY; kept as a literal here so
+# this operational tool doesn't import the RiskManager. test_flatten_orphans
+# asserts the two stay in sync.
+_RISK_STATE_KEY: str = "risk_manager:global"
+
+# Halt flags in the persisted risk_circuit_state blob. If any is truthy the
+# bot has tripped a kill switch and a manual --execute flatten must not run
+# unless explicitly forced.
+_HALT_FLAGS: tuple[str, ...] = (
+    "is_paused",
+    "daily_loss_limit_hit",
+    "drawdown_breaker_active",
+    "commission_stop_active",
+)
+
+
+def _active_halts(db_path: str) -> list[str]:
+    """Return the names of any active risk-circuit halts, or ``[]`` if clear.
+
+    Reads ``risk_circuit_state`` directly from SQLite — no broker connection —
+    so the refusal path never opens an Alpaca session. A read failure is
+    treated as halted (fail-safe): better to block a flatten than to fire one
+    blind to the kill switch.
+    """
+    try:
+        with sqlite3.connect(db_path) as conn:
+            state_row = repo.load_risk_state(conn, _RISK_STATE_KEY)
+    except Exception:
+        logger.exception(
+            "Could not read risk_circuit_state from %s; treating as halted",
+            db_path,
+        )
+        return ["risk_state_unreadable"]
+    if state_row is None:
+        return []
+    blob: dict = state_row.get("state") or {}
+    return [flag for flag in _HALT_FLAGS if blob.get(flag)]
 
 
 @dataclass(frozen=True)
@@ -243,9 +291,35 @@ def plan_and_execute(
     db_path: str,
     tickers: Iterable[str],
     execute: bool,
+    force_during_halt: bool = False,
 ) -> int:
     """Return shell exit code. 0 = all planned/executed cleanly."""
     target_tickers = {t.upper() for t in tickers}
+
+    if not Path(db_path).exists():
+        logger.error("DB not found at %s", db_path)
+        return 2
+
+    # Risk-circuit gate — only when actually placing orders. The read is
+    # offline (SQLite) and happens BEFORE any broker call, so a refusal never
+    # opens an Alpaca session. dry-run is intentionally unaffected: it only
+    # lists positions and prints a plan.
+    if execute:
+        halts = _active_halts(db_path)
+        if halts and not force_during_halt:
+            logger.error(
+                "Risk circuit is HALTED (%s). Refusing --execute to protect the "
+                "account during an active kill switch. Re-run with "
+                "--force-during-halt to override (logs a WARNING).",
+                ", ".join(halts),
+            )
+            return 2
+        if halts and force_during_halt:
+            logger.warning(
+                "Risk circuit is HALTED (%s) but --force-during-halt was "
+                "supplied — proceeding with flatten anyway.",
+                ", ".join(halts),
+            )
 
     api_key, secret_key, is_paper = resolve_alpaca_env()
     if not api_key or not secret_key:
@@ -259,10 +333,6 @@ def plan_and_execute(
     client = TradingClient(api_key, secret_key, paper=is_paper)
     logger.info("Connected to Alpaca (%s, paper=%s)",
                 "live" if not is_paper else "paper", is_paper)
-
-    if not Path(db_path).exists():
-        logger.error("DB not found at %s", db_path)
-        return 2
 
     # Pull live Alpaca positions and the clock state up front. The clock
     # informs the TIF chosen for the flatten orders (see _choose_tif).
@@ -449,16 +519,34 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
                    help="Comma-separated tickers to consider (default: SPY,XLRE,QQQ)")
     p.add_argument("--execute", action="store_true",
                    help="Actually submit orders. Without this flag the script is read-only.")
+    p.add_argument("--force-during-halt", action="store_true",
+                   help="Override the risk-circuit halt gate and flatten even when "
+                        "a kill switch is active. Requires --execute.")
     return p.parse_args(argv)
 
 
 def main(argv: list[str] | None = None) -> int:
     setup_logging("flatten_orphans")
     args = _parse_args(argv)
+
+    # --force-during-halt only has meaning alongside --execute. On its own it's
+    # an operator mistake: warn and exit without touching the broker or DB.
+    if args.force_during_halt and not args.execute:
+        logger.warning(
+            "--force-during-halt has no effect without --execute (the halt gate "
+            "only applies when placing orders). Exiting without action."
+        )
+        return 0
+
     config = Config.load(args.config)
     db_path = args.db or config.db_path
     tickers = [t.strip() for t in args.tickers.split(",") if t.strip()]
-    return plan_and_execute(db_path=db_path, tickers=tickers, execute=args.execute)
+    return plan_and_execute(
+        db_path=db_path,
+        tickers=tickers,
+        execute=args.execute,
+        force_during_halt=args.force_during_halt,
+    )
 
 
 if __name__ == "__main__":

--- a/trading_bot/tests/test_flatten_orphans.py
+++ b/trading_bot/tests/test_flatten_orphans.py
@@ -295,3 +295,162 @@ def test_execute_bulk_does_not_mark_db_closed_on_http_202(tmp_db):
     assert row[0] == "POSITION_OPEN", (
         "HTTP 202 must NOT close the DB row — pre-fix regression"
     )
+
+
+# ---------------------------------------------------------------------------
+# Risk-circuit halt gate (issue #148)
+# ---------------------------------------------------------------------------
+
+
+def _seed_halt(db_path: str, **flags: bool) -> None:
+    """Write a risk_circuit_state row with the given halt flags set."""
+    conn = sqlite3.connect(db_path)
+    try:
+        repo.save_risk_state(
+            conn,
+            _RISK_STATE_KEY,
+            tripped=any(flags.values()),
+            reason="test halt",
+            state=dict(flags),
+        )
+    finally:
+        conn.close()
+
+
+@pytest.mark.unit
+def test_risk_state_key_matches_risk_manager():
+    """The hardcoded key must track risk_manager's canonical definition."""
+    from trading_bot.execution.risk_manager import _RISK_STATE_KEY as rm_key
+    assert _RISK_STATE_KEY == rm_key
+
+
+@pytest.mark.unit
+def test_active_halts_empty_when_no_row(tmp_db_path):
+    assert _active_halts(tmp_db_path) == []
+
+
+@pytest.mark.unit
+def test_active_halts_empty_when_all_flags_false(tmp_db_path):
+    _seed_halt(tmp_db_path, is_paused=False, daily_loss_limit_hit=False,
+               drawdown_breaker_active=False, commission_stop_active=False)
+    assert _active_halts(tmp_db_path) == []
+
+
+@pytest.mark.unit
+def test_active_halts_reports_each_set_flag(tmp_db_path):
+    _seed_halt(tmp_db_path, drawdown_breaker_active=True, is_paused=True)
+    halts = _active_halts(tmp_db_path)
+    assert set(halts) == {"is_paused", "drawdown_breaker_active"}
+    # Only known halt flags are reported, in declared order.
+    assert all(h in _HALT_FLAGS for h in halts)
+
+
+@pytest.mark.unit
+def test_active_halts_failsafe_on_unreadable_db():
+    halts = _active_halts("/nonexistent/path/to.db")
+    assert halts == ["risk_state_unreadable"]
+
+
+@pytest.mark.unit
+def test_execute_refused_when_halted(tmp_db_path, monkeypatch):
+    """halt + --execute → exit 2, and the broker is never contacted."""
+    _seed_halt(tmp_db_path, daily_loss_limit_hit=True)
+    resolve = MagicMock()
+    monkeypatch.setattr(
+        "trading_bot.self_improve.flatten_orphans.resolve_alpaca_env", resolve,
+    )
+    rc = plan_and_execute(
+        db_path=tmp_db_path, tickers=["SPY"], execute=True,
+        force_during_halt=False,
+    )
+    assert rc == 2
+    resolve.assert_not_called()  # refusal happened offline, before any broker call
+
+
+@pytest.mark.unit
+def test_execute_proceeds_past_gate_when_not_halted(tmp_db_path, monkeypatch):
+    """no halt + --execute → gate passes and the broker path is entered."""
+    # Clean risk state (no row).
+    resolve = MagicMock(return_value=("k", "s", True))
+    monkeypatch.setattr(
+        "trading_bot.self_improve.flatten_orphans.resolve_alpaca_env", resolve,
+    )
+    client = MagicMock()
+    client.get_all_positions.return_value = []  # no orphans → clean exit
+    with patch("alpaca.trading.client.TradingClient", return_value=client):
+        rc = plan_and_execute(
+            db_path=tmp_db_path, tickers=["SPY"], execute=True,
+            force_during_halt=False,
+        )
+    assert rc == 0
+    resolve.assert_called_once()  # gate let us through to the broker
+
+
+@pytest.mark.unit
+def test_execute_forced_during_halt_proceeds_with_warning(
+    tmp_db_path, monkeypatch, caplog,
+):
+    """halt + --execute + --force-during-halt → proceeds, logs WARNING."""
+    _seed_halt(tmp_db_path, commission_stop_active=True)
+    resolve = MagicMock(return_value=("k", "s", True))
+    monkeypatch.setattr(
+        "trading_bot.self_improve.flatten_orphans.resolve_alpaca_env", resolve,
+    )
+    client = MagicMock()
+    client.get_all_positions.return_value = []
+    with patch("alpaca.trading.client.TradingClient", return_value=client):
+        with caplog.at_level("WARNING"):
+            rc = plan_and_execute(
+                db_path=tmp_db_path, tickers=["SPY"], execute=True,
+                force_during_halt=True,
+            )
+    assert rc == 0
+    resolve.assert_called_once()
+    assert any(
+        "force-during-halt" in r.message and r.levelname == "WARNING"
+        for r in caplog.records
+    )
+
+
+@pytest.mark.unit
+def test_dry_run_unaffected_by_halt(tmp_db_path, monkeypatch):
+    """Halt state must not block a read-only dry-run."""
+    _seed_halt(tmp_db_path, is_paused=True, drawdown_breaker_active=True)
+    resolve = MagicMock(return_value=("k", "s", True))
+    monkeypatch.setattr(
+        "trading_bot.self_improve.flatten_orphans.resolve_alpaca_env", resolve,
+    )
+    client = MagicMock()
+    client.get_all_positions.return_value = []
+    with patch("alpaca.trading.client.TradingClient", return_value=client):
+        rc = plan_and_execute(
+            db_path=tmp_db_path, tickers=["SPY"], execute=False,
+            force_during_halt=False,
+        )
+    assert rc == 0
+    resolve.assert_called_once()  # dry-run still connects to list positions
+
+
+@pytest.mark.unit
+def test_force_during_halt_without_execute_is_noop(monkeypatch, caplog):
+    """--force-during-halt alone warns and exits without doing anything."""
+    called = MagicMock()
+    monkeypatch.setattr(
+        "trading_bot.self_improve.flatten_orphans.plan_and_execute", called,
+    )
+    monkeypatch.setattr(
+        "trading_bot.self_improve.flatten_orphans.Config.load",
+        lambda *a, **k: MagicMock(db_path=":memory:"),
+    )
+    # No-op setup_logging so it doesn't reconfigure handlers out from under
+    # caplog (which captures via root-logger propagation).
+    monkeypatch.setattr(
+        "trading_bot.self_improve.flatten_orphans.setup_logging",
+        lambda *a, **k: None,
+    )
+    from trading_bot.self_improve.flatten_orphans import main
+    with caplog.at_level("WARNING", logger="trading_bot.self_improve.flatten_orphans"):
+        rc = main(["--force-during-halt"])
+    assert rc == 0
+    called.assert_not_called()
+    assert any("no effect without --execute" in r.message for r in caplog.records)

--- a/trading_bot/tests/test_flatten_orphans.py
+++ b/trading_bot/tests/test_flatten_orphans.py
@@ -9,18 +9,24 @@ and TIF selection from clock state.
 
 from __future__ import annotations
 
+import sqlite3
 from dataclasses import dataclass
 
 import pytest
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
+from trading_bot.db import repository as repo
 from trading_bot.self_improve.flatten_orphans import (
+    _HALT_FLAGS,
+    _RISK_STATE_KEY,
     OrphanPlan,
+    _active_halts,
     _build_plan,
     _choose_tif,
     _execute_bulk,
     _find_db_position,
+    plan_and_execute,
 )
 
 


### PR DESCRIPTION
Closes #148.

## Problem

`trading_bot/self_improve/flatten_orphans.py --execute` is a standalone operational tool that constructs its own `TradingClient` via `resolve_alpaca_env()` and submits market SELLs. It did **not** consult `risk_circuit_state` first. If `drawdown_breaker_active` / `is_paused` / `daily_loss_limit_hit` / `commission_stop_active` is set (the bot just tripped its kill switch) and an operator runs this tool to clean up positions, it ignored the halt and submitted to the broker anyway. On a \$1k live account, a runaway flatten on a stale ticker list (operator typo, copy-paste from a previous incident) can wipe a meaningful chunk of the account.

## Change

- New `_active_halts(db_path)` reads `risk_circuit_state` via `repo.load_risk_state` **offline** (no broker connection) and returns the names of any active halt flags.
- `plan_and_execute(..., force_during_halt=False)`: with `--execute`, the halt read happens **before** `resolve_alpaca_env()` / `TradingClient`, so the refusal path never opens an Alpaca session. If halted → `CRITICAL`-style error + exit `2`, unless `--force-during-halt` is supplied (→ proceeds, logs `WARNING`).
- A risk-state **read failure is fail-safe** (treated as halted) — better to block a flatten than fire one blind to the kill switch.
- `--force-during-halt` without `--execute` → no-op (warn + exit `0`).
- **dry-run is unaffected** by halt state (it only lists positions and prints a plan).
- Module docstring SAFETY section + run examples updated.

## Test plan

- [x] `_active_halts`: no-row, all-false, per-flag reporting, fail-safe-on-unreadable
- [x] `--execute` + halt → exit 2, broker never contacted (asserts `resolve_alpaca_env` not called)
- [x] `--execute` no halt → passes gate into broker path
- [x] `--execute` + halt + `--force-during-halt` → proceeds + WARNING
- [x] dry-run + halt → unaffected
- [x] `--force-during-halt` without `--execute` → no-op + warning
- [x] Drift guard: `_RISK_STATE_KEY` asserted equal to `risk_manager._RISK_STATE_KEY`
- [x] Full suite green: `1029 passed, 4 skipped`; `ruff` + `bandit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)