### PR TITLE
docs(gap_fill): failed A/B — sleeve stays disabled — PR5 for #48

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -858,16 +858,18 @@ multi_strategy:
     # correlation with the RSI-dip mean_reversion and the overnight_drift
     # sleeves.
     #
-    # SHIPPED DISABLED. Requires BOTH A/Bs to pass before enabling (separate
-    # PR): a standalone regime-matched walkforward A/B (PF >= 1.10 with CI
-    # lower >= 1.00, OOS positive in >= 4/6 windows, WR >= 55%, Sharpe >= 0.40
-    # with positive lower CI, MaxDD <= 10%, >= 150 trades, daily-return corr
-    # vs existing sleeves < 0.30) AND a combined-portfolio A/B
-    # (mean_reversion + overnight_drift + gap_fill) whose Sharpe must improve
-    # vs the mean_reversion + overnight_drift baseline.
-    #
-    # Live shorting requires the order path landed in #175/#177/#178; a paper
-    # short smoke test gates the eventual enablement PR.
+    # SHIPPED DISABLED — and STAYS disabled: the standalone A/B FAILED.
+    # 2020-07-27 → 2026-04-16, 13 ETFs (default `run` harness, which honours
+    # the sleeve's own direction/stops; --multi-intraday is long-only + ATR-
+    # stop-overriding so it can't test this sleeve):
+    #   1,985 trades, WR 44.8%, Return -19.31%, MaxDD 20.2%, PF 0.73,
+    #   Sharpe -1.35 — misses every bar except trade count.
+    # The gap-fill base rate held (66% hit take-profit) but the payoff is
+    # negative-skew: tiny target wins (eroded by slippage on <0.5% targets)
+    # vs large 14:00 time-stop losses from gap CONTINUATION in a trend-heavy
+    # window. Combined A/B not run (a -19% sleeve can't lift a portfolio).
+    # Full writeup + follow-up hypotheses (regime conditioning, wider edge,
+    # gap-and-go inverse): trading_bot/docs/gap_fill/2026-05-31_ab_report.md
     gap_fill:
       enabled: false
       allocation_usd: 0.0

--- a/trading_bot/docs/gap_fill/2026-05-31_ab_report.md
+++ b/trading_bot/docs/gap_fill/2026-05-31_ab_report.md
@@ -1,0 +1,95 @@
+# Opening gap-fill A/B — ai-broker#48 (sleeve #9)
+
+**Verdict: ❌ FAIL — sleeve stays `enabled: false`.**
+
+**Window:** 2020-07-27 → 2026-04-16 (1,490 trading days, ~5.7 years)
+**Universe:** SPY, QQQ, XLF, XLK, XLE, XLV, XLI, XLY, XLP, XLU, XLB, XLRE, XLC
+**Cash:** $2,500 (single sleeve)
+**Date run:** 2026-05-31
+
+## Harness note (important — differs from the issue's literal command)
+
+The issue specifies `--multi-intraday`. That mode (`run_multi_ticker_intraday`)
+is **unusable for gap_fill**: it (a) skips every short decision
+(`direction != "long"` guard) and (b) overrides each strategy's own
+stop/target with ATR-anchored *long* stops + a fixed 2% risk model. gap_fill
+shorts gap-ups and sets its own stop (above entry) and target (the prior
+close), all of which that mode discards.
+
+The A/B therefore ran on the **default `run` path**, which honours
+`decision.direction` / `stop_price` / `target_price` (made direction-aware in
+PR #175) and drives the 13-ETF watchlist from config. `run` has no regime
+filter, so no `--no-regime-filter` is needed. Because the harness differs from
+the one behind the published mean_reversion / overnight_drift / ORB numbers,
+these figures are **not** cross-comparable to those sleeves — but the
+standalone pass/fail is self-contained (gap_fill judged against its own
+acceptance bar), so the harness choice does not affect the verdict.
+
+## Acceptance bar (per the issue) vs. result
+
+| Metric | Bar | Result | Pass |
+|---|---|---:|:---:|
+| Profit factor | ≥ 1.10 (95% CI lower ≥ 1.00) | **0.73** | ❌ |
+| Win rate | ≥ 55% | **44.8%** | ❌ |
+| Sharpe | ≥ 0.40 (positive lower CI) | **−1.35** | ❌ |
+| Max drawdown | ≤ 10% | **20.2%** | ❌ |
+| OOS return positive | ≥ 4 of 6 yearly windows | n/a | ❌ |
+| Trade count | ≥ 150 | **1,985** | ✅ |
+| Total return | positive | **−19.31%** ($2,500 → $2,017.24) | ❌ |
+
+Point estimates miss the bar by a wide margin on every metric except trade
+count, so the walkforward CI / yearly-OOS pass was not run (a PF of 0.73 cannot
+have a CI lower bound ≥ 1.00). The **combined-portfolio A/B**
+(`mean_reversion + overnight_drift + gap_fill`) was likewise **not run**: a
+sleeve returning −19% with PF 0.73 cannot improve a portfolio's Sharpe, so the
+secondary gate is moot.
+
+## Why it fails — negative-skew fade
+
+The gap-fill base rate actually held: **66% of trades (1,313 / 1,985) hit the
+take-profit** (price reverted to the prior close). The edge dies in the
+**payoff distribution**, not the hit rate.
+
+| Exit reason | Trades | Total P&L |
+|---|---:|---:|
+| take_profit | 1,313 | +$242.28 |
+| time_stop (14:00, gap unfilled) | 657 | **−$578.21** |
+| stop_loss | 12 | −$137.27 |
+| eod_close | 3 | −$9.34 |
+
+- **Wins are tiny.** The target *is* the gap (often < 0.5%), and 2 bps of
+  entry+exit slippage on a sub-0.5% move erodes a large share of the take-profit
+  winners — 1,313 take-profits net only +$242 total, and overall win rate falls
+  to 44.8% once slippage flips marginal fills negative.
+- **Losses are large.** The 657 time-stops are the gaps that *continued*
+  (gap-and-go) and ran against the fade until the 14:00 cutoff, averaging
+  −$0.88 each vs. +$0.18 for take-profits. This is the issue's flagged failure
+  mode ("trending months — gaps continue rather than fill"), and 2020–2026 was
+  trend-heavy (2021 melt-up, 2022 bear, 2023–24 bull).
+
+Net: a fundamentally negative-skew trade — many small wins, fewer large losses —
+that does not survive costs on this liquid-ETF universe.
+
+## Follow-up hypotheses (all out-of-scope for the simple version)
+
+The simple unconditional fade is dead, but the take-profit base rate suggests
+the reversion signal exists — it's the *payoff* that's broken. Candidates, each
+a separate issue if pursued:
+
+1. **Regime conditioning** — only fade gaps when the underlying is range-bound
+   (e.g. SPY within X% of its 20-day SMA / low ADX); skip trend days where
+   gap-and-go dominates. Directly targets the time-stop losses.
+2. **Asymmetric thresholds / wider edge** — require a larger gap (higher
+   `gap_atr_multiplier`) so the target clears slippage, and/or a tighter time
+   stop to cut the continuation tail sooner.
+3. **Gap-and-go variant** — the inverse: *trade with* the gap on continuation
+   days. The 657 losing time-stops are a profit pool for the opposite signal.
+4. **Cost model** — the strategy is acutely slippage-sensitive (sub-0.5%
+   targets); revisit only with a realistic per-ETF spread model.
+
+## Definition-of-done status
+
+- [x] Standalone A/B run and committed (this report)
+- [x] Combined A/B — not run (moot: standalone −19% / PF 0.73)
+- [x] Sleeve stays `enabled: false` (no enablement PR)
+- [x] Result recorded here + in the `config.yaml` gap_fill block


### PR DESCRIPTION
## Summary

**PR5 of the #48 chain — the A/B gate.** Ran the standalone gap-fill A/B. **Result: ❌ decisive FAIL → gap-fill stays `enabled: false`. No PR6 enablement.**

| Metric | Bar | Result | |
|---|---|---:|:---:|
| Trades | ≥150 | 1,985 | ✅ |
| Win rate | ≥55% | 44.8% | ❌ |
| Return | positive | **−19.31%** | ❌ |
| MaxDD | ≤10% | **20.2%** | ❌ |
| PF | ≥1.10 (CI≥1.0) | **0.73** | ❌ |
| Sharpe | ≥0.40 | **−1.35** | ❌ |

Window 2020-07-27 → 2026-04-16, 13 ETFs, $2,500.

## Why it fails — negative-skew fade
The gap-fill **base rate held** (66% of trades, 1,313/1,985, hit take-profit), but the payoff is broken:

| Exit | Trades | P&L |
|---|---:|---:|
| take_profit | 1,313 | +$242 |
| time_stop (gap unfilled @14:00) | 657 | **−$578** |
| stop_loss | 12 | −$137 |

Wins are tiny (the target *is* the gap, often <0.5%, heavily eroded by slippage) while time-stop losses from **gap continuation** are large — the issue's flagged failure mode in a trend-heavy window. The **combined A/B was not run**: a −19% / PF-0.73 sleeve can't lift a portfolio's Sharpe, so the secondary gate is moot.

## Harness note (reproducibility)
The issue's `--multi-intraday` mode (`run_multi_ticker_intraday`) is **long-only and overrides strategy stops with ATR longs** — it can't test a self-stop-managed short sleeve. The A/B ran on the **default `run` path**, which honours `decision.direction`/`stop_price`/`target_price` (since #175) and drives the 13-ETF watchlist from config. **No code change needed** (the config watchlist already *is* the 13 ETFs). Full detail in the report.

## Changes
- **Add** `trading_bot/docs/gap_fill/2026-05-31_ab_report.md` — full metrics, exit-reason breakdown, harness caveat, and follow-up hypotheses (regime conditioning, wider edge to clear slippage, gap-and-go inverse).
- **Edit** `config.yaml` — records the failed-A/B verdict in the (still-disabled) gap_fill block.

## Chain outcome
1. ✅ PR1 (#175) — backtester short support
2. ✅ PR2 (#176) — exit-before-entry ordering
3. ✅ PR3 (#178) — live short order sides
4. ✅ PR4 (#179) — `GapFillStrategy` (disabled)
5. ✅ **PR5 (this)** — A/B gate → **FAIL, stays disabled**
6. ⛔ PR6 (enablement) — **not pursued** (A/B failed)

The infrastructure PRs (1–3) are durable wins: the bot now has working long+short support in the backtester and live order path, validated and merged. gap-fill itself doesn't earn an allocation as specified, but the sleeve, tests, and a documented edge-analysis remain for a future regime-conditioned retune.

Refs #48