### PR TITLE
fix: process exits before entries within a tick — PR2 for gap-fill #48

### DIFF
--- a/trading_bot/main.py
+++ b/trading_bot/main.py
@@ -470,7 +470,24 @@ class TradingBot:
                 if ranked:
                     self._active_watchlist[Market.US] = ranked
 
-            # --- 12. Entry scan ---
+            # --- 12. Exit check (always) — MUST run before the entry scan ---
+            # Exits are processed first so a closing position frees broker
+            # state (and, once the exit fills, cash) before new entries are
+            # evaluated within the same multi-strategy contract. Concretely:
+            # ``overnight_drift`` sells its long at the open before
+            # ``gap_fill`` evaluates a short on the same ticker at 09:35
+            # (ai-broker#48). Caveat: Alpaca exit fills are asynchronous —
+            # detected by the step-6 order-status poll on a *later* tick —
+            # so this ordering guarantees exit decisions are issued before
+            # entry decisions, not that freed buying power is visible to
+            # entries within the same tick. The next tick's fresh equity
+            # fetch reflects the filled exit.
+            try:
+                await self.check_exits()
+            except Exception:
+                logger.exception("Exit check failed")
+
+            # --- 13. Entry scan (execution window only) ---
             if (
                 self._is_market_in_execution(Market.US)
                 and self._mode != "close-only"
@@ -479,12 +496,6 @@ class TradingBot:
                     await self.scan_for_entries(Market.US)
                 except Exception:
                     logger.exception("Entry scan failed")
-
-            # --- 13. Exit check (always) ---
-            try:
-                await self.check_exits()
-            except Exception:
-                logger.exception("Exit check failed")
 
             # --- 14. Wind-down (once per day within wind-down window) ---
             if (

--- a/trading_bot/tests/test_main_tick.py
+++ b/trading_bot/tests/test_main_tick.py
@@ -216,6 +216,38 @@ async def test_tick_skips_entry_in_close_only_mode(trading_bot):
 
 
 @pytest.mark.asyncio
+async def test_tick_processes_exits_before_entries(trading_bot):
+    """Within a tick, exits MUST run before entries.
+
+    A closing position should free broker state (and, once filled, cash)
+    before new entries are evaluated. This is the exit-before-entry
+    contract the multi-strategy handoff relies on — e.g. ``overnight_drift``
+    selling its long at the open before ``gap_fill`` evaluates a short on
+    the same ticker at 09:35 (ai-broker#48). Pre-fix the tick ran the
+    entry scan (step 12) before the exit check (step 13).
+    """
+    trading_bot._config.is_trading_day = MagicMock(return_value=True)
+    _open_hours(trading_bot)
+    trading_bot._is_market_in_premarket = MagicMock(return_value=False)
+    trading_bot._is_market_in_execution = MagicMock(return_value=True)
+    trading_bot._is_market_in_winddown = MagicMock(return_value=False)
+
+    call_order: list[str] = []
+    trading_bot.check_exits = AsyncMock(
+        side_effect=lambda: call_order.append("exits"),
+    )
+    trading_bot.scan_for_entries = AsyncMock(
+        side_effect=lambda _market: call_order.append("entries"),
+    )
+
+    await trading_bot.tick()
+
+    assert call_order == ["exits", "entries"], (
+        f"exits must be processed before entries within a tick; got {call_order}"
+    )
+
+
+@pytest.mark.asyncio
 async def test_tick_runs_wind_down_within_window(trading_bot):
     trading_bot._config.is_trading_day = MagicMock(return_value=True)
     _open_hours(trading_bot)


### PR DESCRIPTION
## Summary

**PR2 of the #48 opening gap-fill chain.** Independent of PR1 (touches `main.py` only).

The live `tick()` ran the **entry scan (step 12) before the exit check (step 13)** — the opposite of what the multi-strategy contract needs. With entries-first, a new entry could be evaluated (and an order submitted) before a closing position in the same tick was even submitted. Concretely: `overnight_drift` should sell its long at the open *before* `gap_fill` evaluates a short on the same ticker at 09:35; entries-first let `gap_fill`'s order race ahead of (or net against) `overnight_drift`'s not-yet-submitted exit.

## Change

Swap steps 12 and 13 in `tick()`:
- **12 (new):** `check_exits()` — runs unconditionally, first.
- **13 (new):** entry scan — still gated on execution window + non-`close-only` mode.

## Important caveat (documented at the call site)

Alpaca exit fills are **asynchronous** — detected by the step-6 order-status poll on a *later* tick. So this reordering guarantees exit **decisions are issued before entry decisions**, not that freed buying power is visible to entries within the *same* tick. The next tick's fresh equity fetch reflects the filled exit. The structural ordering is still the correct fix: entries never race ahead of a known-pending exit, and the broker interaction becomes predictable.

## Test plan
- New `test_tick_processes_exits_before_entries` records call order across a full tick in the execution window and asserts `["exits", "entries"]`. Verified RED before the swap, GREEN after.
- Full suite: **1035 passed, 4 skipped**.
- `ruff`, `bandit`, `vulture` clean; **`mypy` critical-path (includes `main.py`) clean**.

## Chain context
1. ✅ PR1 (#175) — backtester short support
2. ✅ **PR2 (this)** — exit-before-entry ordering
3. PR3 — short support in live execution (`order_manager`)
4. PR4 — `GapFillStrategy` + tests (ships disabled)
5. PR5 — standalone + combined A/B reports (gate)
6. PR6 — flip `enabled: true` if gates pass

Refs #48