### PR TITLE
chore: shelve opening_range_breakout (enabled: false)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -780,7 +780,11 @@ multi_strategy:
     # any scale-up. Conservative $1k allocation to start (others run $2.5k);
     # raise to 2500 after paper trades confirm clean execution.
     opening_range_breakout:
-      enabled: true
+      enabled: false               # SHELVED 2026-06-03 (#186): recent regime-matched
+                                   # walkforward fails — PF 0.907, OOS -1.37%, Sharpe -0.036,
+                                   # PF CI [0.648, 1.231]. 5.7y in-sample edge was front-loaded
+                                   # 2020-2022. Re-evaluate only on a regime shift.
+                                   # See trading_bot/docs/research/orb_exit_mismatch_2026-06-03.md
       allocation_usd: 1000.0       # conservative start; scale to 2500 after paper-confirm
       max_positions: 3
       range_bars: 6                # 6 × 5min = 30-min opening range


### PR DESCRIPTION
Disables the ORB sleeve per the analysis in #186.

**Why:** recent regime-matched walkforward fails even under favourable let-winners-run exits — PF **0.907**, OOS **−1.37%**, Sharpe −0.036, PF 95% CI **[0.648, 1.231]**. The 5.7y in-sample edge (+23.71%, PF 1.09) was front-loaded in 2020–2022. Live config backtests at PF 0.73 / −10.77% on its own exits (via #187's `--honor-strategy-exits`).

Book now runs on **overnight_drift** (engine) + **mean_reversion**. Re-evaluate ORB only on a regime shift.

Full report: `trading_bot/docs/research/orb_exit_mismatch_2026-06-03.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)