### PR TITLE
feat: direction-aware backtester (long + short) — PR1 for gap-fill #48

### DIFF
--- a/trading_bot/multi_strategy_backtest.py
+++ b/trading_bot/multi_strategy_backtest.py
@@ -93,9 +93,16 @@ class StrategyTrade:
     trail_pct: float | None
     signals: dict[str, Any]
     hold_type: str = "swing"  # "intraday" or "swing"
+    # "long" (buy → sell) or "short" (sell → buy-to-cover). Defaults to
+    # long so every existing call site and persisted long trade is
+    # unchanged; only direction-aware sleeves (gap_fill) set "short".
+    direction: str = "long"
     sentiment_score: float | None = None
     trail_activation_pct: float | None = None
     highest_price: float | None = None
+    # Mirror of ``highest_price`` for shorts: the lowest price seen since
+    # entry, used to anchor a short trailing stop (trail above the low).
+    lowest_price: float | None = None
     exit_time: datetime | None = None
     exit_price: float | None = None
     exit_reason: str | None = None
@@ -533,7 +540,7 @@ class MultiStrategyBacktester:
             day_start_equity: dict[str, float] = {}
             for sid, st in states.items():
                 pos_value = sum(
-                    t.entry_price * t.shares for t in st.open_positions
+                    self._mark_value(t, t.entry_price) for t in st.open_positions
                 )
                 day_start_equity[sid] = st.cash_usd + pos_value
 
@@ -606,9 +613,17 @@ class MultiStrategyBacktester:
                                 decision = decision.__class__(
                                     **{**decision.__dict__, "shares": scaled}
                                 )
+                            is_short = decision.direction == "short"
+                            # Long entry BUYS (fill above close); short
+                            # entry SELLS to open (fill below close).
                             fill_price = self._simulate_fill(
-                                bar_close, "buy", ticker,
+                                bar_close, "sell" if is_short else "buy", ticker,
                             )
+                            # ``cost`` is the gross notional. For longs it's
+                            # capped by available cash; for shorts we use the
+                            # same cap as a conservative proxy for margin
+                            # (no true margin model) so a sleeve can't open
+                            # unbounded short notional.
                             cost = fill_price * decision.shares
                             if cost > st.cash_usd:
                                 adjusted_shares = int(st.cash_usd / fill_price)
@@ -631,11 +646,16 @@ class MultiStrategyBacktester:
                                 trail_pct=decision.trail_pct,
                                 signals=decision.signals,
                                 hold_type=decision.hold_type.value,
+                                direction=decision.direction,
                                 sentiment_score=decision.sentiment_score,
                                 highest_price=fill_price,
+                                lowest_price=fill_price,
                             )
                             st.open_positions.append(trade)
-                            st.cash_usd -= cost
+                            # Short sale ADDS proceeds to cash; the matching
+                            # cover in ``_close_trade`` subtracts the buy-back
+                            # cost, so net cash move = realized P&L.
+                            st.cash_usd += cost if is_short else -cost
                             st.trade_count += 1
 
             # --- End of day ---
@@ -670,9 +690,10 @@ class MultiStrategyBacktester:
                 pos_value = 0.0
                 for trade in st.open_positions:
                     if trade.ticker in last_bar_per_ticker:
-                        pos_value += float(last_bar_per_ticker[trade.ticker][0]["close"]) * trade.shares
+                        mark_px = float(last_bar_per_ticker[trade.ticker][0]["close"])
                     else:
-                        pos_value += trade.entry_price * trade.shares
+                        mark_px = trade.entry_price
+                    pos_value += self._mark_value(trade, mark_px)
                 total_now = st.cash_usd + pos_value
                 if total_now > st.peak_equity_usd:
                     st.peak_equity_usd = total_now
@@ -720,6 +741,19 @@ class MultiStrategyBacktester:
             strategies=strategy_results,
         )
 
+    @staticmethod
+    def _mark_value(trade: StrategyTrade, price: float) -> float:
+        """Signed mark-to-market equity contribution of an open position.
+
+        Long positions contribute ``+price * shares``. Short positions
+        contribute ``-price * shares`` because the short sale already
+        credited ``entry * shares`` to cash at entry, so the position's
+        standing equity is the (negative) cost to buy it back. Identical
+        to the legacy ``price * shares`` for the long path.
+        """
+        signed = -1.0 if trade.direction == "short" else 1.0
+        return signed * price * trade.shares
+
     def _check_trade_exit(
         self,
         trade: StrategyTrade,
@@ -732,26 +766,49 @@ class MultiStrategyBacktester:
         df_daily: pd.DataFrame,
     ) -> tuple[str, float] | None:
         """Check if a trade should exit. Returns (reason, exit_price) or None."""
-        # Update highest price
+        # Update high/low water marks (both tracked unconditionally; the
+        # long path only reads ``highest_price``, the short path only
+        # ``lowest_price``, so this is harmless for either direction).
         if trade.highest_price is None or bar_high > trade.highest_price:
             trade.highest_price = bar_high
+        if trade.lowest_price is None or bar_low < trade.lowest_price:
+            trade.lowest_price = bar_low
 
-        # Stop loss (intrabar check using bar low)
-        if trade.stop_price and bar_low <= trade.stop_price:
-            return "stop_loss", min(trade.stop_price, bar_close)
+        is_short: bool = trade.direction == "short"
 
-        # Take profit (intrabar check using bar high)
-        if trade.target_price and bar_high >= trade.target_price:
-            return "take_profit", trade.target_price
+        if is_short:
+            # Short: stop is ABOVE entry (price rising hurts), target is
+            # BELOW entry (price falling is profit). Cover fills are BUYs,
+            # so the conservative stop fill is at the stop or higher.
+            if trade.stop_price and bar_high >= trade.stop_price:
+                return "stop_loss", max(trade.stop_price, bar_close)
+            if trade.target_price and bar_low <= trade.target_price:
+                return "take_profit", trade.target_price
+            # Trailing stop anchored to the lowest price seen (trail above it).
+            if trade.trail_pct and trade.lowest_price:
+                activation_pct = trade.trail_activation_pct or 0.0
+                down_pct = (trade.entry_price - trade.lowest_price) / trade.entry_price
+                if down_pct >= activation_pct:
+                    trail_stop = trade.lowest_price * (1.0 + trade.trail_pct)
+                    if bar_high >= trail_stop:
+                        return "trailing_stop", max(trail_stop, bar_close)
+        else:
+            # Stop loss (intrabar check using bar low)
+            if trade.stop_price and bar_low <= trade.stop_price:
+                return "stop_loss", min(trade.stop_price, bar_close)
 
-        # Trailing stop (only after activation threshold is reached)
-        if trade.trail_pct and trade.highest_price:
-            activation_pct = trade.trail_activation_pct or 0.0
-            up_pct = (trade.highest_price - trade.entry_price) / trade.entry_price
-            if up_pct >= activation_pct:
-                trail_stop = trade.highest_price * (1.0 - trade.trail_pct)
-                if bar_low <= trail_stop:
-                    return "trailing_stop", min(trail_stop, bar_close)
+            # Take profit (intrabar check using bar high)
+            if trade.target_price and bar_high >= trade.target_price:
+                return "take_profit", trade.target_price
+
+            # Trailing stop (only after activation threshold is reached)
+            if trade.trail_pct and trade.highest_price:
+                activation_pct = trade.trail_activation_pct or 0.0
+                up_pct = (trade.highest_price - trade.entry_price) / trade.entry_price
+                if up_pct >= activation_pct:
+                    trail_stop = trade.highest_price * (1.0 - trade.trail_pct)
+                    if bar_low <= trail_stop:
+                        return "trailing_stop", min(trail_stop, bar_close)
 
         # Delegate to strategy's own evaluate_exit
         position_dict: dict[str, Any] = {
@@ -781,8 +838,18 @@ class MultiStrategyBacktester:
         reason: str,
         exit_time: datetime,
     ) -> None:
-        fill_exit = self._simulate_fill(exit_price, "sell", trade.ticker)
-        gross_pnl = (fill_exit - trade.entry_price) * trade.shares
+        if trade.direction == "short":
+            # Close a short by BUYING to cover: fill above the requested
+            # price, P&L = entry − exit, and cash falls by the cover cost.
+            # (At entry the short ADDED proceeds to cash; see the run-loop
+            # entry block, which keeps the round-trip equity consistent.)
+            fill_exit = self._simulate_fill(exit_price, "buy", trade.ticker)
+            gross_pnl = (trade.entry_price - fill_exit) * trade.shares
+            cash_delta = -fill_exit * trade.shares
+        else:
+            fill_exit = self._simulate_fill(exit_price, "sell", trade.ticker)
+            gross_pnl = (fill_exit - trade.entry_price) * trade.shares
+            cash_delta = fill_exit * trade.shares
 
         trade.exit_time = exit_time
         trade.exit_price = fill_exit
@@ -790,7 +857,7 @@ class MultiStrategyBacktester:
         trade.gross_pnl_usd = gross_pnl
         trade.net_pnl_usd = gross_pnl  # commission-free
 
-        state.cash_usd += fill_exit * trade.shares
+        state.cash_usd += cash_delta
         state.total_pnl_usd += gross_pnl
         if gross_pnl > 0:
             state.wins += 1
@@ -1006,7 +1073,7 @@ class MultiStrategyBacktester:
             day_start_equity: dict[str, float] = {}
             for sid, st in states.items():
                 pos_value = sum(
-                    t.entry_price * t.shares for t in st.open_positions
+                    self._mark_value(t, t.entry_price) for t in st.open_positions
                 )
                 day_start_equity[sid] = st.cash_usd + pos_value
 
@@ -1086,6 +1153,11 @@ class MultiStrategyBacktester:
                         sentiment_score=sentiment,
                     )
                     if decision is not None and decision.shares > 0:
+                        # Daily mode is long-only (hardcoded buy fills + long
+                        # ATR stops). Skip short decisions rather than open
+                        # them in the wrong direction.
+                        if decision.direction != "long":
+                            continue
                         if self._calendar_overlay_blocks(decision, current_time):
                             continue
                         ovl_mult = self._calendar_overlay_multiplier(
@@ -1459,6 +1531,9 @@ class MultiStrategyBacktester:
                     sentiment_score=sentiment,
                 )
                 if decision is not None and decision.shares > 0:
+                    # SPY-intraday mode is long-only; skip short decisions.
+                    if decision.direction != "long":
+                        continue
                     if self._calendar_overlay_blocks(decision, bar_dt):
                         continue
                     ovl_mult = self._calendar_overlay_multiplier(decision, bar_dt)
@@ -1706,7 +1781,7 @@ class MultiStrategyBacktester:
             day_start_equity: dict[str, float] = {}
             for sid, st in states.items():
                 pos_value = sum(
-                    t.entry_price * t.shares for t in st.open_positions
+                    self._mark_value(t, t.entry_price) for t in st.open_positions
                 )
                 day_start_equity[sid] = st.cash_usd + pos_value
 
@@ -1784,6 +1859,9 @@ class MultiStrategyBacktester:
                         sentiment_score=sentiment,
                     )
                     if decision is None or decision.shares <= 0:
+                        continue
+                    # SPY-intraday mode is long-only; skip short decisions.
+                    if decision.direction != "long":
                         continue
 
                     if self._calendar_overlay_blocks(decision, bar_dt):

--- a/trading_bot/tests/test_backtester_shorts.py
+++ b/trading_bot/tests/test_backtester_shorts.py
@@ -1,0 +1,396 @@
+"""Direction-aware backtester tests (PR1 for gap-fill sleeve #48).
+
+The multi-strategy backtester was long-only: stops fired on ``bar_low``,
+targets on ``bar_high``, and P&L was ``(exit - entry) * shares``. The
+opening gap-fill sleeve needs to *short* gap-ups, so the engine's exit
+checks, close accounting, and the intraday ``run`` entry path must become
+direction-aware.
+
+These tests pin the new short behaviour AND guard that the long path is
+unchanged (the regression bar for this PR). Long-path coverage also lives
+in ``test_multi_strategy_backtest.py``; the explicit long asserts here are
+deliberate belt-and-braces around the direction branch.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
+from typing import Any
+from unittest.mock import MagicMock, patch
+from zoneinfo import ZoneInfo
+
+import pandas as pd
+import pytest
+
+from trading_bot.config import Config
+from trading_bot.constants import HoldType
+from trading_bot.multi_strategy_backtest import (
+    MultiStrategyBacktester,
+    StrategyTrade,
+    _StrategyState,
+)
+from trading_bot.strategy.base import ExitSignal, StrategyDecision
+
+TZ_ET = ZoneInfo("US/Eastern")
+
+
+@pytest.fixture
+def config() -> Config:
+    return Config.load("config.yaml")
+
+
+def _make_strategy_mock(strategy_id: str = "gap_fill") -> MagicMock:
+    mock = MagicMock()
+    mock.strategy_id = strategy_id
+    mock.display_name = "Gap Fill (test)"
+    mock.get_max_positions.return_value = 1
+    mock.evaluate_entry.return_value = None
+    mock.evaluate_exit.return_value = ExitSignal(should_exit=False)
+    return mock
+
+
+def _short_trade(
+    *,
+    entry_price: float = 100.0,
+    shares: float = 10.0,
+    stop_price: float = 102.0,
+    target_price: float | None = 97.0,
+    trail_pct: float | None = None,
+    lowest_price: float | None = None,
+) -> StrategyTrade:
+    now = datetime.now(TZ_ET)
+    return StrategyTrade(
+        strategy_id="gap_fill",
+        ticker="SPY",
+        exchange="NYSE",
+        entry_time=now - timedelta(hours=1),
+        entry_price=entry_price,
+        shares=shares,
+        stop_price=stop_price,
+        target_price=target_price,
+        trail_pct=trail_pct,
+        signals={},
+        hold_type="intraday",
+        direction="short",
+        lowest_price=lowest_price if lowest_price is not None else entry_price,
+    )
+
+
+def _long_trade(
+    *,
+    entry_price: float = 100.0,
+    shares: float = 10.0,
+    stop_price: float = 98.0,
+    target_price: float | None = 103.0,
+) -> StrategyTrade:
+    now = datetime.now(TZ_ET)
+    return StrategyTrade(
+        strategy_id="gap_fill",
+        ticker="SPY",
+        exchange="NYSE",
+        entry_time=now - timedelta(hours=1),
+        entry_price=entry_price,
+        shares=shares,
+        stop_price=stop_price,
+        target_price=target_price,
+        trail_pct=None,
+        signals={},
+        hold_type="intraday",
+        direction="long",
+        highest_price=entry_price,
+    )
+
+
+# ---------------------------------------------------------------------------
+# StrategyTrade: new direction field
+# ---------------------------------------------------------------------------
+
+class TestTradeDirectionField:
+    def test_direction_defaults_to_long(self) -> None:
+        now = datetime.now(TZ_ET)
+        trade = StrategyTrade(
+            strategy_id="t", ticker="SPY", exchange="NYSE",
+            entry_time=now, entry_price=100.0, shares=10,
+            stop_price=98.0, target_price=103.0, trail_pct=None, signals={},
+        )
+        assert trade.direction == "long"
+
+    def test_direction_can_be_short(self) -> None:
+        assert _short_trade().direction == "short"
+
+
+# ---------------------------------------------------------------------------
+# Short exit checking — stops fire on the upside, targets on the downside
+# ---------------------------------------------------------------------------
+
+class TestShortExitChecking:
+    def test_short_stop_fires_on_bar_high(self, config: Config) -> None:
+        engine = MultiStrategyBacktester(config)
+        strat = _make_strategy_mock()
+        now = datetime.now(TZ_ET)
+        trade = _short_trade(entry_price=100.0, stop_price=102.0, target_price=97.0)
+        # Price spikes up: bar_high 102.5 breaches the 102 stop.
+        result = engine._check_trade_exit(
+            trade, bar_close=102.2, bar_high=102.5, bar_low=101.0,
+            current_time=now, strategy=strat,
+            df_5min=pd.DataFrame(), df_daily=pd.DataFrame(),
+        )
+        assert result is not None
+        reason, px = result
+        assert reason == "stop_loss"
+        # Cover fills at the stop or worse (higher).
+        assert px >= 102.0
+
+    def test_short_target_fires_on_bar_low(self, config: Config) -> None:
+        engine = MultiStrategyBacktester(config)
+        strat = _make_strategy_mock()
+        now = datetime.now(TZ_ET)
+        trade = _short_trade(entry_price=100.0, stop_price=102.0, target_price=97.0)
+        # Price drops: bar_low 96.5 reaches the 97 target.
+        result = engine._check_trade_exit(
+            trade, bar_close=96.8, bar_high=98.0, bar_low=96.5,
+            current_time=now, strategy=strat,
+            df_5min=pd.DataFrame(), df_daily=pd.DataFrame(),
+        )
+        assert result is not None
+        reason, px = result
+        assert reason == "take_profit"
+        assert px == 97.0
+
+    def test_short_no_exit_when_in_range(self, config: Config) -> None:
+        engine = MultiStrategyBacktester(config)
+        strat = _make_strategy_mock()
+        now = datetime.now(TZ_ET)
+        trade = _short_trade(entry_price=100.0, stop_price=102.0, target_price=97.0)
+        result = engine._check_trade_exit(
+            trade, bar_close=99.5, bar_high=100.5, bar_low=98.5,
+            current_time=now, strategy=strat,
+            df_5min=pd.DataFrame(), df_daily=pd.DataFrame(),
+        )
+        assert result is None
+
+    def test_short_stop_not_triggered_by_bar_low(self, config: Config) -> None:
+        """A short must NOT stop out because price fell (that's profit).
+
+        Regression guard against accidentally reusing the long
+        ``bar_low <= stop`` rule for shorts.
+        """
+        engine = MultiStrategyBacktester(config)
+        strat = _make_strategy_mock()
+        now = datetime.now(TZ_ET)
+        # No target so only the stop could fire; price falls hard.
+        trade = _short_trade(entry_price=100.0, stop_price=102.0, target_price=None)
+        result = engine._check_trade_exit(
+            trade, bar_close=95.0, bar_high=99.0, bar_low=94.0,
+            current_time=now, strategy=strat,
+            df_5min=pd.DataFrame(), df_daily=pd.DataFrame(),
+        )
+        assert result is None
+
+    def test_short_trailing_stop_fires_on_rebound(self, config: Config) -> None:
+        engine = MultiStrategyBacktester(config)
+        strat = _make_strategy_mock()
+        now = datetime.now(TZ_ET)
+        # Short from 100, price fell to a low of 90 (lowest_price), trail 4%.
+        # Trail stop = 90 * 1.04 = 93.6; a rebound bar_high 94 breaches it.
+        trade = _short_trade(
+            entry_price=100.0, stop_price=110.0, target_price=None,
+            trail_pct=0.04, lowest_price=90.0,
+        )
+        result = engine._check_trade_exit(
+            trade, bar_close=93.8, bar_high=94.0, bar_low=92.5,
+            current_time=now, strategy=strat,
+            df_5min=pd.DataFrame(), df_daily=pd.DataFrame(),
+        )
+        assert result is not None
+        assert result[0] == "trailing_stop"
+
+    def test_short_lowest_price_tracked(self, config: Config) -> None:
+        engine = MultiStrategyBacktester(config)
+        strat = _make_strategy_mock()
+        now = datetime.now(TZ_ET)
+        trade = _short_trade(entry_price=100.0, lowest_price=100.0, target_price=None,
+                             stop_price=110.0)
+        engine._check_trade_exit(
+            trade, bar_close=96.0, bar_high=97.0, bar_low=95.0,
+            current_time=now, strategy=strat,
+            df_5min=pd.DataFrame(), df_daily=pd.DataFrame(),
+        )
+        assert trade.lowest_price == 95.0
+
+
+# ---------------------------------------------------------------------------
+# Short close accounting — P&L is (entry - exit) * shares; cover spends cash
+# ---------------------------------------------------------------------------
+
+class TestShortCloseTrade:
+    def test_short_winning_close_is_positive_pnl(self, config: Config) -> None:
+        engine = MultiStrategyBacktester(config)
+        strat = _make_strategy_mock()
+        state = _StrategyState(strategy=strat, cash_usd=2000.0, initial_cash_usd=1000.0)
+        trade = _short_trade(entry_price=100.0, shares=10.0, target_price=97.0)
+        state.open_positions.append(trade)
+        now = datetime.now(TZ_ET)
+        engine._close_trade(state, trade, exit_price=97.0, reason="take_profit", exit_time=now)
+
+        assert trade in state.closed_trades
+        assert trade not in state.open_positions
+        assert trade.net_pnl_usd > 0
+        assert state.wins == 1
+        assert state.losses == 0
+
+    def test_short_losing_close_is_negative_pnl(self, config: Config) -> None:
+        engine = MultiStrategyBacktester(config)
+        strat = _make_strategy_mock()
+        state = _StrategyState(strategy=strat, cash_usd=2000.0, initial_cash_usd=1000.0)
+        trade = _short_trade(entry_price=100.0, shares=10.0, stop_price=102.0)
+        state.open_positions.append(trade)
+        now = datetime.now(TZ_ET)
+        engine._close_trade(state, trade, exit_price=102.0, reason="stop_loss", exit_time=now)
+
+        assert trade.net_pnl_usd < 0
+        assert state.losses == 1
+
+    def test_short_close_spends_cash_to_cover(self, config: Config) -> None:
+        """Covering a short BUYS shares back → cash decreases by the fill cost."""
+        engine = MultiStrategyBacktester(config)
+        strat = _make_strategy_mock()
+        state = _StrategyState(strategy=strat, cash_usd=2000.0, initial_cash_usd=1000.0)
+        trade = _short_trade(entry_price=100.0, shares=10.0, target_price=97.0)
+        state.open_positions.append(trade)
+        now = datetime.now(TZ_ET)
+        cash_before = state.cash_usd
+        engine._close_trade(state, trade, exit_price=97.0, reason="take_profit", exit_time=now)
+        # Cover fill = 97 + slippage; cash drops by fill * shares.
+        assert trade.exit_price is not None
+        assert state.cash_usd == pytest.approx(cash_before - trade.exit_price * trade.shares)
+
+    def test_short_cover_fill_has_buy_slippage(self, config: Config) -> None:
+        """The cover leg is a BUY, so it fills *above* the requested price."""
+        engine = MultiStrategyBacktester(config)
+        strat = _make_strategy_mock()
+        state = _StrategyState(strategy=strat, cash_usd=2000.0, initial_cash_usd=1000.0)
+        trade = _short_trade(entry_price=100.0, shares=10.0, target_price=97.0)
+        state.open_positions.append(trade)
+        now = datetime.now(TZ_ET)
+        engine._close_trade(state, trade, exit_price=97.0, reason="take_profit", exit_time=now)
+        assert trade.exit_price is not None
+        assert trade.exit_price > 97.0
+
+
+# ---------------------------------------------------------------------------
+# Long path regression — direction branch must not alter long behaviour
+# ---------------------------------------------------------------------------
+
+class TestLongPathUnchanged:
+    def test_long_stop_fires_on_bar_low(self, config: Config) -> None:
+        engine = MultiStrategyBacktester(config)
+        strat = _make_strategy_mock()
+        now = datetime.now(TZ_ET)
+        trade = _long_trade(entry_price=100.0, stop_price=98.0, target_price=103.0)
+        result = engine._check_trade_exit(
+            trade, bar_close=97.8, bar_high=99.0, bar_low=97.5,
+            current_time=now, strategy=strat,
+            df_5min=pd.DataFrame(), df_daily=pd.DataFrame(),
+        )
+        assert result is not None
+        assert result[0] == "stop_loss"
+        assert result[1] <= 98.0
+
+    def test_long_target_fires_on_bar_high(self, config: Config) -> None:
+        engine = MultiStrategyBacktester(config)
+        strat = _make_strategy_mock()
+        now = datetime.now(TZ_ET)
+        trade = _long_trade(entry_price=100.0, stop_price=98.0, target_price=103.0)
+        result = engine._check_trade_exit(
+            trade, bar_close=103.2, bar_high=103.5, bar_low=102.0,
+            current_time=now, strategy=strat,
+            df_5min=pd.DataFrame(), df_daily=pd.DataFrame(),
+        )
+        assert result is not None
+        assert result[0] == "take_profit"
+        assert result[1] == 103.0
+
+    def test_long_close_adds_proceeds_to_cash(self, config: Config) -> None:
+        engine = MultiStrategyBacktester(config)
+        strat = _make_strategy_mock()
+        state = _StrategyState(strategy=strat, cash_usd=900.0, initial_cash_usd=1000.0)
+        trade = _long_trade(entry_price=100.0, shares=10.0, target_price=103.0)
+        state.open_positions.append(trade)
+        now = datetime.now(TZ_ET)
+        cash_before = state.cash_usd
+        engine._close_trade(state, trade, exit_price=103.0, reason="take_profit", exit_time=now)
+        assert trade.exit_price is not None
+        # Long exit SELLS → cash increases by sell-fill proceeds.
+        assert state.cash_usd == pytest.approx(cash_before + trade.exit_price * trade.shares)
+        assert trade.net_pnl_usd > 0
+        assert state.wins == 1
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: a profitable short through the intraday ``run`` loop
+# ---------------------------------------------------------------------------
+
+def _declining_5min_df(start_date: date) -> pd.DataFrame:
+    """80 declining 5-min bars from 09:30 ET so a short fills its target."""
+    start_dt = datetime(start_date.year, start_date.month, start_date.day,
+                        9, 30, 0, tzinfo=TZ_ET)
+    n = 80
+    timestamps = [start_dt + timedelta(minutes=5 * i) for i in range(n)]
+    prices = [100.0 - 0.25 * i for i in range(n)]  # 100 → 80.25
+    data = {
+        "open": [p + 0.05 for p in prices],
+        "high": [p + 0.10 for p in prices],
+        "low": [p - 0.10 for p in prices],
+        "close": prices,
+        "volume": [100000] * n,
+    }
+    return pd.DataFrame(
+        data, index=pd.DatetimeIndex(timestamps, tz=TZ_ET, name="timestamp")
+    )
+
+
+class TestEndToEndShort:
+    @pytest.mark.asyncio
+    async def test_profitable_short_increases_cash(self, config: Config) -> None:
+        engine = MultiStrategyBacktester(config)
+
+        df_5min = _declining_5min_df(date(2026, 3, 16))
+        mock_data = {"SPY": {"intraday": df_5min, "daily": pd.DataFrame()}}
+
+        # One strategy that shorts SPY once, on bar index 12, targeting a
+        # lower price the declining series is guaranteed to reach.
+        strat = engine._strategies[0]
+        fired: dict[str, bool] = {"done": False}
+
+        def _entry(*args: Any, **kwargs: Any) -> StrategyDecision | None:
+            if fired["done"]:
+                return None
+            price = float(kwargs["current_price"])
+            # Only fire once we're a few bars in (the run loop skips idx<10).
+            if price > 97.0:
+                return None
+            fired["done"] = True
+            return StrategyDecision(
+                ticker="SPY", exchange="NYSE", direction="short",
+                shares=10.0, entry_price=price,
+                stop_price=price + 3.0, target_price=price - 5.0,
+                trail_pct=None, hold_type=HoldType.INTRADAY,
+                strategy_id=strat.strategy_id,
+            )
+
+        with patch.object(strat, "evaluate_entry", side_effect=_entry), \
+             patch.object(strat, "evaluate_exit", return_value=ExitSignal(should_exit=False)), \
+             patch.object(strat, "get_max_positions", return_value=1), \
+             patch.object(engine, "_strategies", [strat]), \
+             patch.object(engine, "_load_day_data", return_value=mock_data):
+            result = await engine.run(
+                date(2026, 3, 16), date(2026, 3, 16), cash_per_strategy_usd=1000.0,
+            )
+
+        sr = result.strategies[0]
+        assert sr.total_trades == 1, "short entry should have opened exactly one trade"
+        assert sr.final_cash_usd > sr.initial_cash_usd, (
+            "a short in a falling market must be profitable"
+        )
+        assert sr.wins == 1


### PR DESCRIPTION
## Summary

**PR1 of the #48 opening gap-fill chain.** The gap-fill sleeve fades gap-ups by **shorting**, but `multi_strategy_backtest.py` was hard-wired long-only. This makes the intraday `run` path (the `--multi-intraday` mode gap-fill validates on) direction-aware so the standalone A/B the issue requires can actually run. No new strategy here — pure engine capability + tests.

### What was long-only (and is now direction-aware)
- Stop fired on `bar_low <= stop`; target on `bar_high >= target`
- P&L `(exit - entry) * shares`; close always SELLs into cash
- Entry always BUYs, consuming cash

### Changes
- `StrategyTrade`: new `direction` (`"long"`|`"short"`, default `long`) + `lowest_price` water mark mirroring `highest_price`.
- `_check_trade_exit`: short stop fires on `bar_high >= stop`, target on `bar_low <= target`, trailing anchored **above** `lowest_price`. Long branch byte-identical.
- `_close_trade`: short closes by **buying to cover** (buy-side slippage), P&L `(entry - exit) * shares`, cash falls by cover cost.
- `run` entry: short **sells to open**, proceeds **add** to cash; net round-trip cash move = realized P&L. Trade stamped with `direction`/`lowest_price`.
- New `_mark_value` helper signs the mark-to-market contribution (short equity = negative buy-back cost; identical for longs) so drawdown is tracked correctly.
- `run_daily` / `run_spy_intraday` stay long-only (hardcoded buy fills + long ATR stops) and now **defensively skip** any short decision rather than mishandle it.

### Cash convention (documented in code)
Short entry credits `entry*shares` to cash; the matching cover subtracts the buy-back cost — so the net cash move equals realized P&L and equity mark-to-market stays consistent at every bar.

## Test plan
- New `trading_bot/tests/test_backtester_shorts.py` (16 cases): short stop/target/trailing exits, lowest-price tracking, short close accounting (cover slippage, cash, win/loss), an **end-to-end profitable short** through `run`, plus explicit **long-path regression guards**.
- Full suite: **1039 passed, 4 skipped**.
- `ruff`, `bandit`, `vulture` clean. No new `mypy` errors (backtester not on CI mypy path).

## Chain context (re-scoped from #48)
1. **PR1 (this)** — short support in the backtester ← prerequisite for the A/B
2. PR2 — fix live exit-before-entry ordering in `main.tick()`
3. PR3 — short support in live execution (`order_manager`)
4. PR4 — `GapFillStrategy` + tests (ships disabled)
5. PR5 — standalone + combined A/B reports (gate)
6. PR6 — flip `enabled: true` if gates pass

Refs #48