### PR TITLE
ci: pin master branch ruleset + weekly drift detection (#149)

### DIFF
--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -1,0 +1,53 @@
+{
+  "bypass_actors": [],
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "~DEFAULT_BRANCH"
+      ]
+    }
+  },
+  "enforcement": "active",
+  "name": "master",
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "parameters": {
+        "allowed_merge_methods": [
+          "merge",
+          "squash",
+          "rebase"
+        ],
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_approving_review_count": 0,
+        "required_review_thread_resolution": false,
+        "required_reviewers": []
+      },
+      "type": "pull_request"
+    },
+    {
+      "parameters": {
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          {
+            "context": "static-checks"
+          },
+          {
+            "context": "coverage"
+          }
+        ],
+        "strict_required_status_checks_policy": false
+      },
+      "type": "required_status_checks"
+    }
+  ],
+  "target": "branch"
+}

--- a/.github/rulesets/normalize.py
+++ b/.github/rulesets/normalize.py
@@ -1,0 +1,60 @@
+"""Normalize a GitHub repository ruleset payload to its policy invariants.
+
+Reads the ruleset JSON on stdin (either the list endpoint's array or a single
+GET-by-id object) and writes a stable, normalized JSON document on stdout
+(``sort_keys=True``, 2-space indent) so two normalizations of the same policy
+compare byte-for-byte.
+
+Volatile / environment-specific fields are dropped: ``id``, ``node_id``,
+``source``, ``source_type``, ``_links``, ``created_at``, ``updated_at``,
+``current_user_can_bypass``. Only the policy invariants are kept.
+
+Used by BOTH the committed snapshot at ``.github/rulesets/main.json`` and
+``.github/workflows/ruleset-drift.yml``. Regenerate the snapshot with:
+
+    gh api /repos/<owner>/<repo>/rulesets/<id> \
+        | python3 .github/rulesets/normalize.py > .github/rulesets/main.json
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+# Policy fields that define the branch-protection contract. Everything else in
+# the ruleset payload is volatile state, not policy.
+_KEEP: tuple[str, ...] = (
+    "name",
+    "target",
+    "enforcement",
+    "conditions",
+    "bypass_actors",
+)
+
+_RULESET_NAME: str = "master"
+
+
+def normalize(ruleset: dict[str, Any]) -> dict[str, Any]:
+    """Project a ruleset down to its policy invariants, rules sorted by type."""
+    out: dict[str, Any] = {key: ruleset.get(key) for key in _KEEP}
+    rules: list[dict[str, Any]] = list(ruleset.get("rules") or [])
+    out["rules"] = sorted(rules, key=lambda rule: rule.get("type", ""))
+    return out
+
+
+def main() -> int:
+    data: Any = json.load(sys.stdin)
+    # The list endpoint returns an array of summaries; GET-by-id returns one
+    # object. Accept either so callers can pipe whichever they fetched.
+    if isinstance(data, list):
+        data = next(
+            (rs for rs in data if rs.get("name") == _RULESET_NAME),
+            {},
+        )
+    print(json.dumps(normalize(data), indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/ruleset-drift.yml
+++ b/.github/workflows/ruleset-drift.yml
@@ -1,0 +1,70 @@
+name: ruleset-drift
+
+# Pre-live hardening (issue #149): the `master` branch ruleset that protects
+# `main` lives in GitHub's UI, not the repo. If it were ever silently relaxed
+# (bypass actors added, required checks removed, force-push/deletion allowed),
+# the codebase would be unaware. This job fetches the live ruleset weekly,
+# normalizes it to its policy invariants, and fails if it has drifted from the
+# committed snapshot at .github/rulesets/main.json. GitHub emails the repo
+# admin on workflow failure by default (same mechanism as heartbeat.yml).
+#
+# When drift is INTENTIONAL (you changed the ruleset on purpose), regenerate
+# the snapshot and commit it:
+#   RID=$(gh api /repos/${{ github.repository }}/rulesets --jq \
+#       '.[] | select(.name=="master") | .id')
+#   gh api /repos/${{ github.repository }}/rulesets/$RID \
+#       | python3 .github/rulesets/normalize.py > .github/rulesets/main.json
+
+on:
+  schedule:
+    # Mondays 12:00 UTC — quiet time, well outside NYSE hours.
+    - cron: "0 12 * * 1"
+  workflow_dispatch: {}
+
+# Least privilege: rulesets are read via the repo administration scope.
+permissions:
+  contents: read
+  administration: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      GH_TOKEN: ${{ github.token }}
+      SNAPSHOT: .github/rulesets/main.json
+      RULESET_NAME: master
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Compare live ruleset against committed snapshot
+        run: |
+          set -euo pipefail
+
+          if [ ! -f "$SNAPSHOT" ]; then
+            echo "::error::Committed snapshot $SNAPSHOT is missing."
+            exit 1
+          fi
+
+          # Resolve the ruleset id by name, then fetch the full policy.
+          rid=$(gh api "/repos/${{ github.repository }}/rulesets" \
+            --jq ".[] | select(.name==\"$RULESET_NAME\") | .id")
+
+          if [ -z "$rid" ]; then
+            echo "::error::No ruleset named '$RULESET_NAME' found. It may have "
+            echo "::error::been deleted — branch protection on main is GONE."
+            exit 1
+          fi
+
+          gh api "/repos/${{ github.repository }}/rulesets/$rid" \
+            | python3 .github/rulesets/normalize.py > /tmp/live_ruleset.json
+
+          if diff -u "$SNAPSHOT" /tmp/live_ruleset.json; then
+            echo "Ruleset matches the committed snapshot. No drift."
+          else
+            echo "::error::Branch-protection ruleset has DRIFTED from "
+            echo "::error::$SNAPSHOT (diff above). If intentional, regenerate "
+            echo "::error::the snapshot (see header of this workflow) and commit."
+            exit 1
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,6 +130,8 @@ close (via `.github/workflows/daily-review.yml`, 21:30 UTC weekdays). It:
 - `static-checks` AND `coverage` must report `success` before the merge button enables
 - No force-pushes, no branch deletion
 
+The ruleset lives in GitHub's UI, but its policy invariants are pinned in the repo at [.github/rulesets/main.json](.github/rulesets/main.json) (the source of truth for audits — not the UI). A weekly drift-detection workflow ([.github/workflows/ruleset-drift.yml](.github/workflows/ruleset-drift.yml)) re-fetches the live ruleset, normalizes it via `.github/rulesets/normalize.py`, and fails (emailing the admin) if it diverges from the snapshot. If you change the ruleset on purpose, regenerate the snapshot (see the workflow header) and commit it.
+
 **Always queue PRs for auto-merge rather than waiting on CI manually:**
 
 ```bash


### PR DESCRIPTION
Closes #149.

## Problem

`CLAUDE.md` documents the merge protocol for `main` (PR-only, `static-checks` + `coverage` required, no force-push, no deletion) — but the ruleset enforcing it (`name: master`) lives entirely in GitHub's UI. There was no programmatic source-of-truth, so a silent relaxation (bypass actors added, required checks removed, force-push allowed) would go unnoticed. With the live flip imminent, this is the only thing between a buggy PR and a real-money order.

## Step 1 — Verified current state (no drift)

`gh api /repos/alex5imon/ai-broker/rulesets/<id>` confirms the live `master` ruleset matches the documented contract:

- `enforcement: active`
- `target: branch`, `conditions.ref_name.include: ["~DEFAULT_BRANCH"]`
- required status checks: **`static-checks` AND `coverage`**
- `bypass_actors: []`, `current_user_can_bypass: "never"`
- rules: `pull_request` required, `non_fast_forward` + `deletion` blocked

## Step 2–4 — Codify, detect, document

- **`.github/rulesets/main.json`** — committed snapshot of the policy invariants. Volatile fields (`id`, `node_id`, `source`, `_links`, `created_at`, `updated_at`, `current_user_can_bypass`) are stripped; rules sorted by type for a stable diff.
- **`.github/rulesets/normalize.py`** — the shared normalizer, used by *both* the snapshot and the drift workflow so the comparison is apples-to-apples. (Implemented in Python rather than a `jq` filter for readability + because it's already a Python repo.)
- **`.github/workflows/ruleset-drift.yml`** — weekly cron (Mondays 12:00 UTC) + `workflow_dispatch`. Re-fetches the live ruleset, normalizes, `diff`s against the snapshot, and exits non-zero on drift. GitHub emails the repo admin on failure (same mechanism as `heartbeat.yml`). Least-privilege: `administration: read` + `contents: read`. Also fails loudly if the ruleset was **deleted** entirely.
- **`CLAUDE.md`** — merge-protocol section now points at the snapshot (source of truth for audits) and the drift workflow, with a note to regenerate the snapshot on intentional changes.

## Verification

- [x] Round-trip: `gh api .../rulesets/<id> | python3 .github/rulesets/normalize.py` is byte-identical to the committed `main.json`
- [x] `ruff` clean on `normalize.py`; workflow YAML parses (job `check`, 2 steps)

> Note: `ruleset-drift.yml` is a scheduled/dispatch workflow — it won't run on this PR. After merge, trigger once via `gh workflow run ruleset-drift.yml` to confirm `GITHUB_TOKEN` has rulesets read access in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)