### PR TITLE
fix: resolve un-backfillable reconciliation_mismatch rows

### DIFF
--- a/.github/workflows/daily-review.yml
+++ b/.github/workflows/daily-review.yml
@@ -96,6 +96,27 @@ jobs:
         continue-on-error: true
         run: python -m trading_bot.self_improve.backfill_cli
 
+      - name: Resolve un-backfillable reconciliation_mismatch rows
+        # Runs AFTER the backfill so it only sees rows the backfill could not
+        # pair with a real Alpaca fill. These are phantom round-trips (positions
+        # never actually held at the broker) that would otherwise stay
+        # exit_price=NULL forever, retried every night, inflating total_trades
+        # and corrupting per-strategy P&L. Phantoms (entry never confirmed
+        # filled) are voided to $0; genuinely-orphaned exits (entry filled, exit
+        # fill missing) are flagged via ntfy for human review — never voided.
+        # Only touches rows >= 2 days old, so today's mismatches self-heal
+        # through the backfill first and are never voided prematurely.
+        env:
+          ALPACA_ENV: ${{ vars.ALPACA_ENV || 'paper' }}
+          ALPACA_PAPER_KEY_ID: ${{ secrets.ALPACA_PAPER_KEY_ID }}
+          ALPACA_PAPER_SECRET: ${{ secrets.ALPACA_PAPER_SECRET }}
+          ALPACA_LIVE_KEY_ID: ${{ secrets.ALPACA_LIVE_KEY_ID }}
+          ALPACA_LIVE_SECRET: ${{ secrets.ALPACA_LIVE_SECRET }}
+          BOT_LOG_DIR: logs
+        # Continue on error: a failed resolve must not block the report.
+        continue-on-error: true
+        run: python -m trading_bot.self_improve.resolve_cli
+
       - name: Recompute daily_summaries from backfilled trades
         # The live wind-down writes daily_summaries ~16:10 ET, before this
         # backfill runs at 21:30 UTC. Without a recompute, daily_summaries

--- a/trading_bot/constants.py
+++ b/trading_bot/constants.py
@@ -96,6 +96,11 @@ class ExitReason(str, Enum):
     MANUAL = "manual"
     RECONCILIATION_MISMATCH = "reconciliation_mismatch"
     PHASE0_CLEANUP = "phase0_cleanup"
+    # Terminal states for reconciliation_mismatch rows the nightly backfill
+    # can never pair with a real Alpaca fill (see
+    # self_improve/resolve_reconciliation_mismatch.py).
+    VOID_NO_FILL = "void_no_fill"  # phantom round-trip, never held -> P&L = 0
+    UNRESOLVED_EXIT = "unresolved_exit"  # entry filled, exit fill missing -> human
 
 
 # ---------------------------------------------------------------------------

--- a/trading_bot/reporting/performance.py
+++ b/trading_bot/reporting/performance.py
@@ -69,11 +69,19 @@ class PerformanceCalculator:
         """
         conn: sqlite3.Connection = self._connect()
         try:
+            # Exclude terminal non-trade markers: 'void_no_fill' (phantom
+            # round-trips the reconciler closed that were never really held)
+            # and 'unresolved_exit' (entry filled but exit fill unrecoverable,
+            # awaiting human review). Counting either would inflate
+            # total_trades with positions that realized no attributable P&L.
+            # See self_improve/resolve_reconciliation_mismatch.py.
             trades_rows = conn.execute(
                 """
                 SELECT * FROM trades
                 WHERE substr(exit_time, 1, 10) = ?
                   AND exit_time IS NOT NULL
+                  AND (exit_reason IS NULL
+                       OR exit_reason NOT IN ('void_no_fill', 'unresolved_exit'))
                 ORDER BY exit_time
                 """,
                 (date,),

--- a/trading_bot/self_improve/resolve_cli.py
+++ b/trading_bot/self_improve/resolve_cli.py
@@ -1,0 +1,130 @@
+"""CLI wrapper around ``resolve_reconciliation_mismatch``.
+
+Resolves stale ``reconciliation_mismatch`` trades rows that the nightly
+``alpaca_backfill`` can never pair with a real Alpaca fill: phantom
+round-trips are voided to $0, genuinely-orphaned exits are flagged for a
+human via ntfy. Run *after* the backfill in the nightly daily-review job so
+the backfill heals everything it can first.
+
+Usage:
+    python -m trading_bot.self_improve.resolve_cli --dry-run
+    python -m trading_bot.self_improve.resolve_cli
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import sqlite3
+import sys
+from pathlib import Path
+
+from trading_bot.config import Config
+from trading_bot.env import resolve_alpaca_env
+from trading_bot.log_setup import setup_logging
+from trading_bot.self_improve.resolve_reconciliation_mismatch import (
+    MIN_AGE_DAYS,
+    AlertFn,
+    resolve,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _build_alert(config: Config) -> AlertFn | None:
+    """Wire a best-effort ntfy alert callback from config. Returns None (logs
+    only) if the Notifier can't be constructed — a missing alert channel must
+    never block the resolve pass."""
+    try:
+        from trading_bot.notifications.notifier import Notifier
+
+        notifier = Notifier(config.raw_section())
+
+        def _alert(title: str, message: str) -> None:
+            notifier.send_sync(title, message, priority=4, tags=["warning"])
+
+        return _alert
+    except Exception:
+        logger.warning("Could not construct Notifier — unresolved rows will be "
+                       "logged but not pushed", exc_info=True)
+        return None
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Resolve stale reconciliation_mismatch rows the backfill "
+                    "can't pair (void phantoms, flag real orphans).",
+    )
+    parser.add_argument("--config", default="config.yaml", help="Path to config.yaml")
+    parser.add_argument(
+        "--db", default=None,
+        help="SQLite path (default: config's database.path)",
+    )
+    parser.add_argument(
+        "--min-age-days", type=int, default=MIN_AGE_DAYS,
+        help=f"Only resolve rows at least this many days old (default {MIN_AGE_DAYS}). "
+             "Younger rows are left for the nightly backfill.",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Classify and log what would change; do not write to the DB.",
+    )
+    return parser.parse_args(argv)
+
+
+async def _async_main(args: argparse.Namespace) -> int:
+    config = Config.load(args.config)
+    db_path = args.db or config.db_path
+    if not Path(db_path).exists():
+        logger.error("DB not found at %s", db_path)
+        return 2
+
+    api_key, secret_key, is_paper = resolve_alpaca_env()
+    if not api_key or not secret_key:
+        logger.error(
+            "Alpaca credentials not found. Set ALPACA_PAPER_KEY_ID + "
+            "ALPACA_PAPER_SECRET (or ALPACA_API_KEY + ALPACA_SECRET_KEY) "
+            "in your environment or .env file."
+        )
+        return 2
+
+    from alpaca.trading.client import TradingClient
+    client = TradingClient(api_key, secret_key, paper=is_paper)
+    logger.info("Connected to Alpaca (%s)", "paper" if is_paper else "live")
+
+    alert = None if args.dry_run else _build_alert(config)
+
+    conn = sqlite3.connect(db_path)
+    try:
+        report = await resolve(
+            conn, client,
+            dry_run=args.dry_run,
+            min_age_days=args.min_age_days,
+            alert=alert,
+        )
+    finally:
+        conn.close()
+
+    logger.info(
+        "Resolve complete: candidates=%d repaired=%d voided=%d unresolved=%d "
+        "skipped_too_young=%d dry_run=%s",
+        report.candidates, report.repaired, report.voided,
+        report.unresolved, report.skipped_too_young, report.dry_run,
+    )
+    if report.unresolved:
+        logger.warning(
+            "%d row(s) left UNRESOLVED (entry filled, exit missing) — these "
+            "need manual inspection of Alpaca order history.", report.unresolved,
+        )
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    setup_logging("resolve_reconciliation_mismatch")
+    args = _parse_args(argv)
+    return asyncio.run(_async_main(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/trading_bot/self_improve/resolve_reconciliation_mismatch.py
+++ b/trading_bot/self_improve/resolve_reconciliation_mismatch.py
@@ -1,0 +1,364 @@
+"""Terminal resolution for stale ``reconciliation_mismatch`` trades rows.
+
+The live recovery path (``StateRecovery._close_db_position``) writes a trades
+row with ``exit_reason='reconciliation_mismatch'`` and NULL exit data,
+expecting the nightly ``alpaca_backfill`` to pair it with the real Alpaca
+SELL fill. But the backfill only repairs rows where a matching fill *exists*.
+When the reconciler fired because a position was never actually held at the
+broker (a phantom duplicate, or an entry that never filled), there is no SELL
+fill to find — so the row stays ``exit_price IS NULL`` forever, retried every
+night, silently inflating ``total_trades`` and corrupting per-strategy P&L.
+
+This pass closes that gap. For each ``reconciliation_mismatch`` row with NULL
+``exit_price`` older than a safety window:
+
+  1. **Try the existing fill-pairing** (``find_exit_fill``). If a fill now
+     exists, repair via ``insert_backfilled_trade`` — the same proven path
+     the nightly backfill uses. (Belt-and-suspenders: the backfill runs
+     first, so this rarely fires, but it keeps the two passes consistent.)
+  2. **No fill → classify by the ENTRY order at Alpaca:**
+       - entry never filled / no order id / order too old to confirm →
+         **VOID**: ``exit_price = entry_price``, P&L = 0,
+         ``exit_reason='void_no_fill'``. A phantom round-trip realized no
+         P&L, so zeroing is correct and drops it from the win/loss counts.
+       - entry **confirmed filled** but no exit fill → do NOT fabricate a
+         price. Stamp ``exit_reason='unresolved_exit'`` and surface it to a
+         human via the injected ``alert`` callback. Never silently void real
+         money.
+  3. Rows younger than ``MIN_AGE_DAYS`` are left untouched so the ordinary
+     nightly backfill gets first crack. Today's same-day mismatches self-heal
+     through the backfill and must never be voided prematurely.
+
+Idempotent: a resolved row's ``exit_reason`` is no longer
+``reconciliation_mismatch``, so it drops out of the candidate query on the
+next run.
+
+Usage:
+    python -m trading_bot.self_improve.resolve_cli --dry-run
+    python -m trading_bot.self_improve.resolve_cli
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Awaitable, Callable
+
+from trading_bot.constants import ExitReason
+from trading_bot.self_improve.alpaca_backfill import (
+    ClosedPositionRow,
+    ExitFill,
+    _parse_iso,
+    find_exit_fill,
+    insert_backfilled_trade,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# A reconciliation_mismatch row must be at least this many days old before we
+# resolve it, giving the ordinary nightly backfill time to pair it with a real
+# fill first. Same-day / next-day mismatches (e.g. today's ORB exits that the
+# backfill heals at 22:30 UTC) are never touched here — and so are never voided.
+MIN_AGE_DAYS: int = 2
+
+# Notes markers so a resolved row is auditable and the candidate query (keyed
+# on exit_reason) never re-selects it.
+VOID_NOTE: str = "resolve:void_no_fill (no Alpaca fill; entry never confirmed)"
+UNRESOLVED_NOTE: str = "resolve:unresolved_exit (entry filled, exit fill missing — needs human)"
+
+# Alert callback: (title, message) -> None. Injected so the module stays
+# decoupled from the Notifier and trivially testable.
+AlertFn = Callable[[str, str], None]
+# Exit-fill finder signature, injectable for tests.
+FillFinder = Callable[[object, ClosedPositionRow], Awaitable[ExitFill | None]]
+# Entry-filled confirmer signature, injectable for tests.
+EntryConfirmer = Callable[[object, str], Awaitable[bool]]
+
+
+@dataclass(frozen=True)
+class StaleRow:
+    """A ``reconciliation_mismatch`` trades row with NULL exit, plus the
+    Alpaca order ids from its matched ``positions`` row (if any)."""
+
+    trade_id: int
+    ticker: str
+    strategy_id: str | None
+    exchange: str
+    currency: str
+    quantity: float
+    entry_price: float
+    entry_time: datetime
+    hold_type: str
+    phase: int
+    alpaca_order_id: str | None
+    alpaca_stop_order_id: str | None
+    alpaca_target_order_id: str | None
+    alpaca_trail_order_id: str | None
+
+    def as_position(self) -> ClosedPositionRow:
+        """Adapt to the ``ClosedPositionRow`` shape ``find_exit_fill`` and
+        ``insert_backfilled_trade`` expect. ``position_id`` is unused by those
+        functions except for the notes marker; the trade id is a stable
+        substitute when no position row matched."""
+        return ClosedPositionRow(
+            position_id=self.trade_id,
+            ticker=self.ticker,
+            exchange=self.exchange,
+            currency=self.currency,
+            strategy_id=self.strategy_id or "unknown",
+            quantity=self.quantity,
+            entry_price=self.entry_price,
+            entry_time=self.entry_time,
+            hold_type=self.hold_type,
+            phase=self.phase,
+            alpaca_order_id=self.alpaca_order_id,
+            alpaca_stop_order_id=self.alpaca_stop_order_id,
+            alpaca_target_order_id=self.alpaca_target_order_id,
+            alpaca_trail_order_id=self.alpaca_trail_order_id,
+        )
+
+
+@dataclass(frozen=True)
+class ResolveReport:
+    """Summary of a single resolve invocation."""
+
+    candidates: int
+    repaired: int
+    voided: int
+    unresolved: int
+    skipped_too_young: int
+    dry_run: bool
+
+
+def load_stale_rows(
+    conn: sqlite3.Connection,
+    *,
+    now: datetime,
+    min_age_days: int = MIN_AGE_DAYS,
+) -> tuple[list[StaleRow], int]:
+    """Load ``reconciliation_mismatch`` trades rows with NULL ``exit_price``
+    that are at least ``min_age_days`` old.
+
+    Driven off the **trades** table (not ``positions``) so attribution-less
+    rows — ``strategy_id='unknown'`` or with no surviving position row — are
+    still resolved. The matching ``positions`` row, when one exists, is joined
+    in for its Alpaca order ids (needed to confirm the entry fill and infer an
+    exit reason). The join is by ``(ticker, entry_time[:19])`` — the same
+    19-char prefix the backfill uses, tolerant of microsecond / offset drift.
+
+    Returns ``(rows_old_enough, skipped_too_young)``.
+    """
+    cur = conn.execute(
+        """
+        SELECT t.id, t.ticker, t.strategy_id, t.exchange, t.currency,
+               t.quantity, t.entry_price, t.entry_time, t.exit_time,
+               t.hold_type, t.phase,
+               p.alpaca_order_id, p.alpaca_stop_order_id,
+               p.alpaca_target_order_id, p.alpaca_trail_order_id
+          FROM trades t
+          LEFT JOIN positions p
+                 ON p.ticker = t.ticker
+                AND substr(p.entry_time, 1, 19) = substr(t.entry_time, 1, 19)
+         WHERE t.exit_reason = ?
+           AND t.exit_price IS NULL
+         ORDER BY t.entry_time
+        """,
+        (ExitReason.RECONCILIATION_MISMATCH.value,),
+    )
+    rows: list[StaleRow] = []
+    skipped_young = 0
+    for r in cur.fetchall():
+        entry_dt = _parse_iso(r[7])
+        if entry_dt is None:
+            logger.warning("Trade %d has unparseable entry_time %r — skipping",
+                           r[0], r[7])
+            continue
+        # Age off exit_time (when the reconciler closed it); fall back to
+        # entry_time if exit_time is somehow absent.
+        ref_dt = _parse_iso(r[8]) or entry_dt
+        age_days = (now - ref_dt).total_seconds() / 86400.0
+        if age_days < min_age_days:
+            skipped_young += 1
+            continue
+        rows.append(
+            StaleRow(
+                trade_id=int(r[0]),
+                ticker=str(r[1]),
+                strategy_id=r[2],
+                exchange=str(r[3]) if r[3] is not None else "",
+                currency=str(r[4]) if r[4] is not None else "USD",
+                # quantity may be fractional (stored as REAL); never int() it.
+                quantity=float(r[5]),
+                entry_price=float(r[6]),
+                entry_time=entry_dt,
+                hold_type=str(r[9]) if r[9] is not None else "intraday",
+                phase=int(r[10]) if r[10] is not None else 1,
+                alpaca_order_id=r[11],
+                alpaca_stop_order_id=r[12],
+                alpaca_target_order_id=r[13],
+                alpaca_trail_order_id=r[14],
+            )
+        )
+    return rows, skipped_young
+
+
+async def confirm_entry_filled(client, order_id: str) -> bool:
+    """Return True only if Alpaca confirms ``order_id`` reached status filled.
+
+    Conservative: any uncertainty (no order id, lookup error, order aged out
+    of Alpaca's history, non-filled status) returns False, which routes the
+    row to the VOID path. We only protect a row from voiding when we can
+    *positively* confirm its entry filled — that is the one case where zeroing
+    might discard real P&L.
+    """
+    if not order_id:
+        return False
+    try:
+        order = await asyncio.to_thread(client.get_order_by_id, order_id)
+    except Exception:
+        logger.warning("Could not fetch Alpaca entry order %s — treating as "
+                       "unconfirmed (will void)", str(order_id)[:8],
+                       exc_info=True)
+        return False
+    status_str = (getattr(getattr(order, "status", None), "value", "") or "").lower()
+    if not status_str:
+        status_str = str(getattr(order, "status", "")).lower()
+    return "filled" in status_str and "partially" not in status_str
+
+
+def _void_row(conn: sqlite3.Connection, row: StaleRow) -> None:
+    """Mark a phantom row as a zero-P&L void. Keeps the row (audit trail);
+    sets exit_price = entry_price so it reads as a flat scratch."""
+    conn.execute(
+        """
+        UPDATE trades
+           SET exit_price = ?, exit_time = COALESCE(exit_time, ?),
+               gross_pnl = 0, net_pnl = 0, pnl_usd = 0,
+               exit_reason = ?, notes = ?
+         WHERE id = ?
+        """,
+        (
+            row.entry_price,
+            row.entry_time.isoformat(),
+            ExitReason.VOID_NO_FILL.value,
+            VOID_NOTE,
+            row.trade_id,
+        ),
+    )
+
+
+def _mark_unresolved(conn: sqlite3.Connection, row: StaleRow) -> None:
+    """Flag a row whose entry filled but whose exit fill we cannot find.
+    exit_price stays NULL (we will not fabricate one); the changed
+    exit_reason makes it terminal so it is not re-processed."""
+    conn.execute(
+        """
+        UPDATE trades
+           SET exit_reason = ?, notes = ?
+         WHERE id = ?
+        """,
+        (ExitReason.UNRESOLVED_EXIT.value, UNRESOLVED_NOTE, row.trade_id),
+    )
+
+
+async def resolve(
+    conn: sqlite3.Connection,
+    client,
+    *,
+    dry_run: bool = False,
+    now: datetime | None = None,
+    min_age_days: int = MIN_AGE_DAYS,
+    alert: AlertFn | None = None,
+    fill_finder: FillFinder | None = None,
+    entry_confirmer: EntryConfirmer | None = None,
+) -> ResolveReport:
+    """Resolve every stale ``reconciliation_mismatch`` row to a terminal state.
+
+    See the module docstring for the per-row decision tree. ``alert`` (if
+    given) is called once at the end with a single batched summary when any
+    rows are left ``unresolved_exit`` — never once per row.
+    """
+    resolved_now = now or datetime.now(tz=timezone.utc)
+    finder = fill_finder or find_exit_fill
+    confirmer = entry_confirmer or confirm_entry_filled
+
+    candidates, skipped_young = load_stale_rows(
+        conn, now=resolved_now, min_age_days=min_age_days,
+    )
+    logger.info(
+        "Found %d stale reconciliation_mismatch row(s) >= %d day(s) old "
+        "(%d younger, left for the nightly backfill)",
+        len(candidates), min_age_days, skipped_young,
+    )
+
+    repaired = 0
+    voided = 0
+    unresolved_rows: list[StaleRow] = []
+
+    for row in candidates:
+        position = row.as_position()
+        exit_fill = await finder(client, position)
+
+        if exit_fill is not None:
+            gross = (exit_fill.filled_avg_price - row.entry_price) * row.quantity
+            logger.info(
+                "%sRepair trade %d %s: paired exit @ %.4f pnl=%+.2f",
+                "[DRY-RUN] " if dry_run else "",
+                row.trade_id, row.ticker, exit_fill.filled_avg_price, gross,
+            )
+            if not dry_run:
+                insert_backfilled_trade(conn, position, exit_fill)
+            repaired += 1
+            continue
+
+        entry_filled = await confirmer(client, row.alpaca_order_id or "")
+        if entry_filled:
+            logger.warning(
+                "%sUNRESOLVED trade %d %s: entry order %s confirmed filled but "
+                "no exit fill found — flagging for human review",
+                "[DRY-RUN] " if dry_run else "",
+                row.trade_id, row.ticker,
+                str(row.alpaca_order_id or "")[:8],
+            )
+            if not dry_run:
+                _mark_unresolved(conn, row)
+            unresolved_rows.append(row)
+        else:
+            logger.info(
+                "%sVOID trade %d %s qty=%.4f: no exit fill and entry not "
+                "confirmed filled — zeroing P&L",
+                "[DRY-RUN] " if dry_run else "",
+                row.trade_id, row.ticker, row.quantity,
+            )
+            if not dry_run:
+                _void_row(conn, row)
+            voided += 1
+
+    if not dry_run:
+        conn.commit()
+
+    if unresolved_rows and alert is not None:
+        sample = ", ".join(
+            f"{r.ticker}@{r.entry_time.date().isoformat()}"
+            for r in unresolved_rows[:8]
+        )
+        more = "" if len(unresolved_rows) <= 8 else f" (+{len(unresolved_rows) - 8} more)"
+        alert(
+            "⚠️ Unresolved exits need review",
+            f"{len(unresolved_rows)} reconciliation_mismatch row(s) had a "
+            f"confirmed entry fill but no exit fill: {sample}{more}. "
+            f"These were NOT voided — inspect Alpaca order history.",
+        )
+
+    return ResolveReport(
+        candidates=len(candidates),
+        repaired=repaired,
+        voided=voided,
+        unresolved=len(unresolved_rows),
+        skipped_too_young=skipped_young,
+        dry_run=dry_run,
+    )

--- a/trading_bot/tests/test_resolve_reconciliation_mismatch.py
+++ b/trading_bot/tests/test_resolve_reconciliation_mismatch.py
@@ -1,0 +1,362 @@
+"""Tests for trading_bot.self_improve.resolve_reconciliation_mismatch.
+
+The Alpaca client is never hit: the exit-fill finder and entry-fill confirmer
+are injected. The behaviour under test is the per-row decision tree (repair /
+void / unresolved), the age gate, idempotency, dry-run safety, and the batched
+alert — plus the performance.py exclusion of the new terminal states.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from trading_bot.constants import TZ_EASTERN
+from trading_bot.reporting.performance import PerformanceCalculator
+from trading_bot.self_improve.alpaca_backfill import ClosedPositionRow, ExitFill
+from trading_bot.self_improve.resolve_reconciliation_mismatch import (
+    confirm_entry_filled,
+    load_stale_rows,
+    resolve,
+)
+
+# A fixed "now" so age math is deterministic.
+NOW = datetime(2026, 6, 1, 21, 30, tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _insert_mismatch(
+    conn,
+    *,
+    ticker: str = "SPY",
+    strategy_id: str | None = "overnight_drift",
+    entry_dt: datetime,
+    exit_dt: datetime | None = None,
+    quantity: float = 10.0,
+    entry_price: float = 100.0,
+    with_position: bool = True,
+    entry_oid: str | None = "alp-entry-1",
+) -> int:
+    """Insert a reconciliation_mismatch trades row (NULL exit) and, optionally,
+    its matching positions row. Returns the trade id."""
+    # Mirror production: entry/exit times are stored ET-aware ISO strings.
+    entry_iso = entry_dt.astimezone(TZ_EASTERN).isoformat()
+    exit_iso = exit_dt.astimezone(TZ_EASTERN).isoformat() if exit_dt is not None else None
+    conn.execute(
+        """
+        INSERT INTO trades (
+            ticker, exchange, currency, side, entry_time, entry_price,
+            quantity, exit_time, exit_price, exit_reason,
+            gross_pnl, net_pnl, pnl_usd, hold_type, phase, strategy_id, notes
+        ) VALUES (?, 'NYSE', 'USD', 'BUY', ?, ?, ?, ?, NULL,
+                  'reconciliation_mismatch', NULL, NULL, NULL,
+                  'swing', 3, ?, 'Auto-closed by state recovery')
+        """,
+        (ticker, entry_iso, entry_price, quantity, exit_iso, strategy_id),
+    )
+    trade_id = int(conn.execute("SELECT last_insert_rowid()").fetchone()[0])
+    if with_position:
+        conn.execute(
+            """
+            INSERT INTO positions (
+                ticker, exchange, currency, quantity, entry_price, entry_time,
+                status, hold_type, phase, alpaca_order_id, strategy_id
+            ) VALUES (?, 'NYSE', 'USD', ?, ?, ?, 'CLOSED', 'swing', 3, ?, ?)
+            """,
+            (ticker, quantity, entry_price, entry_iso, entry_oid, strategy_id),
+        )
+    conn.commit()
+    return trade_id
+
+
+def _finder_returns(fill: ExitFill | None):
+    async def _f(client, position: ClosedPositionRow):
+        return fill
+    return _f
+
+
+async def _confirm_true(client, order_id: str) -> bool:
+    return True
+
+
+async def _confirm_false(client, order_id: str) -> bool:
+    return False
+
+
+def _row(conn, trade_id: int) -> dict:
+    cur = conn.execute("SELECT * FROM trades WHERE id = ?", (trade_id,))
+    cols = [c[0] for c in cur.description]
+    return dict(zip(cols, cur.fetchone()))
+
+
+# ---------------------------------------------------------------------------
+# load_stale_rows
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_load_stale_rows_selects_only_null_exit_mismatch(tmp_db):
+    old = NOW - timedelta(days=30)
+    keep = _insert_mismatch(tmp_db, ticker="XLF", entry_dt=old, exit_dt=old)
+    # A complete (already-resolved) row must NOT be selected.
+    tmp_db.execute(
+        """
+        INSERT INTO trades (ticker, exchange, currency, side, entry_time,
+            entry_price, quantity, exit_time, exit_price, exit_reason,
+            pnl_usd, hold_type, phase, strategy_id)
+        VALUES ('QQQ','NYSE','USD','BUY', ?, 100, 5, ?, 99, 'stop_loss',
+                -5, 'swing', 3, 'overnight_drift')
+        """,
+        (old.isoformat(), old.isoformat()),
+    )
+    tmp_db.commit()
+
+    rows, skipped = load_stale_rows(tmp_db, now=NOW)
+    assert {r.trade_id for r in rows} == {keep}
+    assert skipped == 0
+
+
+@pytest.mark.unit
+def test_load_stale_rows_age_gate_skips_young(tmp_db):
+    young = _insert_mismatch(tmp_db, ticker="XLF", entry_dt=NOW, exit_dt=NOW)  # same day
+    old = _insert_mismatch(tmp_db, ticker="XLE", entry_dt=NOW - timedelta(days=5),
+                           exit_dt=NOW - timedelta(days=5))
+    rows, skipped = load_stale_rows(tmp_db, now=NOW, min_age_days=2)
+    assert {r.trade_id for r in rows} == {old}
+    assert skipped == 1
+    assert young not in {r.trade_id for r in rows}
+
+
+@pytest.mark.unit
+def test_load_stale_rows_joins_position_order_ids(tmp_db):
+    old = NOW - timedelta(days=10)
+    _insert_mismatch(tmp_db, ticker="XLF", entry_dt=old, exit_dt=old, entry_oid="alp-xyz")
+    rows, _ = load_stale_rows(tmp_db, now=NOW)
+    assert rows[0].alpaca_order_id == "alp-xyz"
+
+
+@pytest.mark.unit
+def test_load_stale_rows_handles_missing_position(tmp_db):
+    """Attribution-less rows with no surviving position must still load (the
+    Root-Cause-A fix: trades-driven, not positions-driven)."""
+    old = NOW - timedelta(days=10)
+    tid = _insert_mismatch(tmp_db, ticker="XLB", strategy_id="unknown",
+                           entry_dt=old, exit_dt=old, with_position=False)
+    rows, _ = load_stale_rows(tmp_db, now=NOW)
+    assert {r.trade_id for r in rows} == {tid}
+    assert rows[0].alpaca_order_id is None
+
+
+# ---------------------------------------------------------------------------
+# resolve — decision tree
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_resolve_repairs_when_fill_found(tmp_db):
+    old = NOW - timedelta(days=10)
+    tid = _insert_mismatch(tmp_db, ticker="XLF", entry_dt=old, exit_dt=old,
+                           entry_price=100.0, quantity=10.0)
+    fill = ExitFill(order_id="sell-1", filled_at=old + timedelta(hours=2),
+                    filled_avg_price=101.0, filled_qty=10.0)
+
+    report = await resolve(tmp_db, client=None, now=NOW,
+                           fill_finder=_finder_returns(fill),
+                           entry_confirmer=_confirm_false)
+
+    assert report.repaired == 1 and report.voided == 0 and report.unresolved == 0
+    row = _row(tmp_db, tid)
+    assert row["exit_price"] == 101.0
+    assert row["exit_reason"] != "reconciliation_mismatch"
+    assert row["pnl_usd"] == pytest.approx(10.0)  # (101-100)*10
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_resolve_voids_when_no_fill_and_entry_unconfirmed(tmp_db):
+    old = NOW - timedelta(days=30)
+    tid = _insert_mismatch(tmp_db, ticker="XLK", entry_dt=old, exit_dt=old,
+                           entry_price=200.0, quantity=3.0)
+
+    report = await resolve(tmp_db, client=None, now=NOW,
+                           fill_finder=_finder_returns(None),
+                           entry_confirmer=_confirm_false)
+
+    assert report.voided == 1 and report.repaired == 0 and report.unresolved == 0
+    row = _row(tmp_db, tid)
+    assert row["exit_reason"] == "void_no_fill"
+    assert row["pnl_usd"] == 0
+    assert row["exit_price"] == 200.0  # entry_price -> flat scratch
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_resolve_flags_unresolved_when_entry_confirmed_filled(tmp_db):
+    old = NOW - timedelta(days=4)
+    tid = _insert_mismatch(tmp_db, ticker="MSFT", entry_dt=old, exit_dt=old)
+    alerts: list[tuple[str, str]] = []
+
+    report = await resolve(tmp_db, client=None, now=NOW,
+                           fill_finder=_finder_returns(None),
+                           entry_confirmer=_confirm_true,
+                           alert=lambda t, m: alerts.append((t, m)))
+
+    assert report.unresolved == 1 and report.voided == 0
+    row = _row(tmp_db, tid)
+    assert row["exit_reason"] == "unresolved_exit"
+    assert row["exit_price"] is None  # never fabricated
+    assert len(alerts) == 1  # batched, fired once
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_resolve_never_voids_confirmed_filled_row(tmp_db):
+    """Safety invariant: a row whose entry is provably filled must never be
+    zeroed — only flagged."""
+    old = NOW - timedelta(days=40)
+    tid = _insert_mismatch(tmp_db, ticker="XLV", entry_dt=old, exit_dt=old)
+    await resolve(tmp_db, client=None, now=NOW,
+                  fill_finder=_finder_returns(None), entry_confirmer=_confirm_true)
+    assert _row(tmp_db, tid)["exit_reason"] == "unresolved_exit"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_resolve_alert_batched_once_for_many(tmp_db):
+    old = NOW - timedelta(days=10)
+    for tk in ("AAA", "BBB", "CCC"):
+        _insert_mismatch(tmp_db, ticker=tk, entry_dt=old, exit_dt=old)
+    alerts: list[tuple[str, str]] = []
+    report = await resolve(tmp_db, client=None, now=NOW,
+                           fill_finder=_finder_returns(None),
+                           entry_confirmer=_confirm_true,
+                           alert=lambda t, m: alerts.append((t, m)))
+    assert report.unresolved == 3
+    assert len(alerts) == 1
+    assert "3" in alerts[0][1]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_resolve_dry_run_writes_nothing(tmp_db):
+    old = NOW - timedelta(days=30)
+    tid = _insert_mismatch(tmp_db, ticker="XLK", entry_dt=old, exit_dt=old)
+    report = await resolve(tmp_db, client=None, now=NOW, dry_run=True,
+                           fill_finder=_finder_returns(None),
+                           entry_confirmer=_confirm_false)
+    assert report.voided == 1  # counted
+    assert _row(tmp_db, tid)["exit_reason"] == "reconciliation_mismatch"  # untouched
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_resolve_is_idempotent(tmp_db):
+    old = NOW - timedelta(days=30)
+    _insert_mismatch(tmp_db, ticker="XLK", entry_dt=old, exit_dt=old)
+    first = await resolve(tmp_db, client=None, now=NOW,
+                          fill_finder=_finder_returns(None), entry_confirmer=_confirm_false)
+    second = await resolve(tmp_db, client=None, now=NOW,
+                           fill_finder=_finder_returns(None), entry_confirmer=_confirm_false)
+    assert first.voided == 1
+    assert second.candidates == 0  # nothing left to resolve
+
+
+# ---------------------------------------------------------------------------
+# confirm_entry_filled
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_confirm_entry_filled_empty_id_is_false():
+    assert await confirm_entry_filled(client=None, order_id="") is False
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_confirm_entry_filled_true_for_filled():
+    class _Status:
+        value = "filled"
+
+    class _Order:
+        status = _Status()
+
+    class _Client:
+        def get_order_by_id(self, oid):
+            return _Order()
+
+    assert await confirm_entry_filled(_Client(), "alp-1") is True
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_confirm_entry_filled_false_on_exception():
+    class _Client:
+        def get_order_by_id(self, oid):
+            raise RuntimeError("404")
+
+    assert await confirm_entry_filled(_Client(), "alp-1") is False
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_confirm_entry_filled_false_for_partial():
+    class _Status:
+        value = "partially_filled"
+
+    class _Order:
+        status = _Status()
+
+    class _Client:
+        def get_order_by_id(self, oid):
+            return _Order()
+
+    assert await confirm_entry_filled(_Client(), "alp-1") is False
+
+
+# ---------------------------------------------------------------------------
+# performance.py exclusion of terminal markers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_daily_metrics_excludes_void_and_unresolved(tmp_db_path):
+    import sqlite3
+
+    conn = sqlite3.connect(tmp_db_path)
+    et_day = "2026-04-30"
+    # one real trade, one void, one unresolved — only the real one counts.
+    conn.execute(
+        """INSERT INTO trades (ticker, exchange, currency, side, entry_time,
+           entry_price, quantity, exit_time, exit_price, exit_reason,
+           gross_pnl, pnl_usd, hold_type, phase, strategy_id)
+           VALUES ('SPY','NYSE','USD','BUY','2026-04-30T09:30:00-04:00',100,10,
+                   '2026-04-30T10:00:00-04:00',101,'take_profit',10,10,'swing',3,'mr')"""
+    )
+    conn.execute(
+        """INSERT INTO trades (ticker, exchange, currency, side, entry_time,
+           entry_price, quantity, exit_time, exit_price, exit_reason, pnl_usd,
+           hold_type, phase, strategy_id)
+           VALUES ('XLF','NYSE','USD','BUY','2026-04-30T09:30:00-04:00',50,10,
+                   '2026-04-30T10:00:00-04:00',50,'void_no_fill',0,'swing',3,'od')"""
+    )
+    conn.execute(
+        """INSERT INTO trades (ticker, exchange, currency, side, entry_time,
+           entry_price, quantity, exit_time, exit_price, exit_reason, pnl_usd,
+           hold_type, phase, strategy_id)
+           VALUES ('XLE','NYSE','USD','BUY','2026-04-30T09:30:00-04:00',60,10,
+                   '2026-04-30T10:00:00-04:00',NULL,'unresolved_exit',NULL,'swing',3,'od')"""
+    )
+    conn.commit()
+    conn.close()
+
+    metrics = PerformanceCalculator(tmp_db_path).calculate_daily_metrics(et_day)
+    assert metrics["total_trades"] == 1
+    assert metrics["wins"] == 1
+    assert metrics["net_pnl_usd"] == pytest.approx(10.0)


### PR DESCRIPTION
## Problem

The nightly `alpaca_backfill` only repairs `reconciliation_mismatch` trades rows **when a matching Alpaca SELL fill exists**. When the reconciler fired because a position was never actually held at the broker (phantom duplicate, or an entry that never filled), there is no fill to pair — so the row stays `exit_price=NULL` forever, retried every night, silently **inflating `total_trades` and corrupting per-strategy P&L**.

A read-only dry-run against today's DB found **55 stuck rows** accumulated since 2026-04-27 (0 with a repaired sibling — genuinely unhealed), dominated by the Apr 27–30 overnight_drift phantom-stop incident.

### Root causes (proven by dry-run)
- **A.** `load_candidates` is positions-driven and gated on `strategy_id != 'unknown'`, so attribution-less rows are never even attempted.
- **B.** `find_exit_fill` returns None for phantom rows (no SELL exists), and the backfill has **no terminal state** — it just gives up silently.

## Fix

New `self_improve/resolve_reconciliation_mismatch.py`, **trades-driven** (fixes A), run **after** the backfill in `daily-review.yml`. Per stale row ≥ 2 days old (so today's mismatches self-heal through the backfill first and are never voided prematurely):

1. Try the existing fill-pairing; repair via `insert_backfilled_trade`.
2. No fill → classify by the **entry** order at Alpaca:
   - entry never confirmed filled → **VOID**: `exit_price=entry_price`, `pnl=0`, `exit_reason='void_no_fill'` (phantom round-trip, realized no P&L).
   - entry confirmed filled, exit missing → `exit_reason='unresolved_exit'` + **batched ntfy alert**. Never fabricate a price.

**Safety invariant:** a row whose entry is provably filled is never voided — only flagged.

`performance.py` excludes the two new terminal `exit_reason`s from daily metrics so voided phantoms don't inflate `total_trades` (NULL-safe predicate).

## Validation

Read-only dry-run on today's DB (`resolve_cli --dry-run`):

```
53 candidates -> 4 repaired, 49 voided, 0 unresolved; 2 (today's XLF/XLE) skipped (too young)
```

The **4 repaired** are exactly the May-4 `unknown`-strategy rows that backfill's gate skips (Root Cause A) — recovered with **real P&L** instead of voided. The **49 voided** are the Apr phantom basket. **0 unresolved** → no real money to escalate.

- 16 new tests; touched suites (resolve + reporting + backfill) green.
- No strategy logic, `config.yaml`, or order path touched — pure data-integrity.

## Steady state & history
- The first nightly run after merge resolves all existing stale rows automatically (the job *is* the cleanup).
- Historical April `daily_summaries` **counts** stay cached until a one-shot wide `recompute_daily_summaries --days 45` is run (dollar impact is $0 — voids are $0; only trade counts). Can run post-merge.

## Test plan
- [x] `pytest trading_bot/tests/test_resolve_reconciliation_mismatch.py` (16 pass)
- [x] `ruff` clean on new/changed files
- [x] Read-only dry-run against real paper DB
- [ ] CI: static-checks + coverage (auto-merge gates on these)
- [ ] First nightly daily-review run after merge resolves the 53 rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)