### PR TITLE
feat(reconcile): Phase 1 shadow reconciler — broker-truth desired-state derivation

### DIFF
--- a/trading_bot/execution/reconciler.py
+++ b/trading_bot/execution/reconciler.py
@@ -1,0 +1,311 @@
+"""Phase 1 reconciler — broker-truth desired-state derivation, in SHADOW mode.
+
+This is **Phase 1** of the broker-truth reconciliation-loop design
+(``trading_bot/docs/research/reconciliation_loop_design.md``, PR #191; Phase 0
+shipped in #192). It builds the two primitives the eventual controller loop is
+made of:
+
+1. :func:`broker_snapshot` — the single source of truth for a tick (Alpaca
+   positions + open orders), reusing the :class:`BrokerView` snapshot type
+   from the Phase 0 guard.
+2. :func:`derive_desired_state` — a **pure** function mapping
+   ``(intent, broker)`` to the disposition the reconciler *would* drive, one
+   row per the design's §3 table.
+
+In Phase 1 these only **observe**: :func:`run_shadow_reconcile` derives a
+disposition for every position each tick and logs where the derived state
+**disagrees** with the live SQLite state machine (the DB ``status`` column).
+**No behaviour changes** and **nothing is paged** — Phase 0's invariant guard
+already owns alerting. The shadow log quantifies how well the reconciler's
+brain matches reality before Phase 2 lets it drive the ``status`` column.
+
+The §3 disposition table this implements:
+
+| Broker says            | Intent (DB status)       | Desired state    |
+|------------------------|--------------------------|------------------|
+| held, has stop         | open                     | ``PROTECTED``    |
+| held, no stop          | open                     | ``NEEDS_STOP``   |
+| held                   | exit requested (CLOSING) | ``FLATTEN``      |
+| not held               | open / CLOSING           | ``CLOSED``       |
+| held                   | entry pending            | ``OPEN`` (adopt) |
+| not held               | entry pending            | ``PENDING_ENTRY``|
+| held, no matching row  | (none)                   | ``ADOPT``        |
+
+:func:`derive_desired_state` and :func:`derive_disposition` are pure and are
+the unit-test surface.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sqlite3
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+from trading_bot.constants import PositionStatus
+from trading_bot.execution.invariant_guard import BrokerView
+
+if TYPE_CHECKING:
+    from trading_bot.gateway import GatewayConnection
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+# DB statuses asserting "this position should be held at the broker now".
+_OPEN_STATUSES: frozenset[str] = frozenset(
+    {
+        PositionStatus.POSITION_OPEN.value,
+        PositionStatus.STOP_ACTIVE.value,
+        PositionStatus.TRAILING_ACTIVE.value,
+    }
+)
+
+
+class DesiredState(str, Enum):
+    """The disposition the reconciler would drive a position toward.
+
+    Derived purely from broker truth + the recorded intent — never
+    transitioned locally. Phase 1 only logs these; Phase 2 acts on them.
+    """
+
+    PROTECTED = "PROTECTED"        # held + protective stop, intent open
+    NEEDS_STOP = "NEEDS_STOP"      # held, no stop on book, intent open
+    FLATTEN = "FLATTEN"            # intent CLOSING, broker still holds it
+    CLOSED = "CLOSED"              # not held, intent open/closing -> exit done
+    OPEN = "OPEN"                  # entry filled (held) while intent pending
+    PENDING_ENTRY = "PENDING_ENTRY"  # entry order still working, not held
+    ADOPT = "ADOPT"               # broker holds it, no DB intent row
+    UNKNOWN = "UNKNOWN"           # unexpected DB status — investigate
+
+
+# Human-readable convergence action the reconciler WOULD take per state. Used
+# only for the shadow log in Phase 1; Phase 2 wires these to real handlers.
+_ACTION_BY_STATE: dict[DesiredState, str] = {
+    DesiredState.PROTECTED: "none (protected)",
+    DesiredState.NEEDS_STOP: "attach stop (idempotent)",
+    DesiredState.FLATTEN: "re-submit flatten iff RTH + no live exit order",
+    DesiredState.CLOSED: "journal exit from broker truth",
+    DesiredState.OPEN: "adopt broker qty/price -> POSITION_OPEN",
+    DesiredState.PENDING_ENTRY: "none (entry order working)",
+    DesiredState.ADOPT: "adopt unknown broker position / investigate lineage",
+    DesiredState.UNKNOWN: "investigate (unexpected DB status)",
+}
+
+
+@dataclass(frozen=True)
+class PositionIntent:
+    """What the DB says we *meant* to hold for one ticker (the intent journal).
+
+    In the reconciliation-loop model the DB row is an intent record, not an
+    authoritative state machine. Phase 1 reads only the fields needed to
+    derive a disposition; later phases will carry stop/target prices too.
+    """
+
+    trade_id: int
+    ticker: str
+    status: str
+    quantity: float
+    strategy_id: str | None = None
+
+    @classmethod
+    def from_row(cls, row: dict[str, Any]) -> PositionIntent:
+        return cls(
+            trade_id=int(row.get("id", 0) or 0),
+            ticker=str(row.get("ticker", "") or ""),
+            status=str(row.get("status", "") or ""),
+            quantity=float(row.get("quantity", 0) or 0),
+            strategy_id=(
+                str(row["strategy_id"]) if row.get("strategy_id") else None
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class Disposition:
+    """A derived desired-state for one ticker, plus the shadow comparison."""
+
+    ticker: str
+    intent_status: str | None  # DB status; None for an ADOPT (no DB row)
+    desired: DesiredState
+    action: str
+    agrees_with_db: bool       # would the reconciler leave the DB untouched?
+
+    def describe(self) -> str:
+        intent: str = self.intent_status or "(no DB row)"
+        flag: str = "OK " if self.agrees_with_db else "DIFF"
+        return (
+            f"{flag} {self.ticker}: db={intent} -> desired={self.desired.value} "
+            f"| would: {self.action}"
+        )
+
+
+def derive_desired_state(intent: PositionIntent, broker: BrokerView) -> DesiredState:
+    """Pure derivation of the desired disposition for one position.
+
+    Implements the design's §3 table from broker truth (held / has-stop) and
+    the recorded DB status. No side effects — the unit-test surface.
+    """
+    held: bool = broker.is_held(intent.ticker)
+    has_stop: bool = broker.has_stop(intent.ticker)
+    status: str = intent.status
+
+    if status == PositionStatus.ENTRY_PENDING.value:
+        return DesiredState.OPEN if held else DesiredState.PENDING_ENTRY
+
+    if status == PositionStatus.CLOSING.value:
+        return DesiredState.FLATTEN if held else DesiredState.CLOSED
+
+    if status in _OPEN_STATUSES:
+        if not held:
+            return DesiredState.CLOSED
+        return DesiredState.PROTECTED if has_stop else DesiredState.NEEDS_STOP
+
+    # Terminal statuses are never loaded as intents; anything else is an
+    # unexpected status the reconciler should surface rather than silently map.
+    return DesiredState.UNKNOWN
+
+
+def _db_reflects(desired: DesiredState, status: str) -> bool:
+    """True iff the live DB status already matches the derived disposition.
+
+    Agreement means "the reconciler would make no change" — so disagreements
+    are exactly the cases Phase 2 would act on. PROTECTED agrees with any open
+    status (the POSITION_OPEN-vs-STOP_ACTIVE distinction is cosmetic when the
+    broker stop is on the book); FLATTEN agrees with CLOSING (intent already
+    recorded, action merely pending). NEEDS_STOP / CLOSED / OPEN / UNKNOWN
+    never have a status that "reflects" them on a non-terminal row.
+    """
+    if desired == DesiredState.PROTECTED:
+        return status in _OPEN_STATUSES
+    if desired == DesiredState.PENDING_ENTRY:
+        return status == PositionStatus.ENTRY_PENDING.value
+    if desired == DesiredState.FLATTEN:
+        return status == PositionStatus.CLOSING.value
+    return False
+
+
+def derive_disposition(intent: PositionIntent, broker: BrokerView) -> Disposition:
+    """Derive the full :class:`Disposition` (state + action + agreement)."""
+    desired: DesiredState = derive_desired_state(intent, broker)
+    return Disposition(
+        ticker=intent.ticker,
+        intent_status=intent.status,
+        desired=desired,
+        action=_ACTION_BY_STATE[desired],
+        agrees_with_db=_db_reflects(desired, intent.status),
+    )
+
+
+def derive_adopt(ticker: str, broker: BrokerView) -> Disposition:
+    """Disposition for a broker position with no matching open DB row."""
+    return Disposition(
+        ticker=ticker,
+        intent_status=None,
+        desired=DesiredState.ADOPT,
+        action=_ACTION_BY_STATE[DesiredState.ADOPT],
+        agrees_with_db=False,
+    )
+
+
+def derive_all_dispositions(
+    intents: list[PositionIntent], broker: BrokerView
+) -> list[Disposition]:
+    """Pure: derive a disposition for every intent + every unmatched broker hold."""
+    dispositions: list[Disposition] = [
+        derive_disposition(intent, broker) for intent in intents
+    ]
+    matched: set[str] = {intent.ticker for intent in intents}
+    for ticker in broker.held_qty:
+        if ticker not in matched:
+            dispositions.append(derive_adopt(ticker, broker))
+    # Disagreements first (agrees_with_db False < True), then by ticker.
+    dispositions.sort(key=lambda d: (d.agrees_with_db, d.ticker))
+    return dispositions
+
+
+@dataclass
+class ShadowReconcileResult:
+    """Outcome of one shadow-mode reconcile pass."""
+
+    dispositions: list[Disposition] = field(default_factory=list)
+
+    @property
+    def disagreements(self) -> list[Disposition]:
+        return [d for d in self.dispositions if not d.agrees_with_db]
+
+    @property
+    def agreement_count(self) -> int:
+        return sum(1 for d in self.dispositions if d.agrees_with_db)
+
+    def summary(self) -> str:
+        total: int = len(self.dispositions)
+        diff: int = len(self.disagreements)
+        head: str = (
+            f"shadow reconcile: {total - diff}/{total} dispositions agree with "
+            f"the live state machine ({diff} would change)"
+        )
+        if not self.dispositions:
+            return "shadow reconcile: no open positions"
+        lines: list[str] = [head]
+        for d in self.dispositions:
+            lines.append(f"  {d.describe()}")
+        return "\n".join(lines)
+
+
+def _load_intents(db_path: str) -> list[PositionIntent]:
+    """Load every non-terminal ``positions`` row as a :class:`PositionIntent`."""
+    try:
+        conn: sqlite3.Connection = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+        try:
+            cursor = conn.execute(
+                "SELECT id, ticker, status, quantity, strategy_id "
+                "FROM positions WHERE status NOT IN ('CLOSED', 'ENTRY_FAILED')"
+            )
+            return [PositionIntent.from_row(dict(row)) for row in cursor.fetchall()]
+        finally:
+            conn.close()
+    except sqlite3.OperationalError:
+        logger.warning("shadow reconcile: positions table unreadable", exc_info=True)
+        return []
+
+
+async def broker_snapshot(gateway: GatewayConnection) -> BrokerView:
+    """Fetch the broker's truth for this tick (positions + open orders).
+
+    One ``get_positions`` + one ``get_open_orders`` round-trip — the single
+    source of truth the reconciler derives from.
+    """
+    positions = await gateway.get_positions()
+    orders = await gateway.get_open_orders()
+    return BrokerView.from_alpaca(positions, orders)
+
+
+async def run_shadow_reconcile(
+    db_path: str,
+    gateway: GatewayConnection,
+) -> ShadowReconcileResult:
+    """Run the Phase 1 reconciler in SHADOW mode for one tick (read-only).
+
+    Derives a desired disposition for every open position and logs where the
+    derivation disagrees with the live SQLite state machine. Takes **no**
+    action and pages **nothing** (Phase 0's guard owns alerting). Safe to call
+    every tick and ignore the result.
+    """
+    broker: BrokerView = await broker_snapshot(gateway)
+    intents: list[PositionIntent] = await asyncio.to_thread(_load_intents, db_path)
+
+    dispositions: list[Disposition] = derive_all_dispositions(intents, broker)
+    result: ShadowReconcileResult = ShadowReconcileResult(dispositions=dispositions)
+
+    logger.info("%s", result.summary())
+    if result.disagreements:
+        logger.warning(
+            "shadow reconcile: %d disposition(s) would change under the "
+            "reconciler (Phase 1 is observe-only — no action taken):\n%s",
+            len(result.disagreements),
+            "\n".join(f"  - {d.describe()}" for d in result.disagreements),
+        )
+    return result

--- a/trading_bot/main.py
+++ b/trading_bot/main.py
@@ -42,6 +42,7 @@ from trading_bot.db.migrations import run_migrations
 from trading_bot.execution.invariant_guard import run_invariant_guard
 from trading_bot.execution.loss_cooldown import LossCooldownConfig, LossCooldownTracker
 from trading_bot.execution.order_manager import OrderManager
+from trading_bot.execution.reconciler import run_shadow_reconcile
 from trading_bot.execution.risk_manager import RiskManager
 from trading_bot.execution.stop_reconciler import reconcile_open_position_stops
 from trading_bot.gateway.connection import GatewayConnection
@@ -380,6 +381,24 @@ class TradingBot:
             except Exception:
                 logger.warning(
                     "Invariant guard failed (non-fatal)",
+                    exc_info=True,
+                )
+
+            # --- 6d. Shadow reconciler (Phase 1, read-only) ---
+            # The reconciliation-loop design's Phase 1 (PR #191): derive each
+            # position's desired state from broker truth (the §3 table) and
+            # log where the derivation disagrees with the live SQLite state
+            # machine. Validates the reconciler's brain against reality before
+            # Phase 2 lets it own the status column. Observe-only — no action,
+            # no paging (Phase 0's guard owns alerting).
+            try:
+                await run_shadow_reconcile(
+                    db_path=self._db_path,
+                    gateway=self._gateway,
+                )
+            except Exception:
+                logger.warning(
+                    "Shadow reconcile failed (non-fatal)",
                     exc_info=True,
                 )
 

--- a/trading_bot/tests/test_reconciler.py
+++ b/trading_bot/tests/test_reconciler.py
@@ -1,0 +1,276 @@
+"""Tests for the Phase 1 shadow reconciler (PR #191 design, follows #192).
+
+Covers:
+- :func:`derive_desired_state` — one case per row of the design's §3
+  disposition table (the pure derivation surface).
+- :func:`derive_disposition` — the agreement flag (would the reconciler change
+  the DB?) for the cases that matter.
+- :func:`derive_all_dispositions` — ADOPT of unmatched broker holds + the
+  disagreements-first ordering.
+- :func:`run_shadow_reconcile` — read-only integration over a temp DB +
+  mock gateway: takes no action, pages nothing, reports disagreements.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from unittest.mock import MagicMock
+
+import pytest
+
+from trading_bot.constants import PositionStatus
+from trading_bot.execution.invariant_guard import BrokerView
+from trading_bot.execution.reconciler import (
+    DesiredState,
+    PositionIntent,
+    derive_all_dispositions,
+    derive_desired_state,
+    derive_disposition,
+    run_shadow_reconcile,
+)
+
+pytestmark = pytest.mark.critical
+
+
+# ---------------------------------------------------------------------------
+# Builders
+# ---------------------------------------------------------------------------
+
+
+def _alpaca_position(symbol: str, qty: float):
+    p = MagicMock()
+    p.symbol = symbol
+    p.qty = qty
+    return p
+
+
+def _alpaca_order(symbol: str, order_type: str):
+    o = MagicMock()
+    o.symbol = symbol
+    o.type = MagicMock()
+    o.type.value = order_type
+    return o
+
+
+def _broker(*, held: dict[str, float] | None = None, stops: list[str] | None = None):
+    positions = [
+        _alpaca_position(sym, qty) for sym, qty in (held or {}).items()
+    ]
+    orders = [_alpaca_order(sym, "stop") for sym in (stops or [])]
+    return BrokerView.from_alpaca(positions, orders)
+
+
+def _intent(ticker: str, status: str, qty: float = 1.0) -> PositionIntent:
+    return PositionIntent(
+        trade_id=1, ticker=ticker, status=status, quantity=qty,
+        strategy_id="mean_reversion",
+    )
+
+
+# ---------------------------------------------------------------------------
+# derive_desired_state — the §3 table
+# ---------------------------------------------------------------------------
+
+
+class TestDeriveDesiredState:
+    def test_held_with_stop_open_is_protected(self) -> None:
+        broker = _broker(held={"SPY": 1.0}, stops=["SPY"])
+        intent = _intent("SPY", PositionStatus.STOP_ACTIVE.value)
+        assert derive_desired_state(intent, broker) == DesiredState.PROTECTED
+
+    def test_held_no_stop_open_is_needs_stop(self) -> None:
+        broker = _broker(held={"SPY": 1.0})
+        intent = _intent("SPY", PositionStatus.POSITION_OPEN.value)
+        assert derive_desired_state(intent, broker) == DesiredState.NEEDS_STOP
+
+    def test_closing_still_held_is_flatten(self) -> None:
+        broker = _broker(held={"XLI": 0.5}, stops=["XLI"])
+        intent = _intent("XLI", PositionStatus.CLOSING.value)
+        assert derive_desired_state(intent, broker) == DesiredState.FLATTEN
+
+    def test_closing_not_held_is_closed(self) -> None:
+        broker = _broker()
+        intent = _intent("XLI", PositionStatus.CLOSING.value)
+        assert derive_desired_state(intent, broker) == DesiredState.CLOSED
+
+    def test_open_not_held_is_closed(self) -> None:
+        broker = _broker()
+        intent = _intent("QQQ", PositionStatus.STOP_ACTIVE.value)
+        assert derive_desired_state(intent, broker) == DesiredState.CLOSED
+
+    def test_entry_pending_held_is_open(self) -> None:
+        broker = _broker(held={"SPY": 1.0})
+        intent = _intent("SPY", PositionStatus.ENTRY_PENDING.value)
+        assert derive_desired_state(intent, broker) == DesiredState.OPEN
+
+    def test_entry_pending_not_held_is_pending(self) -> None:
+        broker = _broker()
+        intent = _intent("SPY", PositionStatus.ENTRY_PENDING.value)
+        assert derive_desired_state(intent, broker) == DesiredState.PENDING_ENTRY
+
+    def test_unexpected_status_is_unknown(self) -> None:
+        broker = _broker(held={"SPY": 1.0})
+        intent = _intent("SPY", "WEIRD_STATUS")
+        assert derive_desired_state(intent, broker) == DesiredState.UNKNOWN
+
+
+# ---------------------------------------------------------------------------
+# derive_disposition — agreement with the live DB
+# ---------------------------------------------------------------------------
+
+
+class TestAgreement:
+    def test_protected_agrees_with_open_statuses(self) -> None:
+        broker = _broker(held={"SPY": 1.0}, stops=["SPY"])
+        for status in (
+            PositionStatus.POSITION_OPEN.value,
+            PositionStatus.STOP_ACTIVE.value,
+            PositionStatus.TRAILING_ACTIVE.value,
+        ):
+            disp = derive_disposition(_intent("SPY", status), broker)
+            assert disp.desired == DesiredState.PROTECTED
+            assert disp.agrees_with_db is True
+
+    def test_needs_stop_disagrees(self) -> None:
+        # DB thinks it's protected (STOP_ACTIVE) but the broker has no stop.
+        broker = _broker(held={"SPY": 1.0})
+        disp = derive_disposition(
+            _intent("SPY", PositionStatus.STOP_ACTIVE.value), broker
+        )
+        assert disp.desired == DesiredState.NEEDS_STOP
+        assert disp.agrees_with_db is False
+
+    def test_flatten_agrees_with_closing(self) -> None:
+        # Intent already recorded as CLOSING — action pending, but DB reflects it.
+        broker = _broker(held={"XLI": 1.0}, stops=["XLI"])
+        disp = derive_disposition(
+            _intent("XLI", PositionStatus.CLOSING.value), broker
+        )
+        assert disp.desired == DesiredState.FLATTEN
+        assert disp.agrees_with_db is True
+
+    def test_closed_disagrees(self) -> None:
+        broker = _broker()
+        disp = derive_disposition(
+            _intent("QQQ", PositionStatus.STOP_ACTIVE.value), broker
+        )
+        assert disp.desired == DesiredState.CLOSED
+        assert disp.agrees_with_db is False
+
+    def test_pending_entry_agrees(self) -> None:
+        broker = _broker()
+        disp = derive_disposition(
+            _intent("SPY", PositionStatus.ENTRY_PENDING.value), broker
+        )
+        assert disp.desired == DesiredState.PENDING_ENTRY
+        assert disp.agrees_with_db is True
+
+
+# ---------------------------------------------------------------------------
+# derive_all_dispositions — adopt + ordering
+# ---------------------------------------------------------------------------
+
+
+class TestDeriveAll:
+    def test_unmatched_broker_hold_is_adopted(self) -> None:
+        broker = _broker(held={"XLE": 2.0})
+        dispositions = derive_all_dispositions([], broker)
+        assert len(dispositions) == 1
+        assert dispositions[0].desired == DesiredState.ADOPT
+        assert dispositions[0].ticker == "XLE"
+        assert dispositions[0].intent_status is None
+        assert dispositions[0].agrees_with_db is False
+
+    def test_disagreements_sorted_first(self) -> None:
+        # SPY protected (agree), QQQ orphan (disagree), XLE adopt (disagree).
+        broker = _broker(held={"SPY": 1.0, "XLE": 1.0}, stops=["SPY"])
+        intents = [
+            _intent("SPY", PositionStatus.STOP_ACTIVE.value),
+            _intent("QQQ", PositionStatus.STOP_ACTIVE.value),
+        ]
+        dispositions = derive_all_dispositions(intents, broker)
+        # Disagreements (sorted by ticker) come before agreements.
+        order = [(d.ticker, d.agrees_with_db) for d in dispositions]
+        assert order == [("QQQ", False), ("XLE", False), ("SPY", True)]
+
+
+# ---------------------------------------------------------------------------
+# run_shadow_reconcile — read-only integration
+# ---------------------------------------------------------------------------
+
+
+def _insert_position(db_path: str, ticker: str, status: str) -> None:
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            "INSERT INTO positions "
+            "(ticker, exchange, currency, quantity, entry_price, entry_time, "
+            "status, hold_type, phase, strategy_id) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                ticker, "US", "USD", 1.0, 100.0,
+                "2026-06-04T10:00:00-04:00", status, "intraday", 3,
+                "mean_reversion",
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+class TestShadowReconcile:
+    @pytest.mark.asyncio
+    async def test_all_consistent_no_disagreements(
+        self, tmp_db_path: str, mock_gateway
+    ) -> None:
+        _insert_position(
+            tmp_db_path, "SPY", PositionStatus.STOP_ACTIVE.value
+        )
+        mock_gateway.get_positions.return_value = [_alpaca_position("SPY", 1.0)]
+        mock_gateway.get_open_orders.return_value = [_alpaca_order("SPY", "stop")]
+
+        result = await run_shadow_reconcile(tmp_db_path, mock_gateway)
+        assert result.disagreements == []
+        assert result.agreement_count == 1
+
+    @pytest.mark.asyncio
+    async def test_naked_position_flagged_as_disagreement(
+        self, tmp_db_path: str, mock_gateway
+    ) -> None:
+        # DB says STOP_ACTIVE; broker holds it with no stop -> NEEDS_STOP.
+        _insert_position(
+            tmp_db_path, "SPY", PositionStatus.STOP_ACTIVE.value
+        )
+        mock_gateway.get_positions.return_value = [_alpaca_position("SPY", 1.0)]
+        mock_gateway.get_open_orders.return_value = []
+
+        result = await run_shadow_reconcile(tmp_db_path, mock_gateway)
+        assert len(result.disagreements) == 1
+        assert result.disagreements[0].desired == DesiredState.NEEDS_STOP
+
+    @pytest.mark.asyncio
+    async def test_takes_no_action_on_broker(
+        self, tmp_db_path: str, mock_gateway
+    ) -> None:
+        # Orphan: DB open, broker flat. Phase 1 must NOT submit/cancel orders.
+        _insert_position(
+            tmp_db_path, "QQQ", PositionStatus.STOP_ACTIVE.value
+        )
+        mock_gateway.get_positions.return_value = []
+        mock_gateway.get_open_orders.return_value = []
+
+        result = await run_shadow_reconcile(tmp_db_path, mock_gateway)
+        assert len(result.disagreements) == 1
+        assert result.disagreements[0].desired == DesiredState.CLOSED
+        # Read-only: no order placement / cancellation on the gateway.
+        mock_gateway.client.submit_order.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_empty_db_empty_broker(
+        self, tmp_db_path: str, mock_gateway
+    ) -> None:
+        mock_gateway.get_positions.return_value = []
+        mock_gateway.get_open_orders.return_value = []
+        result = await run_shadow_reconcile(tmp_db_path, mock_gateway)
+        assert result.dispositions == []
+        assert result.disagreements == []


### PR DESCRIPTION
Implements **Phase 1** of the broker-truth reconciliation-loop design ([#191](https://github.com/alex5imon/ai-broker/pull/191)), building on the Phase 0 guard ([#192](https://github.com/alex5imon/ai-broker/pull/192)).

## What

Builds the two primitives the eventual controller loop is made of, and runs them in **shadow mode** (`trading_bot/execution/reconciler.py`):

1. **`broker_snapshot(gateway)`** — the single source of truth for a tick (Alpaca positions + open orders), reusing Phase 0's `BrokerView`.
2. **`derive_desired_state(intent, broker)`** — a **pure** function mapping `(intent, broker)` to the disposition the reconciler *would* drive, one row per the design's §3 table:

| Broker says | Intent (DB status) | Desired state | Would-action |
|---|---|---|---|
| held, has stop | open | `PROTECTED` | none |
| held, no stop | open | `NEEDS_STOP` | attach stop |
| held | CLOSING | `FLATTEN` | re-submit flatten (RTH) |
| not held | open / CLOSING | `CLOSED` | journal exit |
| held | entry pending | `OPEN` | adopt qty/price |
| not held | entry pending | `PENDING_ENTRY` | none |
| held, no DB row | (none) | `ADOPT` | investigate |

## Shadow mode (read-only)

`run_shadow_reconcile()` runs each tick (`main.py` step 6d): it derives a disposition for every open position + every unmatched broker hold, and **logs where the derivation disagrees with the live SQLite state machine** — i.e. exactly where Phase 2's reconciler would change the `status` column.

- **Takes no action** and **pages nothing.** Phase 0's invariant guard already owns alerting; Phase 1 is purely "validate the reconciler's brain against live reality before it drives anything" (design §5).
- Disagreements logged at WARNING, the full disposition table at INFO. Wired in non-fatal, like its neighbours.

## Test plan

- [x] 19 new tests (`test_reconciler.py`, `@pytest.mark.critical`):
  - `derive_desired_state`: one case per §3 row (incl. UNKNOWN for an unexpected status).
  - Agreement flag: PROTECTED agrees with any open status, FLATTEN agrees with CLOSING, NEEDS_STOP/CLOSED disagree.
  - `derive_all_dispositions`: ADOPT of unmatched broker holds; disagreements-first ordering.
  - `run_shadow_reconcile`: read-only integration — naked → NEEDS_STOP, orphan → CLOSED, **asserts no `submit_order` call** (proves read-only), empty/empty.
- [x] `ruff check .` clean · `mypy` (CI scope) clean · `bandit -ll` clean · `vulture --min-confidence 80` clean
- [x] Full `-m critical` suite: **284 passed**

## Follow-ups (design §5)

- Phase 2 — reconciler owns the `status` column; trigger existing action paths (`_place_standalone_stop`, `place_exit`) from the convergence step; delete reactive patches as their cases are provably covered.
- Phase 3 — retire the out-of-band repair scripts to a thin nightly audit.
