### PR TITLE
feat(reconcile): Phase 0 broker-truth invariant guard (observer-only)

### DIFF
--- a/trading_bot/execution/invariant_guard.py
+++ b/trading_bot/execution/invariant_guard.py
@@ -1,0 +1,427 @@
+"""Phase 0 invariant guard — a per-tick, observer-only consistency check.
+
+This is **Phase 0** of the broker-truth reconciliation-loop design
+(``trading_bot/docs/research/reconciliation_loop_design.md``, PR #191). It
+catches the *entire* DB↔broker lifecycle bug class **as a class**, with one
+assertion per drift mode, instead of one reactive point-fix per new way the
+local SQLite state machine can diverge from Alpaca.
+
+It **takes no corrective action** — it reads broker truth (positions + open
+orders) and the DB-open rows, derives every position's consistency, and
+*reports* divergences. The existing healers (``StateRecovery``,
+``reconcile_open_position_stops``, ``_check_order_statuses``) keep doing the
+actual repair. The guard's job is **early-warning + evidence-gathering**: run
+it for ~1 week in paper to quantify how often each divergence really fires
+before the later phases let the reconciler drive behaviour.
+
+Four invariants, each mapping to a historical incident class:
+
+| Invariant | Condition | Caught by point-fixes |
+|---|---|---|
+| ``naked``   | broker holds it, **no** protective stop on the book | #118 / #169 |
+| ``wedge``   | DB row ``CLOSING`` but broker **still holds** it     | #190        |
+| ``orphan``  | DB row open-ish but broker **does not** hold it      | #65–#70     |
+| ``unknown`` | broker holds a ticker with **no** open DB row        | orphan attr |
+
+**>1-tick persistence gate.** Several of these states are *legitimate* for a
+single tick — a fresh fill lags Alpaca's positions endpoint, an exit order is
+in flight, an overnight_drift entry hasn't had its standalone stop attached
+yet. So a violation only **escalates** to a CRITICAL log + push notification
+once it has been seen on **two consecutive ticks**. The first sighting is
+logged at INFO and remembered (in ``tick_state`` under
+``_INVARIANT_GUARD_KEY``); transient one-tick blips self-resolve and never
+page the operator. This mirrors the design's "inconsistent for > 1 tick" rule.
+
+The guard is pure where it matters: :func:`derive_violations` is a side-effect-
+free function of (broker view, DB rows) and is the unit-test surface.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sqlite3
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from trading_bot.constants import PositionStatus, TERMINAL_POSITION_STATUSES
+
+if TYPE_CHECKING:
+    from alpaca.trading.models import Order as AlpacaOrder
+    from alpaca.trading.models import Position as AlpacaPosition
+
+    from trading_bot.gateway import GatewayConnection
+    from trading_bot.notifications import Notifier
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+# A position smaller than this (in shares) is treated as flat. Alpaca holds
+# fractional quantities down to 1/1e6, so an int() truncation would mask a
+# real sub-1-share holding — compare with a float tolerance instead.
+_QTY_EPSILON: float = 1e-6
+
+# tick_state key under which the guard journals the currently-violating
+# (kind:ticker) set, so the next tick can tell a persistent divergence from a
+# transient one-tick blip.
+_INVARIANT_GUARD_KEY: str = "__invariant_guard__"
+
+# Alpaca order types that count as a protective stop on the book. Matches the
+# convention in ``StateRecovery._verify_stop_orders`` (stop / trailing_stop)
+# plus stop_limit, since a stop-limit exit is equally protective.
+_PROTECTIVE_ORDER_TYPES: frozenset[str] = frozenset(
+    {"stop", "stop_limit", "trailing_stop"}
+)
+
+# DB statuses that assert "this position should be held at the broker right
+# now". ENTRY_PENDING is deliberately excluded — it has not filled yet, so the
+# broker legitimately does not hold it (that is not an orphan). CLOSING is
+# excluded here because it is handled by the dedicated ``wedge`` invariant.
+_HELD_EXPECTED_STATUSES: frozenset[str] = frozenset(
+    {
+        PositionStatus.POSITION_OPEN.value,
+        PositionStatus.STOP_ACTIVE.value,
+        PositionStatus.TRAILING_ACTIVE.value,
+    }
+)
+
+# Invariant kind identifiers (stable strings — used as journal keys).
+KIND_NAKED: str = "naked"
+KIND_WEDGE: str = "wedge"
+KIND_ORPHAN: str = "orphan"
+KIND_UNKNOWN: str = "unknown"
+
+
+@dataclass(frozen=True)
+class BrokerView:
+    """An immutable snapshot of the broker's truth for one tick.
+
+    ``held_qty`` maps ticker -> signed share quantity for every position the
+    broker actually holds (|qty| > epsilon). ``tickers_with_stop`` is the set
+    of tickers with at least one protective stop/stop_limit/trailing_stop
+    order resting on the book.
+    """
+
+    held_qty: dict[str, float]
+    tickers_with_stop: frozenset[str]
+
+    def is_held(self, ticker: str) -> bool:
+        return abs(self.held_qty.get(ticker, 0.0)) > _QTY_EPSILON
+
+    def has_stop(self, ticker: str) -> bool:
+        return ticker in self.tickers_with_stop
+
+    @classmethod
+    def from_alpaca(
+        cls,
+        positions: list[AlpacaPosition],
+        orders: list[AlpacaOrder],
+    ) -> BrokerView:
+        """Build a :class:`BrokerView` from raw Alpaca position/order lists."""
+        held: dict[str, float] = {}
+        for pos in positions:
+            ticker: str = str(pos.symbol)
+            qty: float = float(pos.qty or 0)
+            if abs(qty) > _QTY_EPSILON:
+                held[ticker] = qty
+
+        with_stop: set[str] = set()
+        for order in orders:
+            order_type = getattr(order, "type", None)
+            type_val: str = (getattr(order_type, "value", "") or "").lower()
+            if type_val in _PROTECTIVE_ORDER_TYPES:
+                with_stop.add(str(order.symbol))
+
+        return cls(held_qty=dict(held), tickers_with_stop=frozenset(with_stop))
+
+
+@dataclass(frozen=True)
+class InvariantViolation:
+    """A single DB↔broker inconsistency found on one tick."""
+
+    kind: str  # one of KIND_NAKED / KIND_WEDGE / KIND_ORPHAN / KIND_UNKNOWN
+    ticker: str
+    detail: str
+
+    @property
+    def key(self) -> str:
+        """Stable identity used for cross-tick persistence tracking."""
+        return f"{self.kind}:{self.ticker}"
+
+    def describe(self) -> str:
+        return f"[{self.kind}] {self.ticker}: {self.detail}"
+
+
+@dataclass
+class GuardResult:
+    """Outcome of one guard run."""
+
+    rows_checked: int = 0
+    broker_positions: int = 0
+    violations: list[InvariantViolation] = field(default_factory=list)
+    # Subset of ``violations`` seen on the previous tick too (> 1 tick) — the
+    # ones that escalate to CRITICAL + notification.
+    escalated: list[InvariantViolation] = field(default_factory=list)
+
+    @property
+    def has_violations(self) -> bool:
+        return bool(self.violations)
+
+    def summary(self) -> str:
+        if not self.violations:
+            return (
+                f"invariant guard: {self.rows_checked} DB rows / "
+                f"{self.broker_positions} broker positions consistent"
+            )
+        lines: list[str] = [
+            f"invariant guard: {len(self.violations)} violation(s) "
+            f"({len(self.escalated)} persistent) across "
+            f"{self.rows_checked} DB rows / {self.broker_positions} broker "
+            f"positions:",
+        ]
+        for v in self.violations:
+            persisted: str = " (PERSISTENT)" if v in self.escalated else ""
+            lines.append(f"  - {v.describe()}{persisted}")
+        return "\n".join(lines)
+
+
+def derive_violations(
+    broker: BrokerView,
+    db_rows: list[dict[str, Any]],
+) -> list[InvariantViolation]:
+    """Pure derivation of every DB↔broker invariant violation for one tick.
+
+    Args:
+        broker: the broker truth snapshot for this tick.
+        db_rows: DB ``positions`` rows in any non-terminal state (the caller
+            loads ``status NOT IN (CLOSED, ENTRY_FAILED)``). Each row is a
+            mapping with at least ``ticker`` and ``status``.
+
+    Returns:
+        A deterministic list of :class:`InvariantViolation`, ordered by kind
+        then ticker, with no side effects. This is the unit-test surface.
+    """
+    violations: list[InvariantViolation] = []
+
+    # Index DB rows by ticker for the "broker holds an unknown ticker" check.
+    # A ticker is "known" if any non-terminal row references it.
+    open_tickers: set[str] = set()
+    for row in db_rows:
+        status: str = str(row.get("status", "") or "")
+        if status in TERMINAL_POSITION_STATUSES:
+            continue
+        ticker: str = str(row.get("ticker", "") or "")
+        if not ticker:
+            continue
+        open_tickers.add(ticker)
+
+        held: bool = broker.is_held(ticker)
+
+        # ORPHAN — DB says we hold it, broker disagrees.
+        if status in _HELD_EXPECTED_STATUSES and not held:
+            violations.append(
+                InvariantViolation(
+                    kind=KIND_ORPHAN,
+                    ticker=ticker,
+                    detail=(
+                        f"DB status={status} but broker does not hold it "
+                        f"(expected an open position)"
+                    ),
+                )
+            )
+            continue
+
+        # WEDGE — exit requested (CLOSING) but broker still holds it.
+        if status == PositionStatus.CLOSING.value and held:
+            qty: float = broker.held_qty.get(ticker, 0.0)
+            violations.append(
+                InvariantViolation(
+                    kind=KIND_WEDGE,
+                    ticker=ticker,
+                    detail=(
+                        f"DB status=CLOSING but broker still holds "
+                        f"qty={qty:.6f} (exit never completed)"
+                    ),
+                )
+            )
+            continue
+
+        # NAKED — broker holds it but there is no protective stop on the book.
+        if held and not broker.has_stop(ticker):
+            qty = broker.held_qty.get(ticker, 0.0)
+            violations.append(
+                InvariantViolation(
+                    kind=KIND_NAKED,
+                    ticker=ticker,
+                    detail=(
+                        f"broker holds qty={qty:.6f} (DB status={status}) "
+                        f"with no protective stop on the book"
+                    ),
+                )
+            )
+
+    # UNKNOWN — broker holds a ticker the DB has no open row for.
+    for ticker in broker.held_qty:
+        if ticker in open_tickers:
+            continue
+        qty = broker.held_qty[ticker]
+        held_naked: str = (
+            "" if broker.has_stop(ticker) else " and no protective stop"
+        )
+        violations.append(
+            InvariantViolation(
+                kind=KIND_UNKNOWN,
+                ticker=ticker,
+                detail=(
+                    f"broker holds qty={qty:.6f} with no open DB row"
+                    f"{held_naked}"
+                ),
+            )
+        )
+
+    violations.sort(key=lambda v: (v.kind, v.ticker))
+    return violations
+
+
+def _load_db_open_positions(db_path: str) -> list[dict[str, Any]]:
+    """Load every non-terminal ``positions`` row as plain dicts."""
+    try:
+        conn: sqlite3.Connection = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+        try:
+            cursor = conn.execute(
+                "SELECT id, ticker, status, quantity, strategy_id "
+                "FROM positions WHERE status NOT IN ('CLOSED', 'ENTRY_FAILED')"
+            )
+            return [dict(row) for row in cursor.fetchall()]
+        finally:
+            conn.close()
+    except sqlite3.OperationalError:
+        logger.warning("invariant guard: positions table unreadable", exc_info=True)
+        return []
+
+
+def _load_prev_violation_keys(db_path: str) -> set[str]:
+    """Return the violation keys journaled on the previous tick."""
+    from trading_bot.db import repository as repo
+
+    try:
+        conn: sqlite3.Connection = sqlite3.connect(db_path)
+        try:
+            row: dict[str, Any] | None = repo.load_tick_state(
+                conn, _INVARIANT_GUARD_KEY
+            )
+        finally:
+            conn.close()
+    except sqlite3.OperationalError:
+        logger.warning("invariant guard: tick_state unreadable", exc_info=True)
+        return set()
+    if row is None:
+        return set()
+    keys = row.get("state", {}).get("violation_keys", [])
+    return {str(k) for k in keys}
+
+
+def _save_violation_keys(db_path: str, keys: set[str]) -> None:
+    """Journal the current violation keys for the next tick's persistence gate."""
+    from trading_bot.db import repository as repo
+
+    try:
+        conn: sqlite3.Connection = sqlite3.connect(db_path)
+        try:
+            repo.save_tick_state(
+                conn,
+                _INVARIANT_GUARD_KEY,
+                last_bar_ts=None,
+                state={"violation_keys": sorted(keys)},
+            )
+        finally:
+            conn.close()
+    except sqlite3.OperationalError:
+        logger.warning(
+            "invariant guard: failed to journal violation keys", exc_info=True
+        )
+
+
+async def run_invariant_guard(
+    db_path: str,
+    gateway: GatewayConnection,
+    notifier: Notifier | None = None,
+) -> GuardResult:
+    """Run the Phase 0 observer-only invariant guard for one tick.
+
+    Reads broker truth (one ``get_positions`` + one ``get_open_orders``
+    round-trip), loads DB-open rows, derives every invariant violation, and
+    escalates those that have now persisted for **two consecutive ticks** to a
+    CRITICAL log + (if a notifier is supplied) a push notification. First-tick
+    violations are logged at INFO only and remembered.
+
+    Takes **no corrective action** — see the module docstring. Safe to call on
+    every tick and to ignore the return value.
+    """
+    positions: list[AlpacaPosition] = await gateway.get_positions()
+    orders: list[AlpacaOrder] = await gateway.get_open_orders()
+    broker: BrokerView = BrokerView.from_alpaca(positions, orders)
+
+    db_rows: list[dict[str, Any]] = await asyncio.to_thread(
+        _load_db_open_positions, db_path
+    )
+
+    violations: list[InvariantViolation] = derive_violations(broker, db_rows)
+    result: GuardResult = GuardResult(
+        rows_checked=len(db_rows),
+        broker_positions=len(broker.held_qty),
+        violations=violations,
+    )
+
+    prev_keys: set[str] = await asyncio.to_thread(
+        _load_prev_violation_keys, db_path
+    )
+    current_keys: set[str] = {v.key for v in violations}
+
+    # Persistence gate: escalate only what was already violating last tick.
+    result.escalated = [v for v in violations if v.key in prev_keys]
+
+    await asyncio.to_thread(_save_violation_keys, db_path, current_keys)
+
+    if not violations:
+        logger.info("%s", result.summary())
+        return result
+
+    # First-tick (transient) violations: INFO only, no page.
+    first_seen: list[InvariantViolation] = [
+        v for v in violations if v.key not in prev_keys
+    ]
+    if first_seen:
+        logger.info(
+            "invariant guard: %d new violation(s) this tick (not yet "
+            "escalated — may be a transient one-tick window):\n%s",
+            len(first_seen),
+            "\n".join(f"  - {v.describe()}" for v in first_seen),
+        )
+
+    if not result.escalated:
+        return result
+
+    # Persistent (> 1 tick) violations: loud + paged.
+    logger.critical(
+        "invariant guard: %d PERSISTENT DB↔broker violation(s) "
+        "(inconsistent > 1 tick):\n%s",
+        len(result.escalated),
+        "\n".join(f"  - {v.describe()}" for v in result.escalated),
+    )
+    if notifier is not None:
+        body: str = "\n".join(v.describe() for v in result.escalated)
+        await notifier.send(
+            "Broker/DB Invariant Violation",
+            (
+                f"{len(result.escalated)} position(s) have been inconsistent "
+                f"with broker truth for more than one tick. The in-tick "
+                f"healers should converge these — investigate any that "
+                f"persist.\n\n{body}"
+            ),
+            priority=4,
+            tags=["rotating_light"],
+        )
+
+    return result

--- a/trading_bot/main.py
+++ b/trading_bot/main.py
@@ -39,6 +39,7 @@ from trading_bot.data.market_data import MarketDataManager
 from trading_bot.data.sentiment import SentimentAnalyzer
 from trading_bot.db import repository as repo
 from trading_bot.db.migrations import run_migrations
+from trading_bot.execution.invariant_guard import run_invariant_guard
 from trading_bot.execution.loss_cooldown import LossCooldownConfig, LossCooldownTracker
 from trading_bot.execution.order_manager import OrderManager
 from trading_bot.execution.risk_manager import RiskManager
@@ -360,6 +361,25 @@ class TradingBot:
             except Exception:
                 logger.warning(
                     "Naked-position reconciliation failed (non-fatal)",
+                    exc_info=True,
+                )
+
+            # --- 6c. Broker-truth invariant guard (Phase 0, observer-only) ---
+            # The reconciliation-loop design's Phase 0 (PR #191): one
+            # assertion per DB<->broker drift mode (naked / wedge / orphan /
+            # unknown), escalating only when a divergence persists > 1 tick.
+            # Catches the lifecycle bug class AS A CLASS. Takes no action —
+            # the healers above/below do the repair; this is early-warning
+            # and evidence-gathering before later phases drive behaviour.
+            try:
+                await run_invariant_guard(
+                    db_path=self._db_path,
+                    gateway=self._gateway,
+                    notifier=self._notifier,
+                )
+            except Exception:
+                logger.warning(
+                    "Invariant guard failed (non-fatal)",
                     exc_info=True,
                 )
 

--- a/trading_bot/tests/test_invariant_guard.py
+++ b/trading_bot/tests/test_invariant_guard.py
@@ -1,0 +1,315 @@
+"""Tests for the Phase 0 broker-truth invariant guard (PR #191 / #191 design).
+
+Covers:
+- :func:`BrokerView.from_alpaca` snapshot construction (qty epsilon, stop types).
+- :func:`derive_violations` — the pure, side-effect-free derivation surface, one
+  case per invariant (naked / wedge / orphan / unknown) plus the clean and
+  legitimate-pending cases that must NOT flag.
+- :func:`run_invariant_guard` — the >1-tick persistence gate: a fresh violation
+  is logged but not paged; the same violation on a second consecutive tick
+  escalates and notifies; a resolved violation clears the journal.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from unittest.mock import MagicMock
+
+import pytest
+
+from trading_bot.constants import PositionStatus
+from trading_bot.execution.invariant_guard import (
+    KIND_NAKED,
+    KIND_ORPHAN,
+    KIND_UNKNOWN,
+    KIND_WEDGE,
+    BrokerView,
+    derive_violations,
+    run_invariant_guard,
+)
+
+pytestmark = pytest.mark.critical
+
+
+# ---------------------------------------------------------------------------
+# Builders
+# ---------------------------------------------------------------------------
+
+
+def _alpaca_position(symbol: str, qty: float):
+    p = MagicMock()
+    p.symbol = symbol
+    p.qty = qty
+    return p
+
+
+def _alpaca_order(symbol: str, order_type: str):
+    o = MagicMock()
+    o.symbol = symbol
+    o.type = MagicMock()
+    o.type.value = order_type
+    return o
+
+
+def _db_row(
+    ticker: str,
+    status: str,
+    *,
+    quantity: float = 1.0,
+    strategy_id: str = "mean_reversion",
+    trade_id: int = 1,
+) -> dict[str, object]:
+    return {
+        "id": trade_id,
+        "ticker": ticker,
+        "status": status,
+        "quantity": quantity,
+        "strategy_id": strategy_id,
+    }
+
+
+# ---------------------------------------------------------------------------
+# BrokerView.from_alpaca
+# ---------------------------------------------------------------------------
+
+
+class TestBrokerView:
+    def test_sub_epsilon_position_treated_as_flat(self) -> None:
+        view = BrokerView.from_alpaca(
+            [_alpaca_position("SPY", 1e-9)], []
+        )
+        assert view.is_held("SPY") is False
+        assert view.held_qty == {}
+
+    def test_fractional_position_is_held(self) -> None:
+        view = BrokerView.from_alpaca(
+            [_alpaca_position("SPY", 0.3181)], []
+        )
+        assert view.is_held("SPY") is True
+        assert view.held_qty["SPY"] == pytest.approx(0.3181)
+
+    @pytest.mark.parametrize(
+        "order_type,expected",
+        [
+            ("stop", True),
+            ("stop_limit", True),
+            ("trailing_stop", True),
+            ("limit", False),
+            ("market", False),
+        ],
+    )
+    def test_protective_stop_detection(
+        self, order_type: str, expected: bool
+    ) -> None:
+        view = BrokerView.from_alpaca(
+            [_alpaca_position("SPY", 1.0)],
+            [_alpaca_order("SPY", order_type)],
+        )
+        assert view.has_stop("SPY") is expected
+
+
+# ---------------------------------------------------------------------------
+# derive_violations — pure surface
+# ---------------------------------------------------------------------------
+
+
+class TestDeriveViolations:
+    def test_clean_position_no_violation(self) -> None:
+        broker = BrokerView.from_alpaca(
+            [_alpaca_position("SPY", 1.0)],
+            [_alpaca_order("SPY", "stop")],
+        )
+        rows = [_db_row("SPY", PositionStatus.STOP_ACTIVE.value)]
+        assert derive_violations(broker, rows) == []
+
+    def test_naked_position(self) -> None:
+        # Broker holds it, but no protective stop on the book.
+        broker = BrokerView.from_alpaca([_alpaca_position("SPY", 1.0)], [])
+        rows = [_db_row("SPY", PositionStatus.POSITION_OPEN.value)]
+        violations = derive_violations(broker, rows)
+        assert len(violations) == 1
+        assert violations[0].kind == KIND_NAKED
+        assert violations[0].ticker == "SPY"
+
+    def test_wedge_position(self) -> None:
+        # DB says CLOSING, broker still holds it (the #190 wedge).
+        broker = BrokerView.from_alpaca(
+            [_alpaca_position("XLI", 0.5)],
+            [_alpaca_order("XLI", "stop")],
+        )
+        rows = [_db_row("XLI", PositionStatus.CLOSING.value)]
+        violations = derive_violations(broker, rows)
+        assert len(violations) == 1
+        assert violations[0].kind == KIND_WEDGE
+
+    def test_orphan_position(self) -> None:
+        # DB says open, broker does not hold it (the #65-#70 orphan).
+        broker = BrokerView.from_alpaca([], [])
+        rows = [_db_row("QQQ", PositionStatus.STOP_ACTIVE.value)]
+        violations = derive_violations(broker, rows)
+        assert len(violations) == 1
+        assert violations[0].kind == KIND_ORPHAN
+
+    def test_unknown_broker_position(self) -> None:
+        # Broker holds a ticker the DB has no open row for.
+        broker = BrokerView.from_alpaca([_alpaca_position("XLE", 2.0)], [])
+        violations = derive_violations(broker, [])
+        assert len(violations) == 1
+        assert violations[0].kind == KIND_UNKNOWN
+        assert violations[0].ticker == "XLE"
+
+    def test_entry_pending_not_held_is_not_orphan(self) -> None:
+        # ENTRY_PENDING has not filled yet — the broker legitimately does
+        # not hold it. This must NOT be flagged as an orphan.
+        broker = BrokerView.from_alpaca([], [])
+        rows = [_db_row("SPY", PositionStatus.ENTRY_PENDING.value)]
+        assert derive_violations(broker, rows) == []
+
+    def test_terminal_rows_ignored(self) -> None:
+        broker = BrokerView.from_alpaca([], [])
+        rows = [
+            _db_row("SPY", PositionStatus.CLOSED.value),
+            _db_row("QQQ", PositionStatus.ENTRY_FAILED.value),
+        ]
+        assert derive_violations(broker, rows) == []
+
+    def test_multiple_violations_sorted_deterministically(self) -> None:
+        broker = BrokerView.from_alpaca(
+            [
+                _alpaca_position("SPY", 1.0),  # naked
+                _alpaca_position("ZZZ", 1.0),  # unknown
+            ],
+            [],
+        )
+        rows = [
+            _db_row("SPY", PositionStatus.POSITION_OPEN.value),
+            _db_row("QQQ", PositionStatus.STOP_ACTIVE.value),  # orphan
+        ]
+        violations = derive_violations(broker, rows)
+        kinds = [(v.kind, v.ticker) for v in violations]
+        # Sorted by (kind, ticker): naked < orphan < unknown.
+        assert kinds == [
+            (KIND_NAKED, "SPY"),
+            (KIND_ORPHAN, "QQQ"),
+            (KIND_UNKNOWN, "ZZZ"),
+        ]
+
+
+# ---------------------------------------------------------------------------
+# run_invariant_guard — persistence gate (integration with tick_state)
+# ---------------------------------------------------------------------------
+
+
+def _insert_position(db_path: str, ticker: str, status: str) -> None:
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            "INSERT INTO positions "
+            "(ticker, exchange, currency, quantity, entry_price, entry_time, "
+            "status, hold_type, phase, strategy_id) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                ticker,
+                "US",
+                "USD",
+                1.0,
+                100.0,
+                "2026-06-04T10:00:00-04:00",
+                status,
+                "intraday",
+                3,
+                "mean_reversion",
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+class TestPersistenceGate:
+    @pytest.mark.asyncio
+    async def test_first_tick_does_not_escalate(
+        self, tmp_db_path: str, mock_gateway, mock_notifier
+    ) -> None:
+        _insert_position(
+            tmp_db_path, "SPY", PositionStatus.STOP_ACTIVE.value
+        )
+        # Broker does not hold SPY -> orphan, but it's the first sighting.
+        result = await run_invariant_guard(
+            tmp_db_path, mock_gateway, mock_notifier
+        )
+        assert result.has_violations
+        assert result.escalated == []
+        mock_notifier.send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_second_consecutive_tick_escalates_and_pages(
+        self, tmp_db_path: str, mock_gateway, mock_notifier
+    ) -> None:
+        _insert_position(
+            tmp_db_path, "SPY", PositionStatus.STOP_ACTIVE.value
+        )
+        await run_invariant_guard(tmp_db_path, mock_gateway, mock_notifier)
+        # Same divergence still present on the next tick.
+        result = await run_invariant_guard(
+            tmp_db_path, mock_gateway, mock_notifier
+        )
+        assert len(result.escalated) == 1
+        assert result.escalated[0].kind == KIND_ORPHAN
+        mock_notifier.send.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_resolved_violation_clears_and_does_not_page(
+        self, tmp_db_path: str, mock_gateway, mock_notifier
+    ) -> None:
+        _insert_position(
+            tmp_db_path, "SPY", PositionStatus.STOP_ACTIVE.value
+        )
+        await run_invariant_guard(tmp_db_path, mock_gateway, mock_notifier)
+
+        # Resolve it: mark CLOSED so it's no longer open.
+        conn = sqlite3.connect(tmp_db_path)
+        conn.execute(
+            "UPDATE positions SET status = ? WHERE ticker = ?",
+            (PositionStatus.CLOSED.value, "SPY"),
+        )
+        conn.commit()
+        conn.close()
+
+        result = await run_invariant_guard(
+            tmp_db_path, mock_gateway, mock_notifier
+        )
+        assert result.has_violations is False
+        assert result.escalated == []
+        mock_notifier.send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_transient_then_new_violation_not_escalated(
+        self, tmp_db_path: str, mock_gateway, mock_notifier
+    ) -> None:
+        # Tick 1: SPY orphan. Tick 2: SPY resolved, QQQ orphan appears.
+        # QQQ is brand new on tick 2 -> must not escalate even though a
+        # violation existed on tick 1.
+        _insert_position(
+            tmp_db_path, "SPY", PositionStatus.STOP_ACTIVE.value
+        )
+        await run_invariant_guard(tmp_db_path, mock_gateway, mock_notifier)
+
+        conn = sqlite3.connect(tmp_db_path)
+        conn.execute(
+            "UPDATE positions SET status = ? WHERE ticker = ?",
+            (PositionStatus.CLOSED.value, "SPY"),
+        )
+        conn.commit()
+        conn.close()
+        _insert_position(
+            tmp_db_path, "QQQ", PositionStatus.STOP_ACTIVE.value
+        )
+
+        result = await run_invariant_guard(
+            tmp_db_path, mock_gateway, mock_notifier
+        )
+        assert len(result.violations) == 1
+        assert result.violations[0].ticker == "QQQ"
+        assert result.escalated == []
+        mock_notifier.send.assert_not_called()


### PR DESCRIPTION
Implements **Phase 0** of the broker-truth reconciliation-loop design ([#191](https://github.com/alex5imon/ai-broker/pull/191)) — "ship the invariant guard next."

## What

A per-tick, **observer-only** consistency check (`trading_bot/execution/invariant_guard.py`) that derives each position's status from **broker truth** (one `get_positions` + one `get_open_orders`) and flags DB↔broker divergence **as a class**, rather than one reactive point-fix per drift mode.

Four invariants, each mapping to a historical incident class:

| Invariant | Condition | Caught by point-fixes |
|---|---|---|
| `naked`   | broker holds it, **no** protective stop on the book | #118 / #169 |
| `wedge`   | DB row `CLOSING` but broker **still holds** it       | #190        |
| `orphan`  | DB row open-ish but broker **does not** hold it      | #65–#70     |
| `unknown` | broker holds a ticker with **no** open DB row        | orphan attr |

## >1-tick persistence gate

Several of these states are legitimate for a single tick (fresh-fill lag on Alpaca's positions endpoint, exit order in flight, overnight_drift entry before its standalone stop attaches). So a violation **only escalates** to a CRITICAL log + push notification once it has been seen on **two consecutive ticks**. The first sighting is logged at INFO and journaled in `tick_state`; transient one-tick blips self-resolve and never page. This mirrors the design's "inconsistent for > 1 tick" rule.

## Safety

- **Takes no corrective action.** The existing healers (`StateRecovery`, `reconcile_open_position_stops`, `_check_order_statuses`) still do the repair. This is early-warning + evidence-gathering for ~1 week in paper before later phases let the reconciler drive behaviour.
- Wired into the tick at step **6c**, right after the existing naked-position reconciliation, wrapped in a non-fatal try/except like its neighbours.
- `derive_violations()` is a pure function of `(BrokerView, DB rows)` — no I/O, fully deterministic.

## Test plan

- [x] 19 new tests (`test_invariant_guard.py`, `@pytest.mark.critical`):
  - `BrokerView.from_alpaca`: sub-epsilon qty → flat, fractional → held, stop/stop_limit/trailing_stop detection.
  - `derive_violations`: one case per invariant; must-not-flag cases (`ENTRY_PENDING` not-held, terminal rows ignored); deterministic sort.
  - Persistence gate: first-tick quiet, second-tick escalates+pages, resolve clears journal, transient-then-new does not escalate.
- [x] `ruff check .` clean
- [x] `mypy --ignore-missing-imports` (CI scope) clean
- [x] `bandit -ll` clean, `vulture --min-confidence 80` clean
- [x] Full `-m critical` suite: 265 passed
- [x] Recovery + lifecycle regression suites: 62 passed

## Follow-ups (per design §5, not in this PR)

- Phase 1 — `broker_snapshot()` + `derive_desired_state()` in shadow mode
- Phase 2 — reconciler owns the `status` column; retire reactive patches
- Phase 3 — retire the out-of-band repair scripts
