### PR TITLE
feat: direction-aware order sides for live shorts — PR3 for gap-fill #48

### DIFF
--- a/trading_bot/execution/order_manager.py
+++ b/trading_bot/execution/order_manager.py
@@ -1171,14 +1171,28 @@ class OrderManager:
         except Exception:
             logger.exception("Error cancelling orders for %s", ticker)
 
-    async def emergency_flatten(self, ticker: str, qty: float, exchange: str) -> None:
-        """Emergency market sell."""
+    async def emergency_flatten(
+        self, ticker: str, qty: float, exchange: str,
+        *, position_side: str = "BUY",
+    ) -> None:
+        """Emergency market flatten.
+
+        Flattens a long (``position_side == "BUY"``) by SELLing and a short
+        (``position_side == "SELL"``) by BUYing to cover. ``position_side``
+        defaults to BUY so existing callers are unchanged; callers that may
+        hold shorts (wind-down, the legacy exit path, ``_transition_to_open``)
+        pass the position's side. Flattening a short with the default SELL
+        would *double* the short — hence the explicit threading.
+        """
+        flatten_side: OrderSide = (
+            OrderSide.BUY if position_side == "SELL" else OrderSide.SELL
+        )
         client: TradingClient = self._gw.client
         try:
             request = MarketOrderRequest(
                 symbol=ticker,
                 qty=qty,
-                side=OrderSide.SELL,
+                side=flatten_side,
                 type=OrderType.MARKET,
                 time_in_force=tif_for_market(qty),
             )
@@ -1187,8 +1201,8 @@ class OrderManager:
                 order_data=request,
             )
             logger.warning(
-                "Emergency flatten: SELL %.6f %s @ MARKET (alpaca_id=%s)",
-                qty, ticker, str(order.id),
+                "Emergency flatten: %s %.6f %s @ MARKET (alpaca_id=%s)",
+                flatten_side.value, qty, ticker, str(order.id),
             )
         except Exception:
             logger.exception(
@@ -1270,20 +1284,26 @@ class OrderManager:
         # when an emergency-flatten path explicitly canceled all
         # orders for the symbol. Treat broker as source of truth.
         #
-        # SELL-side filter: only cancel SELL orders (existing
-        # stops/targets/trailing). If another strategy has an in-flight
-        # BUY entry on the same ticker (allowed by the multi-strategy
-        # framework once breakout/trend_following are re-enabled), we
-        # must not cancel it — only the bracket-leg sells reserve the
-        # qty that's blocking our SELL.
-        await self.cancel_all_for_ticker(ticker, side_filter=OrderSide.SELL)
+        # Direction-aware cover + cancel. Long: SELL to close, cancel the
+        # protective SELL stop (preserve any in-flight BUY entry from
+        # another sleeve). Short: BUY to cover, cancel the protective BUY
+        # stop (preserve any in-flight SELL entry). The cancel releases the
+        # held_for_orders qty that would otherwise reject the exit with
+        # code 40310000 ("insufficient qty available"). Falls back to long
+        # when there's no matching in-memory order (recovery/drain).
+        is_short: bool = (
+            matching_active is not None and matching_active.side == "SELL"
+        )
+        exit_side: OrderSide = OrderSide.BUY if is_short else OrderSide.SELL
+        protective_side: OrderSide = OrderSide.BUY if is_short else OrderSide.SELL
+        await self.cancel_all_for_ticker(ticker, side_filter=protective_side)
 
         client: TradingClient = self._gw.client
         try:
             request = MarketOrderRequest(
                 symbol=ticker,
                 qty=qty,
-                side=OrderSide.SELL,
+                side=exit_side,
                 type=OrderType.MARKET,
                 time_in_force=TimeInForce.DAY,
             )
@@ -1293,8 +1313,8 @@ class OrderManager:
             )
             order_id: str = str(order.id)
             logger.info(
-                "Strategy exit submitted: SELL %s %s @ MARKET (reason=%s, alpaca_id=%s)",
-                qty, ticker, reason, order_id,
+                "Strategy exit submitted: %s %s %s @ MARKET (reason=%s, alpaca_id=%s)",
+                exit_side.value, qty, ticker, reason, order_id,
             )
             # Pin order_id → trade_id and transition to CLOSING so the
             # next stateless tick doesn't re-evaluate the same exit and
@@ -1404,13 +1424,16 @@ class OrderManager:
             )
             return None
 
-        # Cancel SELL-side orders only for the ticker. Mirrors the
-        # change in place_exit — see that comment for rationale.
-        # Phantom stops not tracked in the local DB will otherwise hold
-        # the qty and reject this LIMIT submission with "insufficient
-        # qty available". The SELL filter protects an in-flight BUY
-        # entry from another strategy on the same ticker.
-        await self.cancel_all_for_ticker(ticker, side_filter=OrderSide.SELL)
+        # Direction-aware cover + cancel — mirrors place_exit. Long: SELL
+        # to close, cancel the protective SELL stop. Short: BUY to cover,
+        # cancel the protective BUY stop. The opposite side may be a
+        # concurrent sleeve's in-flight entry, so we never cancel it.
+        is_short: bool = (
+            matching_active is not None and matching_active.side == "SELL"
+        )
+        exit_side: OrderSide = OrderSide.BUY if is_short else OrderSide.SELL
+        protective_side: OrderSide = OrderSide.BUY if is_short else OrderSide.SELL
+        await self.cancel_all_for_ticker(ticker, side_filter=protective_side)
 
         # Snapshot the prior status so we can roll back if Alpaca
         # rejects the submission. Without this, a failed submit leaves
@@ -1427,7 +1450,7 @@ class OrderManager:
             request = LimitOrderRequest(
                 symbol=ticker,
                 qty=qty,
-                side=OrderSide.SELL,
+                side=exit_side,
                 type=OrderType.LIMIT,
                 time_in_force=TimeInForce.DAY,
                 limit_price=round(limit_price, 2),
@@ -1438,8 +1461,8 @@ class OrderManager:
             )
             order_id = str(order.id)
             logger.info(
-                "Limit exit submitted: SELL %s %s @ %.2f (reason=%s, alpaca_id=%s)",
-                qty, ticker, limit_price, reason, order_id,
+                "Limit exit submitted: %s %s %s @ %.2f (reason=%s, alpaca_id=%s)",
+                exit_side.value, qty, ticker, limit_price, reason, order_id,
             )
 
             # Pin order_id → trade_id and transition position state so
@@ -1530,6 +1553,7 @@ class OrderManager:
             # whether a matching stop is already live at Alpaca and adopt it.
             recovered_stop_id = await self._find_existing_stop(
                 active.ticker, filled_qty, stop_price=active.stop_price,
+                position_side=active.side,
             )
             if recovered_stop_id is not None:
                 logger.warning(
@@ -1555,7 +1579,10 @@ class OrderManager:
                 "(trade_id=%d). Emergency flattening.",
                 active.ticker, trade_id,
             )
-            await self.emergency_flatten(active.ticker, filled_qty, active.exchange)
+            await self.emergency_flatten(
+                active.ticker, filled_qty, active.exchange,
+                position_side=active.side,
+            )
             await self._notifier.send(
                 "Stop Attach Failed",
                 f"Could not attach protective stop for {active.ticker} "
@@ -1585,7 +1612,7 @@ class OrderManager:
 
         await self._notifier.trade_entry(
             ticker=active.ticker,
-            side="BUY",
+            side=active.side,
             price=active.entry_price,
             qty=filled_qty,
             reason=f"Phase {self._config.get_phase().value} | {active.hold_type}",
@@ -1594,7 +1621,12 @@ class OrderManager:
     async def _place_standalone_stop(
         self, trade_id: int, active: _ActiveOrder, qty: float,
     ) -> str | None:
-        """Submit a standalone sell-stop order. Returns Alpaca order id or None.
+        """Submit a standalone protective stop. Returns Alpaca order id or None.
+
+        A long (``side == "BUY"``) is protected by a SELL stop below entry;
+        a short (``side == "SELL"``) by a BUY stop above entry. The strategy
+        supplies a stop_price already on the correct side of entry — here we
+        only flip the order side.
 
         Catches all exceptions so the caller can choose the recovery path
         (emergency flatten + notification) without unwinding the transaction.
@@ -1605,11 +1637,14 @@ class OrderManager:
                 active.stop_price, active.ticker,
             )
             return None
+        stop_side: OrderSide = (
+            OrderSide.BUY if active.side == "SELL" else OrderSide.SELL
+        )
         try:
             request = StopOrderRequest(
                 symbol=active.ticker,
                 qty=qty,
-                side=OrderSide.SELL,
+                side=stop_side,
                 time_in_force=tif_for_stop(qty),
                 stop_price=round(active.stop_price, 2),
             )
@@ -1627,8 +1662,13 @@ class OrderManager:
 
     async def _find_existing_stop(
         self, ticker: str, qty: float, *, stop_price: float | None = None,
+        position_side: str = "BUY",
     ) -> str | None:
-        """Look up an open SELL stop on ``ticker`` matching ``qty`` at Alpaca.
+        """Look up an open protective stop on ``ticker`` matching ``qty``.
+
+        The protective side depends on the position: a long (``side ==
+        "BUY"``) is protected by a SELL stop, a short by a BUY stop.
+        Defaults to the long case.
 
         Used by ``_transition_to_open`` to recover from a submit-response
         loss: alpaca-py occasionally raises during response parsing after
@@ -1677,7 +1717,9 @@ class OrderManager:
                 order_qty: float = float(getattr(order, "qty", 0) or 0)
             except (TypeError, ValueError):
                 continue
-            if order_type_str != "stop" or side_str != "sell":
+            # A short's protective stop is a BUY; a long's a SELL.
+            expected_side: str = "buy" if position_side == "SELL" else "sell"
+            if order_type_str != "stop" or side_str != expected_side:
                 continue
             if abs(order_qty - qty) > 1e-6:
                 continue

--- a/trading_bot/main.py
+++ b/trading_bot/main.py
@@ -829,18 +829,25 @@ class TradingBot:
                 logger.warning("%s: exit triggered but qty=0 — skipping", ticker)
                 continue
 
+            # A short (side='SELL') covers with a BUY; thread the side into
+            # the emergency_flatten fallbacks. place_limit_exit derives it
+            # itself from the matching in-memory order.
+            position_side: str = str(position.get("side", "BUY"))
+
             if self._dry_run:
                 logger.info(
-                    "[DRY RUN] Would exit: SELL %.6f %s @ %.4f (reason=%s)",
-                    qty, ticker, current_price, exit_decision.reason,
+                    "[DRY RUN] Would exit: %.6f %s @ %.4f (reason=%s, side=%s)",
+                    qty, ticker, current_price, exit_decision.reason, position_side,
                 )
                 continue
 
             if exit_decision.use_market_order or force_market_exit:
                 # Market exit: cancel ALL ticker orders first so Alpaca
-                # releases held_for_orders qty before the IOC sell.
+                # releases held_for_orders qty before the IOC flatten.
                 await self._order_manager.cancel_all_for_ticker(ticker)
-                await self._order_manager.emergency_flatten(ticker, qty, exchange)
+                await self._order_manager.emergency_flatten(
+                    ticker, qty, exchange, position_side=position_side,
+                )
                 self._clear_spread_defer(ticker)
             else:
                 # Limit sell at mid-price. place_limit_exit cancels just
@@ -889,7 +896,9 @@ class TradingBot:
                         "Limit exit failed for %s — falling back to market", ticker,
                     )
                     await self._order_manager.cancel_all_for_ticker(ticker)
-                    await self._order_manager.emergency_flatten(ticker, qty, exchange)
+                    await self._order_manager.emergency_flatten(
+                        ticker, qty, exchange, position_side=position_side,
+                    )
                 self._clear_spread_defer(ticker)
 
     # ------------------------------------------------------------------
@@ -993,6 +1002,10 @@ class TradingBot:
             if qty <= 0.0:
                 continue
 
+            # Short intraday positions cover with a BUY; thread side into
+            # the emergency_flatten fallbacks (place_limit_exit derives it).
+            position_side: str = str(position.get("side", "BUY"))
+
             logger.info(
                 "Wind-down: closing intraday %s (%.6f shares) for %s market",
                 ticker, qty, market.value,
@@ -1022,7 +1035,9 @@ class TradingBot:
                     "%s: no price for wind-down — using emergency market flatten",
                     ticker,
                 )
-                await self._order_manager.emergency_flatten(ticker, qty, exchange)
+                await self._order_manager.emergency_flatten(
+                    ticker, qty, exchange, position_side=position_side,
+                )
                 continue
 
             # Tick-model wind-down: place a DAY limit sell via OrderManager
@@ -1041,7 +1056,9 @@ class TradingBot:
                     "Wind-down limit failed for %s — falling back to market",
                     ticker,
                 )
-                await self._order_manager.emergency_flatten(ticker, qty, exchange)
+                await self._order_manager.emergency_flatten(
+                    ticker, qty, exchange, position_side=position_side,
+                )
 
         logger.info("Wind-down complete for %s", market.value)
 

--- a/trading_bot/tests/test_order_manager_short_orders.py
+++ b/trading_bot/tests/test_order_manager_short_orders.py
@@ -1,0 +1,209 @@
+"""Short order-side tests (PR3 for gap-fill sleeve #48).
+
+Issue #126 (PR #177) added the ``positions.side`` column, hydration, and a
+``side``-based P&L-sign helper — but left the *order submission* sides
+long-only: the protective stop, the cover, and the emergency flatten were
+hardcoded SELL. A live short would therefore enter correctly (SELL) but get
+a SELL protective stop, a SELL cover, and a SELL flatten — each of which
+*adds to* the short rather than protecting/closing it.
+
+This suite pins the order-side path: short positions get a BUY protective
+stop (above entry), cover with a BUY (market + limit), cancel the protective
+BUY leg (not the SELL entry), and emergency-flatten with a BUY. Long-path
+guards confirm the SELL behaviour is unchanged.
+
+Mocked Alpaca client only — real-broker (paper) validation of shorting
+permissions / margin / stop acceptance is a gating prerequisite to
+enablement (PR6), not covered here.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from alpaca.trading.enums import OrderSide
+
+from trading_bot.constants import PositionStatus
+from trading_bot.execution.order_manager import (
+    EntryDecision,
+    OrderManager,
+    _ActiveOrder,
+)
+
+pytestmark = pytest.mark.critical
+
+
+def _make_om(config, db_path: str, notifier) -> OrderManager:
+    gw = MagicMock()
+    gw.client = MagicMock()
+    return OrderManager(gw, config, notifier, db_path)
+
+
+def _entry(*, side: str = "BUY", ticker: str = "SPY", price: float = 100.0) -> EntryDecision:
+    is_short = side == "SELL"
+    return EntryDecision(
+        ticker=ticker, exchange="US", side=side, shares=10.0, limit_price=price,
+        stop_price=price * (1.02 if is_short else 0.98),
+        target_price=price * (0.97 if is_short else 1.04),
+        hold_type="intraday", sector="Information Technology", phase=1,
+        sentiment_score=0.0, signals="test", currency="USD", strategy_id="gap_fill",
+    )
+
+
+def _last_request(om: OrderManager) -> Any:
+    return om._gw.client.submit_order.call_args.kwargs["order_data"]
+
+
+def _seed_open_short(om: OrderManager) -> int:
+    """Create a short position row + in-memory _ActiveOrder; return trade_id."""
+    trade_id = om._create_position_record(_entry(side="SELL"))
+    assert trade_id is not None
+    om._active_orders[trade_id] = _ActiveOrder(
+        trade_id=trade_id, ticker="SPY", exchange="US", side="SELL",
+        status=PositionStatus.STOP_ACTIVE, entry_shares=10.0, filled_shares=10.0,
+        entry_price=100.0, stop_price=102.0, target_price=97.0,
+        db_trade_id=om._pending_db_trade_ids.get(trade_id),
+    )
+    return trade_id
+
+
+# ---------------------------------------------------------------------------
+# Protective stop side
+# ---------------------------------------------------------------------------
+
+class TestProtectiveStopSide:
+    @pytest.mark.asyncio
+    async def test_short_stop_is_buy(self, config, tmp_db_path, mock_notifier) -> None:
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        active = _ActiveOrder(
+            trade_id=1, ticker="SPY", exchange="US", side="SELL",
+            entry_price=100.0, stop_price=102.0,
+        )
+        stop_id = await om._place_standalone_stop(1, active, qty=10.0)
+        assert stop_id is not None
+        assert _last_request(om).side == OrderSide.BUY
+
+    @pytest.mark.asyncio
+    async def test_long_stop_is_sell(self, config, tmp_db_path, mock_notifier) -> None:
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        active = _ActiveOrder(
+            trade_id=1, ticker="SPY", exchange="US", side="BUY",
+            entry_price=100.0, stop_price=98.0,
+        )
+        stop_id = await om._place_standalone_stop(1, active, qty=10.0)
+        assert stop_id is not None
+        assert _last_request(om).side == OrderSide.SELL
+
+
+# ---------------------------------------------------------------------------
+# Cover sides (market + limit) and cancel filter
+# ---------------------------------------------------------------------------
+
+class TestCoverSides:
+    @pytest.mark.asyncio
+    async def test_market_cover_of_short_buys_and_cancels_buy_stop(
+        self, config, tmp_db_path, mock_notifier
+    ) -> None:
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        _seed_open_short(om)
+        om.cancel_all_for_ticker = AsyncMock()  # type: ignore[method-assign]
+        await om.place_exit(ticker="SPY", qty=10.0, reason="take_profit")
+        assert _last_request(om).side == OrderSide.BUY
+        assert om.cancel_all_for_ticker.call_args.kwargs["side_filter"] == OrderSide.BUY
+
+    @pytest.mark.asyncio
+    async def test_market_exit_of_long_sells_and_cancels_sell_stop(
+        self, config, tmp_db_path, mock_notifier
+    ) -> None:
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        trade_id = om._create_position_record(_entry(side="BUY"))
+        om._active_orders[trade_id] = _ActiveOrder(
+            trade_id=trade_id, ticker="SPY", exchange="US", side="BUY",
+            status=PositionStatus.STOP_ACTIVE, filled_shares=10.0, entry_price=100.0,
+            db_trade_id=om._pending_db_trade_ids.get(trade_id),
+        )
+        om.cancel_all_for_ticker = AsyncMock()  # type: ignore[method-assign]
+        await om.place_exit(ticker="SPY", qty=10.0, reason="take_profit")
+        assert _last_request(om).side == OrderSide.SELL
+        assert om.cancel_all_for_ticker.call_args.kwargs["side_filter"] == OrderSide.SELL
+
+    @pytest.mark.asyncio
+    async def test_limit_cover_of_short_buys(
+        self, config, tmp_db_path, mock_notifier
+    ) -> None:
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        _seed_open_short(om)
+        om.cancel_all_for_ticker = AsyncMock()  # type: ignore[method-assign]
+        await om.place_limit_exit(
+            ticker="SPY", qty=10.0, limit_price=97.0, reason="take_profit",
+        )
+        assert _last_request(om).side == OrderSide.BUY
+        assert om.cancel_all_for_ticker.call_args.kwargs["side_filter"] == OrderSide.BUY
+
+
+# ---------------------------------------------------------------------------
+# Emergency flatten side
+# ---------------------------------------------------------------------------
+
+class TestEmergencyFlattenSide:
+    @pytest.mark.asyncio
+    async def test_short_flatten_buys_to_cover(
+        self, config, tmp_db_path, mock_notifier
+    ) -> None:
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        await om.emergency_flatten("SPY", 10.0, "US", position_side="SELL")
+        assert _last_request(om).side == OrderSide.BUY
+
+    @pytest.mark.asyncio
+    async def test_long_flatten_sells(self, config, tmp_db_path, mock_notifier) -> None:
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        await om.emergency_flatten("SPY", 10.0, "US")
+        assert _last_request(om).side == OrderSide.SELL
+
+
+# ---------------------------------------------------------------------------
+# Stop-recovery side matching
+# ---------------------------------------------------------------------------
+
+def _mock_open_order(*, side: str, order_type: str = "stop", qty: float = 10.0,
+                     order_id: str = "stop-1") -> MagicMock:
+    o = MagicMock()
+    o.id = order_id
+    o.side = MagicMock()
+    o.side.value = side
+    o.order_type = MagicMock()
+    o.order_type.value = order_type
+    o.qty = qty
+    o.stop_price = 102.0
+    return o
+
+
+class TestFindExistingStopSide:
+    @pytest.mark.asyncio
+    async def test_short_recovery_matches_buy_stop(
+        self, config, tmp_db_path, mock_notifier
+    ) -> None:
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        om._gw.client.get_orders = MagicMock(return_value=[
+            _mock_open_order(side="sell"),            # the long stop — wrong side
+            _mock_open_order(side="buy", order_id="buy-stop"),  # the short's stop
+        ])
+        found = await om._find_existing_stop(
+            "SPY", 10.0, stop_price=102.0, position_side="SELL",
+        )
+        assert found == "buy-stop"
+
+    @pytest.mark.asyncio
+    async def test_long_recovery_matches_sell_stop(
+        self, config, tmp_db_path, mock_notifier
+    ) -> None:
+        om = _make_om(config, tmp_db_path, mock_notifier)
+        om._gw.client.get_orders = MagicMock(return_value=[
+            _mock_open_order(side="buy", order_id="buy-stop"),
+            _mock_open_order(side="sell", order_id="sell-stop"),
+        ])
+        found = await om._find_existing_stop("SPY", 10.0, stop_price=102.0)
+        assert found == "sell-stop"


### PR DESCRIPTION
## Summary

**PR3 of the #48 gap-fill chain — reworked** onto the `side` column that **PR #177 (issue #126)** landed in parallel while this was in flight.

#177 added `positions.side`, `_ActiveOrder.side` hydration, and a `side`-based `_signed_pnl` helper — but left the **order-submission sides long-only**: the protective stop, the cover (market + limit), and the emergency flatten were hardcoded `SELL`. On main today a live short would enter correctly (SELL) yet receive a **SELL protective stop, SELL cover, and SELL flatten** — each of which *adds to* the short instead of protecting/closing it. This PR wires that remaining gap.

## Changes (keyed on `active.side == "SELL"`; long path byte-identical)
- `_place_standalone_stop`: **BUY stop** for a short (above entry), SELL for a long.
- `_find_existing_stop`: new `position_side` param — matches the BUY stop on short-recovery; `_transition_to_open` passes `active.side`.
- `place_exit` / `place_limit_exit`: **BUY-to-cover** for a short, cancelling the protective **BUY** leg (not the SELL entry a concurrent sleeve may hold).
- `emergency_flatten`: new `position_side` kwarg — a short covers with a **BUY** (a SELL would *double* it). `_transition_to_open` + `main.py` wind-down/legacy-exit fallbacks thread the position's side (`place_limit_exit` derives it itself).
- `_transition_to_open` entry notification reflects `active.side`.

## Reconciliation note
The first cut of this PR added a redundant `direction` column + `_directional_pnl` + its own V16 migration — these collided with #177. **Dropped** in favour of #177's `side` / `_signed_pnl` / V16. No schema or migration changes here now; diff is order-side logic only.

## Out of scope (documented)
- `virtual_portfolio.record_exit` books a short's sleeve-comparison P&L long-only — informational; vol-target reads the real `trades` table.
- **Paper-account validation** of shorting permissions / margin / stop acceptance gates enablement (PR6), not these mocked-Alpaca unit tests.

## Test plan
- New `test_order_manager_short_orders.py` (9 cases): stop side, market + limit cover sides + cancel-filter, flatten side, stop-recovery side matching, plus long-path guards.
- Full suite: **1071 passed, 4 skipped**.
- `ruff`, `bandit`, `vulture` clean; **`mypy` critical-path (incl. `main.py` + `execution/`) clean**.

## Chain context
1. ✅ PR1 (#175) — backtester short support — merged
2. ✅ PR2 (#176) — exit-before-entry ordering — merged
3. ✅ **PR3 (this)** — live short order sides (reworked onto #177's `side`)
4. PR4 — `GapFillStrategy` + tests (ships disabled)
5. PR5 — standalone + combined A/B reports (gate)
6. PR6 — flip `enabled: true` if gates pass (+ paper short smoke test)

Refs #48