### PR TITLE
feat(strategy): opening gap-fill sleeve #9 (disabled) — PR4 for #48

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -850,3 +850,52 @@ multi_strategy:
       disaster_stop_pct: 0.15
       fractional_shares: true
       position_pct: 0.95
+
+    # Opening gap-fill (sleeve #9, issue #48).
+    # Fades large overnight gaps in the 13-ETF basket on the session's first
+    # 5-min bar and targets the prior (adjusted) close. Gap up → short, gap
+    # down → long. Short holding period (< ~4h, 14:00 ET time stop) → low
+    # correlation with the RSI-dip mean_reversion and the overnight_drift
+    # sleeves.
+    #
+    # SHIPPED DISABLED. Requires BOTH A/Bs to pass before enabling (separate
+    # PR): a standalone regime-matched walkforward A/B (PF >= 1.10 with CI
+    # lower >= 1.00, OOS positive in >= 4/6 windows, WR >= 55%, Sharpe >= 0.40
+    # with positive lower CI, MaxDD <= 10%, >= 150 trades, daily-return corr
+    # vs existing sleeves < 0.30) AND a combined-portfolio A/B
+    # (mean_reversion + overnight_drift + gap_fill) whose Sharpe must improve
+    # vs the mean_reversion + overnight_drift baseline.
+    #
+    # Live shorting requires the order path landed in #175/#177/#178; a paper
+    # short smoke test gates the eventual enablement PR.
+    gap_fill:
+      enabled: false
+      allocation_usd: 0.0
+      max_positions: 3
+      universe:
+        - "SPY"
+        - "QQQ"
+        - "XLF"
+        - "XLK"
+        - "XLE"
+        - "XLV"
+        - "XLI"
+        - "XLY"
+        - "XLP"
+        - "XLU"
+        - "XLB"
+        - "XLRE"
+        - "XLC"
+      # Latest acceptable label-time for the session's first 5-min bar. The
+      # open bar is left-labelled 09:30 (covers 09:30–09:34:59); entry fills
+      # at its close (~09:35). A later first bar (halt/late open) is skipped.
+      entry_time_et: "09:35"
+      time_stop_et: "14:00"
+      min_gap_pct: 0.005             # absolute gap-threshold floor
+      gap_atr_multiplier: 0.5        # adaptive: gap must exceed 0.5 × overnight ATR%
+      overnight_atr_period: 14
+      stop_atr_multiplier: 1.5
+      stop_pct_floor: 0.008          # minimum stop distance (prevents tiny-ATR size blow-up)
+      risk_per_trade_pct: 0.005      # 0.5% equity risked per trade
+      max_position_pct: 0.33
+      fractional_shares: true

--- a/trading_bot/multi_strategy_backtest.py
+++ b/trading_bot/multi_strategy_backtest.py
@@ -574,7 +574,10 @@ class MultiStrategyBacktester:
 
                     # --- Check entries (execution window only) ---
                     if us_exec_start <= bar_time <= us_exec_end:
-                        if bar_idx < 10:
+                        # Per-strategy intraday warm-up. Default 10 bars for
+                        # indicator-based sleeves; open-driven sleeves
+                        # (gap_fill) relax it to fire early in the session.
+                        if bar_idx < strat.min_warmup_bars():
                             continue
                         already_in = any(
                             t.ticker == ticker for t in st.open_positions

--- a/trading_bot/strategy/base.py
+++ b/trading_bot/strategy/base.py
@@ -124,6 +124,18 @@ class StrategyBase(ABC):
     def get_max_positions(self) -> int:
         """Max concurrent positions for this strategy."""
 
+    def min_warmup_bars(self) -> int:
+        """Minimum intraday 5-min bars before the backtester evaluates entries.
+
+        The intraday backtester skips entries on a ticker until this many
+        bars of the session have elapsed, so indicator-based sleeves (RSI,
+        opening range, etc.) have enough warm-up. Default 10 preserves the
+        historical behaviour for every existing sleeve. Open-driven sleeves
+        that key off the session open + daily history (gap_fill) override to
+        a smaller value so their early-session entry isn't suppressed.
+        """
+        return 10
+
     def _compute_shares(
         self,
         price: float,

--- a/trading_bot/strategy/strategies/__init__.py
+++ b/trading_bot/strategy/strategies/__init__.py
@@ -16,6 +16,7 @@ from trading_bot.strategy.strategies.opening_range_breakout import (
 from trading_bot.strategy.strategies.cross_sectional_momentum import (
     CrossSectionalMomentumStrategy,
 )
+from trading_bot.strategy.strategies.gap_fill import GapFillStrategy
 
 STRATEGY_REGISTRY: dict[str, type[StrategyBase]] = {
     "mean_reversion": MeanReversionStrategy,
@@ -25,6 +26,7 @@ STRATEGY_REGISTRY: dict[str, type[StrategyBase]] = {
     "overnight_drift": OvernightDriftStrategy,
     "opening_range_breakout": OpeningRangeBreakoutStrategy,
     "cross_sectional_momentum": CrossSectionalMomentumStrategy,
+    "gap_fill": GapFillStrategy,
 }
 
 

--- a/trading_bot/strategy/strategies/gap_fill.py
+++ b/trading_bot/strategy/strategies/gap_fill.py
@@ -1,0 +1,316 @@
+"""Opening gap-fill strategy (sleeve #9, ai-broker#48).
+
+Fades large overnight gaps in liquid ETFs at the open and targets the prior
+close. Captures the well-documented intraday gap-reversion tendency: opening
+gaps in liquid ETFs fill a large fraction of the time intraday.
+
+Mechanics (one entry per ticker per session, enforced structurally by the
+first-bar-only entry gate):
+
+Entry  : on the session's FIRST 5-min bar, if the gap from the prior
+         (adjusted) daily close exceeds an adaptive threshold. Gap up → SHORT
+         (fade), gap down → LONG (fade). Entry price = that bar's close.
+Target : the prior adjusted close (full gap fill).
+Stop   : ATR-anchored (``stop_atr_multiplier`` × overnight ATR%) with a
+         percentage FLOOR (``stop_pct_floor``) so a pathologically small ATR
+         can't collapse the stop and explode position size.
+Exit   : target / stop (handled intrabar by the backtester and broker-side
+         live), plus a hard 14:00 ET time stop — an unfilled gap by midday is
+         a trending regime, so we get out rather than risk gap continuation.
+
+Bar-timestamp convention (CRITICAL — a known off-by-one source):
+The repo resamples 5-min bars LEFT-labelled (``label="left", closed="left"``),
+so the session's OPEN bar is labelled 09:30 and covers 09:30:00–09:34:59. The
+gap reference is that open bar's OPEN (the opening print). We *act* on the bar
+labelled 09:35 — the first bar inside the 09:35 execution window (the backtester
+and live config both skip the first 5 minutes) — giving the gap ~5 minutes to
+settle, as issue #48 intended (the issue assumed right-labelling, where "the
+09:35 bar" was the open bar). Acting on the 09:35 bar also means the entry
+clears the backtester's execution-window and warm-up gates; the warm-up gate is
+relaxed for this sleeve via ``min_warmup_bars`` since it keys off the open and
+daily history rather than intraday indicator history.
+
+Hold type is INTRADAY so the backtester / live wind-down force-closes any
+position still open at session end.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date, datetime, time
+from typing import Any
+
+import pandas as pd
+
+from trading_bot.constants import TZ_EASTERN, HoldType
+from trading_bot.strategy.base import ExitSignal, StrategyBase, StrategyDecision
+from trading_bot.utils import coalesce
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+class GapFillStrategy(StrategyBase):
+    """Fade the opening gap; target the prior close."""
+
+    def __init__(self, config: dict[str, Any], **kwargs: Any) -> None:
+        super().__init__(
+            strategy_id="gap_fill",
+            display_name="Opening Gap Fill",
+            config=config,
+            **kwargs,
+        )
+        self._max_positions: int = int(config.get("max_positions", 3))
+        # Label-time of the bar we act on — the first bar inside the 09:35
+        # execution window. The gap is measured from the session open (the
+        # 09:30 bar's open); we enter at this bar. Firing on exactly this
+        # label makes the entry inherently once-per-session.
+        self._entry_time: time = _parse_time(str(config.get("entry_time_et", "09:35")))
+        # Hard midday time stop (ET): close an unfilled gap rather than ride a
+        # trend continuation into the afternoon.
+        self._time_stop: time = _parse_time(str(config.get("time_stop_et", "14:00")))
+        # Adaptive gap threshold: max(floor, multiplier × overnight ATR%).
+        self._min_gap_pct: float = float(config.get("min_gap_pct", 0.005))
+        self._gap_atr_multiplier: float = float(config.get("gap_atr_multiplier", 0.5))
+        self._overnight_atr_period: int = int(config.get("overnight_atr_period", 14))
+        # Stop: ATR-anchored with a percentage floor (minimum distance).
+        self._stop_atr_multiplier: float = float(config.get("stop_atr_multiplier", 1.5))
+        self._stop_pct_floor: float = float(config.get("stop_pct_floor", 0.008))
+        # Risk-anchored sizing.
+        self._risk_per_trade_pct: float = float(config.get("risk_per_trade_pct", 0.005))
+        self._max_position_pct: float = float(config.get("max_position_pct", 0.33))
+        self._fractional_shares: bool = bool(config.get("fractional_shares", True))
+
+    # ------------------------------------------------------------------
+    # Entry
+    # ------------------------------------------------------------------
+
+    def evaluate_entry(
+        self,
+        ticker: str,
+        exchange: str,
+        df_5min: pd.DataFrame,
+        df_daily: pd.DataFrame,
+        current_price: float,
+        available_cash: float,
+        sentiment_score: float | None = None,
+    ) -> StrategyDecision | None:
+        if df_5min is None or len(df_5min) == 0:
+            return None
+        if df_daily is None or len(df_daily) == 0:
+            return None
+        if available_cash <= 0 or current_price <= 0:
+            return None
+
+        df_e: pd.DataFrame = df_5min.rename(columns=str.lower)
+        last_dt: datetime | None = _to_et_datetime(df_e.index[-1])
+        if last_dt is None:
+            return None
+
+        # Act only on the configured entry bar (default 09:35) — the first
+        # bar inside the execution window. Exactly-once per session, so no
+        # explicit per-day flag is needed. A halted/late session with no
+        # 09:35 bar is simply skipped.
+        if last_dt.time() != self._entry_time:
+            return None
+
+        today: date = last_dt.date()
+        today_bars: pd.DataFrame = df_e[
+            df_e.index.map(lambda ts: _to_et_date(ts) == today)
+        ]
+        if len(today_bars) == 0:
+            return None
+
+        # Prior (adjusted) close: the last daily bar STRICTLY before today.
+        # Using rows < today avoids any look-ahead onto today's daily bar that
+        # some cache layouts include. Adjusted close handles ex-div/split days
+        # cleanly — a raw last-bar close would read an ex-div day as a 1-3% gap.
+        def _before_today(ts: Any) -> bool:
+            d: date | None = _to_et_date(ts)
+            return d is not None and d < today
+
+        daily_before: pd.DataFrame = df_daily[df_daily.index.map(_before_today)]
+        if len(daily_before) < self._overnight_atr_period + 1:
+            return None  # insufficient history for ATR / prior close
+        prior_close: float = float(daily_before["close"].iloc[-1])
+        if prior_close <= 0:
+            return None
+
+        session_open: float = float(today_bars["open"].iloc[0])
+        gap_pct: float = (session_open - prior_close) / prior_close
+
+        overnight_atr: float | None = self._compute_atr(
+            daily_before, self._overnight_atr_period,
+        )
+        if overnight_atr is None:
+            return None
+        overnight_atr_pct: float = overnight_atr / prior_close
+
+        threshold: float = max(
+            self._min_gap_pct, self._gap_atr_multiplier * overnight_atr_pct,
+        )
+        if abs(gap_pct) < threshold:
+            return None
+
+        # Fade the gap. Gap up → short; gap down → long.
+        is_short: bool = gap_pct > 0
+        direction: str = "short" if is_short else "long"
+        entry_price: float = current_price  # = the first bar's close
+
+        # Stop: ATR-anchored, with a percentage floor (minimum distance) so a
+        # tiny ATR can't collapse the stop and explode the risk-based size.
+        stop_distance_pct: float = max(
+            self._stop_atr_multiplier * overnight_atr_pct, self._stop_pct_floor,
+        )
+        if is_short:
+            stop_price: float = round(entry_price * (1.0 + stop_distance_pct), 4)
+        else:
+            stop_price = round(entry_price * (1.0 - stop_distance_pct), 4)
+        target_price: float = round(prior_close, 4)
+
+        shares: float = self.size_by_risk(
+            entry_price=entry_price,
+            stop_price=stop_price,
+            available_cash=available_cash,
+            risk_per_trade_pct=self._risk_per_trade_pct,
+            max_position_pct=self._max_position_pct,
+            fractional=self._fractional_shares,
+            vol_multiplier=self.vol_multiplier(),
+        )
+        min_shares: float = 0.001 if self._fractional_shares else 1.0
+        if shares < min_shares:
+            return None
+
+        logger.info(
+            "[%s] Gap-fill %s: %s gap=%.3f%% (thr=%.3f%%) open=$%.2f "
+            "prior_close=$%.2f entry=$%.2f stop=$%.2f tgt=$%.2f shares=%.4f",
+            self.strategy_id, direction, ticker, gap_pct * 100, threshold * 100,
+            session_open, prior_close, entry_price, stop_price, target_price, shares,
+        )
+
+        return StrategyDecision(
+            ticker=ticker,
+            exchange=exchange,
+            direction=direction,
+            shares=shares,
+            entry_price=entry_price,
+            stop_price=stop_price,
+            target_price=target_price,
+            trail_pct=None,
+            hold_type=HoldType.INTRADAY,
+            strategy_id=self.strategy_id,
+            signals={
+                "gap_pct": gap_pct,
+                "threshold_pct": threshold,
+                "prior_close": prior_close,
+                "session_open": session_open,
+                "overnight_atr_pct": overnight_atr_pct,
+            },
+            sentiment_score=sentiment_score,
+        )
+
+    # ------------------------------------------------------------------
+    # Exit
+    # ------------------------------------------------------------------
+
+    def evaluate_exit(
+        self,
+        position: dict[str, Any],
+        current_price: float,
+        df_5min: pd.DataFrame | None = None,
+        df_daily: pd.DataFrame | None = None,
+    ) -> ExitSignal:
+        is_short: bool = _position_is_short(position)
+        stop_price: float = float(coalesce(position, "stop_price", 0))
+        target_price: float = float(coalesce(position, "target_price", 0))
+
+        # Hard 14:00 ET time stop — close an unfilled gap before the afternoon.
+        bar_time: time | None = _last_bar_time(df_5min)
+        if bar_time is not None and bar_time >= self._time_stop:
+            return ExitSignal(
+                should_exit=True, reason="time_stop", use_market_order=True,
+            )
+
+        # Target = prior close (full gap fill).
+        if target_price > 0:
+            hit_target = (
+                current_price <= target_price if is_short
+                else current_price >= target_price
+            )
+            if hit_target:
+                return ExitSignal(should_exit=True, reason="take_profit")
+
+        # Protective stop (redundant with the broker stop / backtester intrabar
+        # check, but belt-and-braces for the live path).
+        if stop_price > 0:
+            hit_stop = (
+                current_price >= stop_price if is_short
+                else current_price <= stop_price
+            )
+            if hit_stop:
+                return ExitSignal(
+                    should_exit=True, reason="stop_loss",
+                    is_emergency=True, use_market_order=True,
+                )
+
+        return ExitSignal(should_exit=False)
+
+    def get_max_positions(self) -> int:
+        return self._max_positions
+
+    def min_warmup_bars(self) -> int:
+        # Gap-fill keys off the session open + daily ATR history, not intraday
+        # indicators, and fires on the 09:35 bar (bar index 1). Relax the
+        # backtester's default 10-bar intraday warm-up so that bar isn't
+        # skipped. The 09:35 execution-window start still gates out the open bar.
+        return 1
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _position_is_short(position: dict[str, Any]) -> bool:
+    """Direction of a position dict, tolerating both representations.
+
+    The live positions row carries ``side`` ("BUY"/"SELL"); the backtester's
+    exit-check dict may carry ``direction`` ("long"/"short"). Either marks a
+    short. Defaults to long when neither is present (backtest dicts that omit
+    direction — harmless because the backtester resolves target/stop intrabar
+    by trade direction before delegating to this method).
+    """
+    if str(position.get("direction", "")).lower() == "short":
+        return True
+    return str(position.get("side", "")).upper() == "SELL"
+
+
+def _parse_time(value: str) -> time:
+    parts = value.split(":")
+    if len(parts) != 2:
+        raise ValueError(f"Invalid time string '{value}', expected HH:MM")
+    return time(int(parts[0]), int(parts[1]))
+
+
+def _to_et_datetime(ts: Any) -> datetime | None:
+    if ts is None:
+        return None
+    dt = ts.to_pydatetime() if hasattr(ts, "to_pydatetime") else ts
+    if not isinstance(dt, datetime):
+        return None
+    if dt.tzinfo is not None:
+        try:
+            return dt.astimezone(TZ_EASTERN)
+        except Exception:
+            return dt
+    return dt
+
+
+def _to_et_date(ts: Any) -> date | None:
+    dt = _to_et_datetime(ts)
+    return dt.date() if dt is not None else None
+
+
+def _last_bar_time(df_5min: pd.DataFrame | None) -> time | None:
+    if df_5min is None or len(df_5min) == 0:
+        return None
+    dt = _to_et_datetime(df_5min.index[-1])
+    return dt.time() if dt is not None else None

--- a/trading_bot/tests/test_gap_fill.py
+++ b/trading_bot/tests/test_gap_fill.py
@@ -1,0 +1,341 @@
+"""Unit tests for GapFillStrategy (sleeve #9, ai-broker#48)."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, time, timedelta
+from typing import Any
+from zoneinfo import ZoneInfo
+
+import pandas as pd
+import pytest
+
+from trading_bot.constants import HoldType
+from trading_bot.strategy.strategies.gap_fill import GapFillStrategy
+
+ET = ZoneInfo("US/Eastern")
+TODAY = date(2026, 3, 16)        # Monday
+PRIOR_DAY = date(2026, 3, 13)    # Friday
+PRIOR_CLOSE = 100.0
+CASH = 100_000.0
+
+
+def _strat(**overrides: Any) -> GapFillStrategy:
+    cfg: dict[str, Any] = {
+        "max_positions": 3,
+        "entry_time_et": "09:35",
+        "time_stop_et": "14:00",
+        "min_gap_pct": 0.005,
+        "gap_atr_multiplier": 0.5,
+        "overnight_atr_period": 14,
+        "stop_atr_multiplier": 1.5,
+        "stop_pct_floor": 0.008,
+        "risk_per_trade_pct": 0.005,
+        "max_position_pct": 0.33,
+        "fractional_shares": True,
+    }
+    cfg.update(overrides)
+    return GapFillStrategy(cfg)
+
+
+def _daily(prior_close: float = PRIOR_CLOSE, atr_pct: float = 0.005, n: int = 20) -> pd.DataFrame:
+    """Daily bars ending the Friday before TODAY, with a controllable ATR%.
+
+    Constant close → true range per bar ≈ 2*h, so ATR ≈ 2*h and
+    overnight_atr_pct ≈ atr_pct when h = atr_pct*prior_close/2.
+    """
+    end = PRIOR_DAY
+    dates: list[date] = []
+    d = end
+    while len(dates) < n:
+        if d.weekday() < 5:
+            dates.append(d)
+        d -= timedelta(days=1)
+    dates = sorted(dates)
+    ts = [datetime(x.year, x.month, x.day, 16, 0, tzinfo=ET) for x in dates]
+    h = atr_pct * prior_close / 2.0
+    data = {
+        "open": [prior_close] * n,
+        "high": [prior_close + h] * n,
+        "low": [prior_close - h] * n,
+        "close": [prior_close] * n,
+        "volume": [1_000_000] * n,
+    }
+    return pd.DataFrame(data, index=pd.DatetimeIndex(ts, tz=ET))
+
+
+def _today_5min(
+    *, gap_pct: float, n_bars: int = 2, day: date = TODAY,
+    first_bar: time = time(9, 30),
+) -> pd.DataFrame:
+    """Today's 5-min bars. The first (09:30) bar's OPEN encodes the gap; the
+    entry fires on the 09:35 bar (default n_bars=2 → last bar labelled 09:35).
+    All opens/closes are the session open for deterministic sizing."""
+    session_open = PRIOR_CLOSE * (1.0 + gap_pct)
+    start = datetime(day.year, day.month, day.day, first_bar.hour, first_bar.minute, tzinfo=ET)
+    ts = [start + timedelta(minutes=5 * i) for i in range(n_bars)]
+    opens = [session_open] * n_bars
+    closes = [session_open] * n_bars
+    data = {
+        "open": opens,
+        "high": [o + 0.05 for o in opens],
+        "low": [o - 0.05 for o in opens],
+        "close": closes,
+        "volume": [100_000] * n_bars,
+    }
+    return pd.DataFrame(data, index=pd.DatetimeIndex(ts, tz=ET))
+
+
+def _entry(strat: GapFillStrategy, df5: pd.DataFrame, dfd: pd.DataFrame):
+    return strat.evaluate_entry(
+        ticker="SPY", exchange="NYSE", df_5min=df5, df_daily=dfd,
+        current_price=float(df5["close"].iloc[-1]), available_cash=CASH,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Threshold gating
+# ---------------------------------------------------------------------------
+
+def test_no_entry_below_gap_threshold() -> None:
+    # gap 0.4%, ATR 0.5% → threshold max(0.5%, 0.25%) = 0.5% → 0.4% rejected.
+    s = _strat()
+    d = _entry(s, _today_5min(gap_pct=0.004), _daily(atr_pct=0.005))
+    assert d is None
+
+
+def test_no_entry_below_adaptive_threshold() -> None:
+    # gap 0.6%, ATR 1.5% → threshold max(0.5%, 0.75%) = 0.75% → 0.6% rejected.
+    s = _strat()
+    d = _entry(s, _today_5min(gap_pct=0.006), _daily(atr_pct=0.015))
+    assert d is None
+
+
+def test_short_entry_on_gap_up() -> None:
+    s = _strat()
+    d = _entry(s, _today_5min(gap_pct=0.01), _daily(atr_pct=0.005))
+    assert d is not None
+    assert d.direction == "short"
+    assert d.stop_price > d.entry_price          # short stop sits above entry
+    assert d.target_price == pytest.approx(PRIOR_CLOSE, abs=1e-4)
+    assert d.hold_type == HoldType.INTRADAY
+
+
+def test_long_entry_on_gap_down() -> None:
+    s = _strat()
+    d = _entry(s, _today_5min(gap_pct=-0.01), _daily(atr_pct=0.005))
+    assert d is not None
+    assert d.direction == "long"
+    assert d.stop_price < d.entry_price          # long stop sits below entry
+
+
+def test_target_at_prior_close() -> None:
+    s = _strat()
+    d = _entry(s, _today_5min(gap_pct=-0.01), _daily(prior_close=100.0, atr_pct=0.005))
+    assert d is not None
+    assert d.target_price == pytest.approx(100.0, abs=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# Stop sizing
+# ---------------------------------------------------------------------------
+
+def test_stop_at_atr_distance() -> None:
+    # Large ATR (2%) → stop distance = max(1.5*2%, 0.8%) = 3%.
+    s = _strat()
+    d = _entry(s, _today_5min(gap_pct=-0.04), _daily(atr_pct=0.02))
+    assert d is not None
+    stop_dist = (d.entry_price - d.stop_price) / d.entry_price
+    assert stop_dist == pytest.approx(0.03, abs=2e-3)
+
+
+def test_stop_floor_enforced() -> None:
+    # Pathologically tiny ATR (0.1%) → 1.5*0.1% = 0.15% < 0.8% floor → 0.8%.
+    s = _strat()
+    d = _entry(s, _today_5min(gap_pct=-0.01), _daily(atr_pct=0.001))
+    assert d is not None
+    stop_dist = (d.entry_price - d.stop_price) / d.entry_price
+    assert stop_dist == pytest.approx(0.008, abs=2e-3)
+
+
+# ---------------------------------------------------------------------------
+# Entry window / one-per-day / convention
+# ---------------------------------------------------------------------------
+
+def test_one_entry_per_ticker_per_day() -> None:
+    # Past the entry bar (last bar 09:40) → no entry. The entry fires only on
+    # the single 09:35 bar, so the sleeve enters at most once per session.
+    s = _strat()
+    d = _entry(s, _today_5min(gap_pct=0.01, n_bars=3), _daily(atr_pct=0.005))
+    assert d is None
+
+
+def test_no_entry_outside_window() -> None:
+    # Late/halted open: first bar labelled 09:45 → no 09:35 bar → skip.
+    s = _strat()
+    d = _entry(s, _today_5min(gap_pct=0.01, first_bar=time(9, 45)), _daily(atr_pct=0.005))
+    assert d is None
+
+
+def test_5min_bar_timestamp_convention_correct() -> None:
+    """Off-by-one guard for the LEFT-labelled 5-min grid.
+
+    We act on the bar labelled 09:35 (the first inside the execution window)
+    and measure the gap from the session OPEN — the 09:30 bar's open. We must
+    NOT fire on the 09:30 bar (before the window) nor on a later bar (09:40).
+    """
+    s = _strat()
+
+    # Only the 09:30 open bar → before the entry bar → no fire.
+    df_open_only = _today_5min(gap_pct=0.01, n_bars=1)
+    assert df_open_only.index[-1].time() == time(9, 30)
+    assert _entry(s, df_open_only, _daily(atr_pct=0.005)) is None
+
+    # 09:35 is the last bar → fire; gap measured from the 09:30 open.
+    df_two = _today_5min(gap_pct=0.01, n_bars=2)
+    assert df_two.index[-1].time() == time(9, 35)
+    d = _entry(s, df_two, _daily(atr_pct=0.005))
+    assert d is not None
+    assert d.signals["session_open"] == pytest.approx(PRIOR_CLOSE * 1.01, abs=1e-4)
+
+    # 09:40 is the last bar → past the entry bar → no fire.
+    df_three = _today_5min(gap_pct=0.01, n_bars=3)
+    assert df_three.index[-1].time() == time(9, 40)
+    assert _entry(s, df_three, _daily(atr_pct=0.005)) is None
+
+
+def test_min_warmup_bars_relaxed() -> None:
+    # gap_fill must relax the backtester's 10-bar intraday warm-up so its
+    # bar-index-1 (09:35) entry isn't suppressed.
+    assert _strat().min_warmup_bars() == 1
+
+
+def test_uses_adjusted_close_for_prior_close() -> None:
+    # The gap is measured against the daily (adjusted) close, not anything in
+    # the 5-min frame. Prior close 100, open 101 → +1% gap recorded.
+    s = _strat()
+    d = _entry(s, _today_5min(gap_pct=0.01), _daily(prior_close=100.0, atr_pct=0.005))
+    assert d is not None
+    assert d.signals["prior_close"] == pytest.approx(100.0, abs=1e-4)
+    assert d.signals["gap_pct"] == pytest.approx(0.01, abs=1e-4)
+
+
+def test_short_history_skips_ticker() -> None:
+    # Fewer than overnight_atr_period+1 daily bars → skip, no crash.
+    s = _strat()
+    d = _entry(s, _today_5min(gap_pct=0.01), _daily(atr_pct=0.005, n=10))
+    assert d is None
+
+
+def test_state_resets_at_session_start() -> None:
+    # A fresh first bar on a different session fires again (no stale latch).
+    s = _strat()
+    next_day = date(2026, 3, 17)
+    df = _today_5min(gap_pct=0.01, day=next_day)
+    # Daily history still ends before TODAY, which is before next_day — valid.
+    d = _entry(s, df, _daily(atr_pct=0.005))
+    assert d is not None
+    assert d.direction == "short"
+
+
+# ---------------------------------------------------------------------------
+# Exits
+# ---------------------------------------------------------------------------
+
+def _exit_bars(bar_time: time) -> pd.DataFrame:
+    ts = [datetime(TODAY.year, TODAY.month, TODAY.day, bar_time.hour, bar_time.minute, tzinfo=ET)]
+    return pd.DataFrame(
+        {"open": [100.0], "high": [100.0], "low": [100.0], "close": [100.0],
+         "volume": [1000]},
+        index=pd.DatetimeIndex(ts, tz=ET),
+    )
+
+
+def test_time_stop_at_14_00() -> None:
+    s = _strat()
+    pos = {"direction": "short", "entry_price": 101.0, "stop_price": 103.0,
+           "target_price": 100.0}
+    sig = s.evaluate_exit(pos, current_price=101.0, df_5min=_exit_bars(time(14, 0)))
+    assert sig.should_exit
+    assert sig.reason == "time_stop"
+
+
+def test_no_time_stop_before_14_00() -> None:
+    s = _strat()
+    pos = {"direction": "short", "entry_price": 101.0, "stop_price": 103.0,
+           "target_price": 100.0}
+    sig = s.evaluate_exit(pos, current_price=101.0, df_5min=_exit_bars(time(13, 55)))
+    assert not sig.should_exit
+
+
+def test_short_target_exit_at_prior_close() -> None:
+    s = _strat()
+    pos = {"side": "SELL", "entry_price": 101.0, "stop_price": 103.0,
+           "target_price": 100.0}
+    sig = s.evaluate_exit(pos, current_price=99.9, df_5min=_exit_bars(time(11, 0)))
+    assert sig.should_exit
+    assert sig.reason == "take_profit"
+
+
+def test_short_stop_exit_above_entry() -> None:
+    s = _strat()
+    pos = {"side": "SELL", "entry_price": 101.0, "stop_price": 103.0,
+           "target_price": 100.0}
+    sig = s.evaluate_exit(pos, current_price=103.5, df_5min=_exit_bars(time(11, 0)))
+    assert sig.should_exit
+    assert sig.reason == "stop_loss"
+
+
+def test_long_target_exit_at_prior_close() -> None:
+    s = _strat()
+    pos = {"direction": "long", "entry_price": 99.0, "stop_price": 98.0,
+           "target_price": 100.0}
+    sig = s.evaluate_exit(pos, current_price=100.1, df_5min=_exit_bars(time(11, 0)))
+    assert sig.should_exit
+    assert sig.reason == "take_profit"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end through the real backtester (wiring: warm-up hook + exec window
+# + short entry → backtester short path → target cover)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_gap_fill_short_fills_target_through_backtester() -> None:
+    from unittest.mock import patch
+
+    from trading_bot.config import Config
+    from trading_bot.multi_strategy_backtest import MultiStrategyBacktester
+
+    config = Config.load("config.yaml")
+    engine = MultiStrategyBacktester(config)
+    # Run only gap_fill regardless of which sleeves config enables.
+    engine._strategies = [_strat()]
+
+    # A full gap-up-then-revert session: 09:30 opens +1.5%, drifts back
+    # through the prior close (100) so the short covers at target.
+    start = datetime(TODAY.year, TODAY.month, TODAY.day, 9, 30, tzinfo=ET)
+    n = 78  # 09:30 → ~15:55
+    ts = [start + timedelta(minutes=5 * i) for i in range(n)]
+    # Price path: 101.5 → 99.0 over the first 20 bars, then flat at 99.
+    prices = [max(99.0, 101.5 - 0.125 * i) for i in range(n)]
+    df5 = pd.DataFrame(
+        {
+            "open": prices,
+            "high": [p + 0.05 for p in prices],
+            "low": [p - 0.05 for p in prices],
+            "close": prices,
+            "volume": [100_000] * n,
+        },
+        index=pd.DatetimeIndex(ts, tz=ET),
+    )
+    mock_data = {"SPY": {"intraday": df5, "daily": _daily(atr_pct=0.005)}}
+
+    with patch.object(engine, "_load_day_data", return_value=mock_data):
+        result = await engine.run(TODAY, TODAY, cash_per_strategy_usd=100_000.0)
+
+    sr = result.strategies[0]
+    assert sr.total_trades == 1, "gap_fill should open exactly one short"
+    trade = sr.trades[0]
+    assert trade.direction == "short"
+    assert trade.exit_reason == "take_profit"
+    assert trade.net_pnl_usd > 0, "a short that covers below entry must profit"


### PR DESCRIPTION
## Summary

**PR4 of the #48 chain.** Implements `GapFillStrategy` — fades large overnight gaps in the 13-ETF basket on the session's 09:35 bar and targets the prior (adjusted) close. **Gap up → short, gap down → long.** INTRADAY hold, hard 14:00 ET time stop. **Ships `enabled: false`** — gated on the A/B (next PR) before any allocation.

## Design decisions (pinned by research)
- **Bar convention (the issue's flagged off-by-one):** 5-min bars are **left-labelled**, so the open bar is 09:30 and the gap reference is its open. We act on the **09:35 bar** — the first inside the execution window — so the entry clears the backtester's exec-window and warm-up gates and gets ~5 min of settle. Firing on exactly that label makes entry **once-per-session** (no `fired_today` flag needed). The issue assumed right-labelling; this corrects it.
- **Prior close:** the last daily bar **strictly before today** (avoids look-ahead onto a same-day daily bar), and the Alpaca-**adjusted** close (ex-div/split safe — a raw close reads an ex-div day as a 1–3% phantom gap).
- **Adaptive threshold:** `max(min_gap_pct, gap_atr_multiplier × overnight_ATR%)`.
- **Stop:** ATR-anchored with a percentage **floor** (`stop_pct_floor`) so a pathologically tiny ATR can't collapse the stop and explode risk-based size. *(The issue's floor-vs-cap wording was internally contradictory; floor matches `test_stop_floor_enforced`'s intent and is the safe reading — documented for A/B confirmation.)*
- **Sizing:** risk-anchored via `StrategyBase.size_by_risk`.

## Backtester wiring (required for the A/B)
The intraday `run` loop skipped entries for `bar_idx < 10` (indicator warm-up). Added a per-strategy **`StrategyBase.min_warmup_bars()`** hook (default 10 — **every existing sleeve unchanged**) which gap_fill overrides to `1` so its early-session entry isn't suppressed. **Without this the A/B would produce zero trades** — caught by the end-to-end test below.

## Files
- **Add:** `strategy/strategies/gap_fill.py`, `tests/test_gap_fill.py`
- **Modify:** `strategies/__init__.py` (registry), `config.yaml` (sleeve, disabled), `strategy/base.py` (`min_warmup_bars` hook), `multi_strategy_backtest.py` (use the hook)

## Test plan
- `test_gap_fill.py` — **20 cases**: threshold gating (floor + adaptive), short/long fade direction, target = prior close, ATR stop + floor clamp, the **09:35 bar-convention off-by-one guard**, one-per-session, late-open skip, short-history skip, session reset, direction-aware exits + 14:00 time stop, the warm-up override, **and an end-to-end short through the real backtester** (entry → short path → target cover → positive P&L).
- Full suite: **1091 passed, 4 skipped**.
- `ruff`, `bandit`, `vulture` clean; **`mypy` clean (incl. `base.py` on the critical path)**.

## Notes
- The exit-before-entry ordering integration (overnight_drift exit → gap_fill entry on the same ticker) is covered at the live tick level by PR2's `test_tick_processes_exits_before_entries`; the backtester's isolated per-sleeve cash can't reproduce that cross-sleeve handoff.

## Chain context
1. ✅ PR1 (#175) — backtester short support
2. ✅ PR2 (#176) — exit-before-entry ordering
3. ✅ PR3 (#178) — live short order sides
4. ✅ **PR4 (this)** — `GapFillStrategy` (disabled)
5. PR5 — standalone + combined A/B reports (gate)
6. PR6 — flip `enabled: true` if gates pass (+ paper short smoke test)

Refs #48