### PR TITLE
fix(orders): unwedge positions stuck in CLOSING with no exit in flight

### DIFF
--- a/trading_bot/execution/order_manager.py
+++ b/trading_bot/execution/order_manager.py
@@ -722,6 +722,50 @@ class OrderManager:
                 else:
                     await self._recover_missing_stop(trade_id, active)
 
+            # Watchdog: a position wedged in CLOSING with NO exit order in
+            # flight (alpaca_exit_order_id is None) is unrecoverable through
+            # the normal paths — place_exit / drain_disabled_sleeves refuse to
+            # act on a CLOSING row ("exit already in flight"), and the CLOSING
+            # fill-poll below requires an exit order id to advance. This state
+            # arises when a market flatten is submitted after the close and
+            # canceled without persisting its id (emergency_flatten is
+            # fire-and-forget), or when a tick dies between the canceled-exit
+            # rollback and the re-drive. The row then sits CLOSING + held
+            # indefinitely (XLI #147 sat 2 days, 2026-06-01 wind-down). If the
+            # broker still holds the shares, roll back to STOP_ACTIVE so the
+            # exit/drain path re-drives a proper RTH flatten next tick (the
+            # protective stop is re-attached by the block above). If the broker
+            # no longer holds it, the exit already happened — leave it for the
+            # strategy-exit / StateRecovery close path. Guard on a positive
+            # broker qty so a transient lookup failure (returns None) never
+            # rolls back a position that is genuinely mid-close.
+            if (
+                active.status == PositionStatus.CLOSING
+                and active.alpaca_exit_order_id is None
+                and active.filled_shares > 0
+            ):
+                held_qty: float | None = await self._broker_held_qty(active.ticker)
+                if held_qty is not None and held_qty > 1e-6:
+                    logger.warning(
+                        "Position %s (trade_id=%d) wedged in CLOSING with no "
+                        "exit order in flight but %.6f still held at broker — "
+                        "rolling back to STOP_ACTIVE so the exit path re-drives.",
+                        active.ticker, trade_id, held_qty,
+                    )
+                    active.status = PositionStatus.STOP_ACTIVE
+                    self._update_position_status(
+                        trade_id, PositionStatus.STOP_ACTIVE,
+                    )
+                    await self._notifier.send(
+                        "Unwedged stuck CLOSING position",
+                        f"{active.ticker} was stuck in CLOSING with no exit "
+                        f"order in flight ({held_qty:.4f} held); rolled back "
+                        f"to STOP_ACTIVE for re-exit.",
+                        priority=4,
+                        tags=["warning"],
+                    )
+                    continue
+
             # Strategy-driven exit (place_exit / place_limit_exit). Without
             # this branch the row stays CLOSING until the next tick's
             # StateRecovery reconciles it as 'reconciliation_mismatch',

--- a/trading_bot/tests/test_order_manager_winddown_wedge.py
+++ b/trading_bot/tests/test_order_manager_winddown_wedge.py
@@ -1,0 +1,136 @@
+"""Watchdog: unwedge a position stuck in CLOSING with no exit order in flight.
+
+Regression for XLI position #147 (2026-06-01 wind-down): an after-hours market
+flatten was canceled without persisting its order id, leaving the position
+CLOSING + held for 2 days. place_exit / drain_disabled_sleeves refuse to act on
+a CLOSING row, and the CLOSING fill-poll needs an exit id — so the row was
+unrecoverable. `_check_order_statuses` now rolls such a position back to
+STOP_ACTIVE when the broker still holds the shares.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from unittest.mock import MagicMock
+
+import pytest
+
+from trading_bot.constants import PositionStatus
+from trading_bot.execution.order_manager import (
+    EntryDecision,
+    OrderManager,
+    _ActiveOrder,
+)
+
+pytestmark = pytest.mark.critical
+
+
+def _make_om(config, db_path: str, notifier) -> OrderManager:
+    gw = MagicMock()
+    gw.client = MagicMock()
+    return OrderManager(gw, config, notifier, db_path)
+
+
+def _entry(ticker: str = "XLI", price: float = 172.76) -> EntryDecision:
+    return EntryDecision(
+        ticker=ticker, exchange="US", side="BUY", shares=1.0, limit_price=price,
+        stop_price=price * 0.98, target_price=price * 1.04,
+        hold_type="intraday", sector="Industrials", phase=3,
+        sentiment_score=0.0, signals="test", currency="USD",
+        strategy_id="opening_range_breakout",
+    )
+
+
+def _seed_closing_no_exit(om: OrderManager, *, qty: float = 0.1143) -> int:
+    """Seed a position stuck in CLOSING with no exit order id (the wedge)."""
+    trade_id = om._create_position_record(_entry())
+    assert trade_id is not None
+    active = _ActiveOrder(
+        trade_id=trade_id, ticker="XLI", exchange="US", side="BUY",
+        status=PositionStatus.CLOSING, entry_shares=qty, filled_shares=qty,
+        entry_price=172.76, stop_price=170.0, target_price=180.0,
+        db_trade_id=om._pending_db_trade_ids.get(trade_id),
+    )
+    active.alpaca_exit_order_id = None
+    active.alpaca_stop_order_id = None
+    om._active_orders[trade_id] = active
+    om._update_position_status(trade_id, PositionStatus.CLOSING)
+    return trade_id
+
+
+def _db_status(db_path: str, trade_id: int) -> str:
+    conn = sqlite3.connect(db_path)
+    try:
+        row = conn.execute(
+            "SELECT status FROM positions WHERE id = ?", (trade_id,)
+        ).fetchone()
+        return row[0] if row else ""
+    finally:
+        conn.close()
+
+
+def _broker_holds(qty: str):
+    pos = MagicMock()
+    pos.qty = qty
+    return MagicMock(return_value=pos)
+
+
+@pytest.mark.asyncio
+async def test_wedged_closing_held_rolls_back_to_stop_active(
+    config, tmp_db_path: str, mock_notifier
+):
+    om = _make_om(config, tmp_db_path, mock_notifier)
+    trade_id = _seed_closing_no_exit(om)
+    # Broker still holds the shares.
+    om._gw.client.get_open_position = _broker_holds("0.1143")
+
+    await om._check_order_statuses()
+
+    assert om._active_orders[trade_id].status == PositionStatus.STOP_ACTIVE, (
+        "wedged CLOSING+held position must roll back to STOP_ACTIVE"
+    )
+    assert _db_status(tmp_db_path, trade_id) == PositionStatus.STOP_ACTIVE.value, (
+        "rollback must be persisted (stateless tick rehydrates from DB)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_wedged_closing_not_held_left_alone(
+    config, tmp_db_path: str, mock_notifier
+):
+    from alpaca.common.exceptions import APIError
+
+    om = _make_om(config, tmp_db_path, mock_notifier)
+    trade_id = _seed_closing_no_exit(om)
+    # Broker has NO position — it already exited; do not resurrect it.
+    om._gw.client.get_open_position = MagicMock(
+        side_effect=APIError({"message": "position not found"})
+    )
+
+    await om._check_order_statuses()
+
+    assert om._active_orders[trade_id].status == PositionStatus.CLOSING, (
+        "not held at broker -> leave CLOSING for the close/recovery path"
+    )
+
+
+@pytest.mark.asyncio
+async def test_closing_with_exit_id_not_touched_by_watchdog(
+    config, tmp_db_path: str, mock_notifier
+):
+    """A CLOSING row WITH a live exit order id is a normal in-flight close —
+    the watchdog must not roll it back (the fill-poll branch owns it)."""
+    om = _make_om(config, tmp_db_path, mock_notifier)
+    trade_id = _seed_closing_no_exit(om)
+    om._active_orders[trade_id].alpaca_exit_order_id = "exit-123"
+    # Exit order still working (not filled/canceled).
+    pending = MagicMock()
+    pending.status.value = "new"
+    om._gw.client.get_order_by_id = MagicMock(return_value=pending)
+    om._gw.client.get_open_position = _broker_holds("0.1143")
+
+    await om._check_order_statuses()
+
+    assert om._active_orders[trade_id].status == PositionStatus.CLOSING, (
+        "an in-flight close (exit id present, order working) must stay CLOSING"
+    )


### PR DESCRIPTION
## The bug (live: XLI #147, held 2 days)
A position can land in `status=CLOSING` with `alpaca_exit_order_id=NULL` and **stay there indefinitely while still held at the broker**. Every recovery path is blocked by the `CLOSING` status:
- `_check_order_statuses`' CLOSING fill-poll needs an exit order id to advance;
- `place_exit` / `drain_disabled_sleeves` **refuse** to act on `CLOSING` ("exit already in flight");
- `StateRecovery` sees the broker still holds it (DB+broker agree) → flags no mismatch.

**What happened:** XLI bought 2026-06-01 14:40 ET. Wind-down DAY limit expired at the close; the escalation **MARKET** flatten was submitted at **16:05 ET — after the 16:00 close** → Alpaca **canceled** it, and `emergency_flatten` (fire-and-forget) never persisted the order id. Result: `CLOSING` + held for 2 days, protected only by a re-attached morning stop.

## The fix
A watchdog in `_check_order_statuses`: when a position is `CLOSING` with **no exit order id** AND the **broker still holds** the shares, roll it back to `STOP_ACTIVE` (persisted) so the normal exit/drain path re-drives a proper RTH flatten next tick. Guarded on a positive broker qty so a transient lookup failure never resurrects a genuinely-closed position. **Recovers the wedge regardless of which path created it.**

Auto-resolves XLI #147 on the next live tick (→ STOP_ACTIVE → `drain_disabled_sleeves` flattens it, since ORB is now disabled).

## Scope (deliberate)
This is the robust catch-all. Two complementary hardenings to the **last-resort flatten path** are deferred to a focused follow-up (that path is the kill-switch/drawdown safety mechanism and deserves separate review):
- **A:** don't submit a market flatten after the close (it's canceled);
- **B:** have `emergency_flatten` persist `CLOSING` + the exit order id so a cancel is recoverable via the existing rollback.

## Tests
- [x] `test_order_manager_winddown_wedge.py` — held→rollback, not-held→left alone, in-flight-close→untouched (3 pass)
- [x] order-manager / lifecycle / recovery suites green (171 pass)
- [ ] CI: static-checks + coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)