### PR TITLE
feat(reconcile): Phase 2a — reconciler owns status (drive flag, default off)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -410,6 +410,22 @@ recovery:
   fresh_entry_grace_minutes: 10
 
 # -----------------------------------------------------------------------------
+# Broker-truth reconciler (reconciliation-loop design, PR #191)
+# -----------------------------------------------------------------------------
+reconciler:
+  # Phase 2 drive switch. When false (default), the reconciler runs in
+  # SHADOW mode each tick: it derives each position's desired state from
+  # broker truth and only LOGS where that diverges from the live SQLite
+  # state machine — no behaviour change. When true, the derived state OWNS
+  # the DB `status` column for the lossless transitions the reconciler can
+  # safely drive from positive broker evidence (e.g. normalize a held +
+  # broker-stopped row from POSITION_OPEN to STOP_ACTIVE). Order-submitting
+  # actions (attach stop, flatten, journal exit) stay with the existing
+  # healers regardless. Flip to true only after the shadow log has been
+  # quiet/consistent for several paper days (design §5 gate).
+  drive: false
+
+# -----------------------------------------------------------------------------
 # Exit Parameters - Swing
 # -----------------------------------------------------------------------------
 exit_swing:

--- a/trading_bot/execution/reconciler.py
+++ b/trading_bot/execution/reconciler.py
@@ -131,6 +131,7 @@ class Disposition:
     desired: DesiredState
     action: str
     agrees_with_db: bool       # would the reconciler leave the DB untouched?
+    trade_id: int | None = None  # DB positions.id; None for an ADOPT
 
     def describe(self) -> str:
         intent: str = self.intent_status or "(no DB row)"
@@ -195,6 +196,7 @@ def derive_disposition(intent: PositionIntent, broker: BrokerView) -> Dispositio
         desired=desired,
         action=_ACTION_BY_STATE[desired],
         agrees_with_db=_db_reflects(desired, intent.status),
+        trade_id=intent.trade_id,
     )
 
 
@@ -225,11 +227,198 @@ def derive_all_dispositions(
     return dispositions
 
 
+# ---------------------------------------------------------------------------
+# Phase 2 — convergence (status ownership), gated by the `reconciler.drive`
+# flag. With the flag OFF (default) this layer plans + logs but executes
+# nothing: behaviour is identical to Phase 1 shadow mode. With it ON, the
+# reconciler OWNS the DB `status` column for the *lossless, DB-only*
+# transitions it can safely drive from positive broker evidence; every
+# order-submitting or P&L-bearing action is delegated to the existing healers
+# (StateRecovery / OrderManager) and only logged here. Deleting those reactive
+# patches is Phase 2b, gated on shadow-agreement evidence (design §5).
+# ---------------------------------------------------------------------------
+
+
+class ConvergenceOp(str, Enum):
+    """The kind of convergence step a disposition implies."""
+
+    NONE = "NONE"                          # already converged — nothing to do
+    NORMALIZE_STATUS = "NORMALIZE_STATUS"  # reconciler-owned lossless DB write
+    ATTACH_STOP = "ATTACH_STOP"            # delegated: submit protective stop
+    FLATTEN = "FLATTEN"                    # delegated: submit flatten (RTH)
+    JOURNAL_CLOSED = "JOURNAL_CLOSED"      # delegated: exit journal + P&L
+    ADOPT = "ADOPT"                        # delegated: adopt broker qty/price
+    INVESTIGATE = "INVESTIGATE"            # unexpected — alert only
+
+
+# The ONLY op the reconciler executes itself when drive is on. It is lossless
+# (a status label change), idempotent, and fires only on positive broker
+# evidence (held + protective stop on the book) — so a transient/empty broker
+# read can never trigger it. Every other op is owned by the existing healers.
+_RECONCILER_OWNED: frozenset[ConvergenceOp] = frozenset({ConvergenceOp.NORMALIZE_STATUS})
+
+
+@dataclass(frozen=True)
+class ConvergenceAction:
+    """A single planned convergence step for one ticker."""
+
+    ticker: str
+    trade_id: int | None
+    desired: DesiredState
+    op: ConvergenceOp
+    target_status: str | None  # only set for NORMALIZE_STATUS
+    detail: str
+
+    @property
+    def reconciler_owned(self) -> bool:
+        return self.op in _RECONCILER_OWNED
+
+    def describe(self) -> str:
+        owner: str = "reconciler" if self.reconciler_owned else "healer"
+        return f"[{self.op.value}/{owner}] {self.ticker}: {self.detail}"
+
+
+def _plan_one(disp: Disposition) -> ConvergenceAction:
+    """Pure: map one :class:`Disposition` to its convergence action."""
+    d: DesiredState = disp.desired
+
+    if d == DesiredState.PROTECTED:
+        # Lossless normalization: a held+stopped position recorded as
+        # POSITION_OPEN should read STOP_ACTIVE. Fires only on positive broker
+        # evidence, so it is safe against transient/empty reads. Any other
+        # open status already reflects reality -> NONE.
+        if disp.intent_status == PositionStatus.POSITION_OPEN.value:
+            return ConvergenceAction(
+                ticker=disp.ticker, trade_id=disp.trade_id, desired=d,
+                op=ConvergenceOp.NORMALIZE_STATUS,
+                target_status=PositionStatus.STOP_ACTIVE.value,
+                detail="normalize POSITION_OPEN -> STOP_ACTIVE (broker stop confirmed)",
+            )
+        return ConvergenceAction(
+            ticker=disp.ticker, trade_id=disp.trade_id, desired=d,
+            op=ConvergenceOp.NONE, target_status=None,
+            detail="already protected",
+        )
+
+    op_by_state: dict[DesiredState, tuple[ConvergenceOp, str]] = {
+        DesiredState.NEEDS_STOP: (
+            ConvergenceOp.ATTACH_STOP,
+            "attach protective stop (delegated to OrderManager recovery)",
+        ),
+        DesiredState.FLATTEN: (
+            ConvergenceOp.FLATTEN,
+            "re-submit flatten iff RTH (delegated to existing exit path)",
+        ),
+        DesiredState.CLOSED: (
+            ConvergenceOp.JOURNAL_CLOSED,
+            "journal exit from broker truth (delegated to StateRecovery/poll)",
+        ),
+        DesiredState.OPEN: (
+            ConvergenceOp.ADOPT,
+            "adopt broker qty/price (delegated to _transition_to_open)",
+        ),
+        DesiredState.ADOPT: (
+            ConvergenceOp.ADOPT,
+            "adopt unknown broker position (delegated to StateRecovery)",
+        ),
+        DesiredState.UNKNOWN: (
+            ConvergenceOp.INVESTIGATE,
+            "unexpected DB status — investigate",
+        ),
+        DesiredState.PENDING_ENTRY: (
+            ConvergenceOp.NONE,
+            "entry order still working",
+        ),
+    }
+    op, detail = op_by_state[d]
+    return ConvergenceAction(
+        ticker=disp.ticker, trade_id=disp.trade_id, desired=d,
+        op=op, target_status=None, detail=detail,
+    )
+
+
+def plan_convergence(dispositions: list[Disposition]) -> list[ConvergenceAction]:
+    """Pure: turn dispositions into the convergence plan (no side effects).
+
+    Actions that are no-ops (``NONE``) are dropped — the plan lists only the
+    steps that would change something. Reconciler-owned actions sort first.
+    """
+    actions: list[ConvergenceAction] = [
+        a for a in (_plan_one(d) for d in dispositions) if a.op != ConvergenceOp.NONE
+    ]
+    actions.sort(key=lambda a: (not a.reconciler_owned, a.ticker))
+    return actions
+
+
+def _write_status(db_path: str, trade_id: int, status: str) -> bool:
+    """Idempotently set a non-terminal position's status. Returns True on write.
+
+    Guarded to never touch a terminal row (CLOSED/ENTRY_FAILED) — the
+    reconciler must not resurrect a closed position.
+    """
+    from trading_bot.constants import TERMINAL_POSITION_STATUSES
+
+    placeholders: str = ",".join("?" * len(TERMINAL_POSITION_STATUSES))
+    try:
+        conn: sqlite3.Connection = sqlite3.connect(db_path)
+        try:
+            cur = conn.execute(
+                # nosec B608 — placeholders are literal "?" from a fixed
+                # module-level constant; no user input reaches the SQL.
+                f"UPDATE positions SET status = ?, "  # nosec B608
+                f"updated_at = datetime('now') "
+                f"WHERE id = ? AND status NOT IN ({placeholders})",
+                (status, trade_id, *sorted(TERMINAL_POSITION_STATUSES)),
+            )
+            conn.commit()
+            return cur.rowcount > 0
+        finally:
+            conn.close()
+    except sqlite3.OperationalError:
+        logger.warning(
+            "reconcile: failed to write status for trade_id=%s", trade_id,
+            exc_info=True,
+        )
+        return False
+
+
+async def converge(
+    db_path: str,
+    plan: list[ConvergenceAction],
+    *,
+    drive: bool,
+) -> list[ConvergenceAction]:
+    """Execute the reconciler-owned subset of the plan iff ``drive`` is on.
+
+    Returns the list of actions actually executed (empty when ``drive`` is
+    off, or when the plan has no reconciler-owned steps). Healer-delegated
+    actions are never executed here — the existing in-tick healers do that
+    work; this layer only plans and logs them.
+    """
+    if not drive:
+        return []
+    executed: list[ConvergenceAction] = []
+    for action in plan:
+        if action.op != ConvergenceOp.NORMALIZE_STATUS or action.trade_id is None:
+            continue
+        assert action.target_status is not None  # NORMALIZE_STATUS invariant
+        wrote: bool = await asyncio.to_thread(
+            _write_status, db_path, action.trade_id, action.target_status,
+        )
+        if wrote:
+            executed.append(action)
+            logger.info("reconcile: drove %s", action.describe())
+    return executed
+
+
 @dataclass
 class ShadowReconcileResult:
-    """Outcome of one shadow-mode reconcile pass."""
+    """Outcome of one reconcile pass (shadow, or driven when the flag is on)."""
 
     dispositions: list[Disposition] = field(default_factory=list)
+    plan: list[ConvergenceAction] = field(default_factory=list)
+    executed: list[ConvergenceAction] = field(default_factory=list)
+    drive: bool = False
 
     @property
     def disagreements(self) -> list[Disposition]:
@@ -283,29 +472,68 @@ async def broker_snapshot(gateway: GatewayConnection) -> BrokerView:
     return BrokerView.from_alpaca(positions, orders)
 
 
-async def run_shadow_reconcile(
+async def run_reconcile(
     db_path: str,
     gateway: GatewayConnection,
+    *,
+    drive: bool = False,
 ) -> ShadowReconcileResult:
-    """Run the Phase 1 reconciler in SHADOW mode for one tick (read-only).
+    """Run one reconcile pass for a tick.
 
-    Derives a desired disposition for every open position and logs where the
-    derivation disagrees with the live SQLite state machine. Takes **no**
-    action and pages **nothing** (Phase 0's guard owns alerting). Safe to call
-    every tick and ignore the result.
+    Always derives a desired disposition for every open position and logs
+    where the derivation disagrees with the live SQLite state machine
+    (shadow). It then plans the convergence steps; when ``drive`` is **on**,
+    the reconciler-owned subset (lossless status normalization) is executed
+    and the DB ``status`` column is owned by broker truth. When ``drive`` is
+    **off** (the default), nothing is executed — behaviour is identical to
+    Phase 1 shadow mode.
+
+    Order-submitting / P&L-bearing actions (attach stop, flatten, journal
+    exit, adopt) are **never** executed here — they are planned and logged,
+    and the existing in-tick healers do the work. Pages nothing (Phase 0's
+    guard owns alerting). Safe to call every tick and ignore the result.
     """
     broker: BrokerView = await broker_snapshot(gateway)
     intents: list[PositionIntent] = await asyncio.to_thread(_load_intents, db_path)
 
     dispositions: list[Disposition] = derive_all_dispositions(intents, broker)
-    result: ShadowReconcileResult = ShadowReconcileResult(dispositions=dispositions)
+    plan: list[ConvergenceAction] = plan_convergence(dispositions)
+    result: ShadowReconcileResult = ShadowReconcileResult(
+        dispositions=dispositions, plan=plan, drive=drive,
+    )
 
     logger.info("%s", result.summary())
     if result.disagreements:
+        mode: str = "drive" if drive else "shadow"
         logger.warning(
-            "shadow reconcile: %d disposition(s) would change under the "
-            "reconciler (Phase 1 is observe-only — no action taken):\n%s",
+            "reconcile (%s): %d disposition(s) diverge from the live state "
+            "machine:\n%s",
+            mode,
             len(result.disagreements),
             "\n".join(f"  - {d.describe()}" for d in result.disagreements),
         )
+
+    result.executed = await converge(db_path, plan, drive=drive)
+
+    # Surface the steps the reconciler did NOT own (delegated to healers) so
+    # the operator can confirm the healers are converging them.
+    delegated: list[ConvergenceAction] = [
+        a for a in plan if not a.reconciler_owned
+    ]
+    if delegated:
+        logger.info(
+            "reconcile: %d action(s) delegated to existing healers "
+            "(not driven by the reconciler):\n%s",
+            len(delegated),
+            "\n".join(f"  - {a.describe()}" for a in delegated),
+        )
     return result
+
+
+async def run_shadow_reconcile(
+    db_path: str,
+    gateway: GatewayConnection,
+) -> ShadowReconcileResult:
+    """Backward-compatible shadow entry point — :func:`run_reconcile` with
+    ``drive=False``. Retained for callers that only want observe-only mode."""
+    return await run_reconcile(db_path, gateway, drive=False)

--- a/trading_bot/main.py
+++ b/trading_bot/main.py
@@ -42,7 +42,7 @@ from trading_bot.db.migrations import run_migrations
 from trading_bot.execution.invariant_guard import run_invariant_guard
 from trading_bot.execution.loss_cooldown import LossCooldownConfig, LossCooldownTracker
 from trading_bot.execution.order_manager import OrderManager
-from trading_bot.execution.reconciler import run_shadow_reconcile
+from trading_bot.execution.reconciler import run_reconcile
 from trading_bot.execution.risk_manager import RiskManager
 from trading_bot.execution.stop_reconciler import reconcile_open_position_stops
 from trading_bot.gateway.connection import GatewayConnection
@@ -384,21 +384,27 @@ class TradingBot:
                     exc_info=True,
                 )
 
-            # --- 6d. Shadow reconciler (Phase 1, read-only) ---
-            # The reconciliation-loop design's Phase 1 (PR #191): derive each
-            # position's desired state from broker truth (the §3 table) and
-            # log where the derivation disagrees with the live SQLite state
-            # machine. Validates the reconciler's brain against reality before
-            # Phase 2 lets it own the status column. Observe-only — no action,
-            # no paging (Phase 0's guard owns alerting).
+            # --- 6d. Reconciler (Phase 1 shadow / Phase 2 drive) ---
+            # Derives each position's desired state from broker truth (the §3
+            # table) and logs where it diverges from the live SQLite state
+            # machine. When `reconciler.drive` is true (Phase 2), the derived
+            # state OWNS the DB status column for the lossless transitions the
+            # reconciler can safely drive from positive broker evidence;
+            # order-submitting actions stay with the existing healers. Default
+            # OFF -> pure Phase 1 shadow (no action). Pages nothing (Phase 0's
+            # guard owns alerting).
+            reconciler_drive: bool = bool(
+                self._config._get("reconciler", "drive", default=False)
+            )
             try:
-                await run_shadow_reconcile(
+                await run_reconcile(
                     db_path=self._db_path,
                     gateway=self._gateway,
+                    drive=reconciler_drive,
                 )
             except Exception:
                 logger.warning(
-                    "Shadow reconcile failed (non-fatal)",
+                    "Reconcile failed (non-fatal)",
                     exc_info=True,
                 )
 

--- a/trading_bot/tests/test_reconciler_drive.py
+++ b/trading_bot/tests/test_reconciler_drive.py
@@ -1,0 +1,290 @@
+"""Tests for the Phase 2 reconciler convergence engine (PR #191 design).
+
+Phase 2 lets the reconciler OWN the DB ``status`` column for the lossless,
+DB-only transitions it can safely drive from positive broker evidence, gated
+by the ``reconciler.drive`` flag. Order-submitting / P&L-bearing actions are
+planned + logged but delegated to the existing healers.
+
+Covers:
+- :func:`plan_convergence` — pure mapping from dispositions to typed actions;
+  which ops are reconciler-owned vs delegated.
+- :func:`converge` — drive OFF executes nothing; drive ON executes ONLY the
+  lossless ``NORMALIZE_STATUS`` write; order-bearing ops are never executed.
+- :func:`_write_status` — refuses to touch a terminal row.
+- :func:`run_reconcile` — end-to-end drive vs shadow over a temp DB + mock
+  gateway, asserting the DB status is/ isn't changed and no order is placed.
+- Safety: a transient/empty broker read can never drive a normalization.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from unittest.mock import MagicMock
+
+import pytest
+
+from trading_bot.constants import PositionStatus
+from trading_bot.execution.reconciler import (
+    ConvergenceOp,
+    DesiredState,
+    Disposition,
+    _write_status,
+    converge,
+    plan_convergence,
+    run_reconcile,
+)
+
+pytestmark = pytest.mark.critical
+
+
+# ---------------------------------------------------------------------------
+# Builders
+# ---------------------------------------------------------------------------
+
+
+def _alpaca_position(symbol: str, qty: float):
+    p = MagicMock()
+    p.symbol = symbol
+    p.qty = qty
+    return p
+
+
+def _alpaca_order(symbol: str, order_type: str):
+    o = MagicMock()
+    o.symbol = symbol
+    o.type = MagicMock()
+    o.type.value = order_type
+    return o
+
+
+def _disp(
+    ticker: str,
+    intent_status: str | None,
+    desired: DesiredState,
+    *,
+    trade_id: int | None = 1,
+) -> Disposition:
+    return Disposition(
+        ticker=ticker,
+        intent_status=intent_status,
+        desired=desired,
+        action="",
+        agrees_with_db=False,
+        trade_id=trade_id,
+    )
+
+
+def _insert_position(db_path: str, ticker: str, status: str) -> int:
+    conn = sqlite3.connect(db_path)
+    try:
+        cur = conn.execute(
+            "INSERT INTO positions "
+            "(ticker, exchange, currency, quantity, entry_price, entry_time, "
+            "status, hold_type, phase, strategy_id) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                ticker, "US", "USD", 1.0, 100.0,
+                "2026-06-04T10:00:00-04:00", status, "intraday", 3,
+                "mean_reversion",
+            ),
+        )
+        conn.commit()
+        return int(cur.lastrowid or 0)
+    finally:
+        conn.close()
+
+
+def _status_of(db_path: str, trade_id: int) -> str:
+    conn = sqlite3.connect(db_path)
+    try:
+        row = conn.execute(
+            "SELECT status FROM positions WHERE id = ?", (trade_id,)
+        ).fetchone()
+        return str(row[0]) if row else ""
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# plan_convergence — pure
+# ---------------------------------------------------------------------------
+
+
+class TestPlanConvergence:
+    def test_protected_open_normalizes_and_is_reconciler_owned(self) -> None:
+        disp = _disp(
+            "SPY", PositionStatus.POSITION_OPEN.value, DesiredState.PROTECTED
+        )
+        plan = plan_convergence([disp])
+        assert len(plan) == 1
+        assert plan[0].op == ConvergenceOp.NORMALIZE_STATUS
+        assert plan[0].target_status == PositionStatus.STOP_ACTIVE.value
+        assert plan[0].reconciler_owned is True
+
+    def test_protected_already_stop_active_is_noop_dropped(self) -> None:
+        disp = _disp(
+            "SPY", PositionStatus.STOP_ACTIVE.value, DesiredState.PROTECTED
+        )
+        # NONE actions are dropped from the plan.
+        assert plan_convergence([disp]) == []
+
+    @pytest.mark.parametrize(
+        "desired,expected_op",
+        [
+            (DesiredState.NEEDS_STOP, ConvergenceOp.ATTACH_STOP),
+            (DesiredState.FLATTEN, ConvergenceOp.FLATTEN),
+            (DesiredState.CLOSED, ConvergenceOp.JOURNAL_CLOSED),
+            (DesiredState.OPEN, ConvergenceOp.ADOPT),
+            (DesiredState.ADOPT, ConvergenceOp.ADOPT),
+            (DesiredState.UNKNOWN, ConvergenceOp.INVESTIGATE),
+        ],
+    )
+    def test_order_bearing_ops_are_delegated(
+        self, desired: DesiredState, expected_op: ConvergenceOp
+    ) -> None:
+        disp = _disp("SPY", PositionStatus.POSITION_OPEN.value, desired)
+        plan = plan_convergence([disp])
+        assert len(plan) == 1
+        assert plan[0].op == expected_op
+        assert plan[0].reconciler_owned is False
+
+    def test_reconciler_owned_actions_sorted_first(self) -> None:
+        plan = plan_convergence([
+            _disp("QQQ", PositionStatus.STOP_ACTIVE.value, DesiredState.CLOSED),
+            _disp("SPY", PositionStatus.POSITION_OPEN.value, DesiredState.PROTECTED),
+        ])
+        assert [a.ticker for a in plan] == ["SPY", "QQQ"]
+        assert plan[0].reconciler_owned is True
+
+
+# ---------------------------------------------------------------------------
+# converge — execution gating
+# ---------------------------------------------------------------------------
+
+
+class TestConverge:
+    @pytest.mark.asyncio
+    async def test_drive_off_executes_nothing(self, tmp_db_path: str) -> None:
+        tid = _insert_position(
+            tmp_db_path, "SPY", PositionStatus.POSITION_OPEN.value
+        )
+        plan = plan_convergence([
+            _disp("SPY", PositionStatus.POSITION_OPEN.value,
+                  DesiredState.PROTECTED, trade_id=tid),
+        ])
+        executed = await converge(tmp_db_path, plan, drive=False)
+        assert executed == []
+        assert _status_of(tmp_db_path, tid) == PositionStatus.POSITION_OPEN.value
+
+    @pytest.mark.asyncio
+    async def test_drive_on_normalizes_status(self, tmp_db_path: str) -> None:
+        tid = _insert_position(
+            tmp_db_path, "SPY", PositionStatus.POSITION_OPEN.value
+        )
+        plan = plan_convergence([
+            _disp("SPY", PositionStatus.POSITION_OPEN.value,
+                  DesiredState.PROTECTED, trade_id=tid),
+        ])
+        executed = await converge(tmp_db_path, plan, drive=True)
+        assert len(executed) == 1
+        assert _status_of(tmp_db_path, tid) == PositionStatus.STOP_ACTIVE.value
+
+    @pytest.mark.asyncio
+    async def test_drive_on_does_not_execute_order_bearing_ops(
+        self, tmp_db_path: str
+    ) -> None:
+        tid = _insert_position(
+            tmp_db_path, "QQQ", PositionStatus.STOP_ACTIVE.value
+        )
+        # Orphan -> CLOSED -> JOURNAL_CLOSED (delegated, not reconciler-owned).
+        plan = plan_convergence([
+            _disp("QQQ", PositionStatus.STOP_ACTIVE.value,
+                  DesiredState.CLOSED, trade_id=tid),
+        ])
+        executed = await converge(tmp_db_path, plan, drive=True)
+        assert executed == []
+        # Status untouched — the reconciler did not journal the close itself.
+        assert _status_of(tmp_db_path, tid) == PositionStatus.STOP_ACTIVE.value
+
+
+# ---------------------------------------------------------------------------
+# _write_status — terminal-row guard
+# ---------------------------------------------------------------------------
+
+
+class TestWriteStatusGuard:
+    def test_refuses_to_touch_terminal_row(self, tmp_db_path: str) -> None:
+        tid = _insert_position(
+            tmp_db_path, "SPY", PositionStatus.CLOSED.value
+        )
+        wrote = _write_status(
+            tmp_db_path, tid, PositionStatus.STOP_ACTIVE.value
+        )
+        assert wrote is False
+        assert _status_of(tmp_db_path, tid) == PositionStatus.CLOSED.value
+
+    def test_writes_non_terminal_row(self, tmp_db_path: str) -> None:
+        tid = _insert_position(
+            tmp_db_path, "SPY", PositionStatus.POSITION_OPEN.value
+        )
+        wrote = _write_status(
+            tmp_db_path, tid, PositionStatus.STOP_ACTIVE.value
+        )
+        assert wrote is True
+        assert _status_of(tmp_db_path, tid) == PositionStatus.STOP_ACTIVE.value
+
+
+# ---------------------------------------------------------------------------
+# run_reconcile — end-to-end drive vs shadow
+# ---------------------------------------------------------------------------
+
+
+class TestRunReconcileDrive:
+    @pytest.mark.asyncio
+    async def test_shadow_does_not_change_db(
+        self, tmp_db_path: str, mock_gateway
+    ) -> None:
+        tid = _insert_position(
+            tmp_db_path, "SPY", PositionStatus.POSITION_OPEN.value
+        )
+        mock_gateway.get_positions.return_value = [_alpaca_position("SPY", 1.0)]
+        mock_gateway.get_open_orders.return_value = [_alpaca_order("SPY", "stop")]
+
+        result = await run_reconcile(tmp_db_path, mock_gateway, drive=False)
+        assert result.executed == []
+        assert _status_of(tmp_db_path, tid) == PositionStatus.POSITION_OPEN.value
+        mock_gateway.client.submit_order.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_drive_owns_status_for_protected(
+        self, tmp_db_path: str, mock_gateway
+    ) -> None:
+        tid = _insert_position(
+            tmp_db_path, "SPY", PositionStatus.POSITION_OPEN.value
+        )
+        # Held + broker stop on the book -> PROTECTED -> normalize.
+        mock_gateway.get_positions.return_value = [_alpaca_position("SPY", 1.0)]
+        mock_gateway.get_open_orders.return_value = [_alpaca_order("SPY", "stop")]
+
+        result = await run_reconcile(tmp_db_path, mock_gateway, drive=True)
+        assert len(result.executed) == 1
+        assert _status_of(tmp_db_path, tid) == PositionStatus.STOP_ACTIVE.value
+        # Still places NO orders — the only driven action is a DB status write.
+        mock_gateway.client.submit_order.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_drive_on_empty_broker_read_drives_nothing(
+        self, tmp_db_path: str, mock_gateway
+    ) -> None:
+        # Safety: an empty/transient broker read yields no held positions, so
+        # no PROTECTED disposition and no normalization can fire — even with
+        # drive on. The orphan it produces is delegated (CLOSED), not driven.
+        tid = _insert_position(
+            tmp_db_path, "SPY", PositionStatus.POSITION_OPEN.value
+        )
+        mock_gateway.get_positions.return_value = []
+        mock_gateway.get_open_orders.return_value = []
+
+        result = await run_reconcile(tmp_db_path, mock_gateway, drive=True)
+        assert result.executed == []
+        assert _status_of(tmp_db_path, tid) == PositionStatus.POSITION_OPEN.value


### PR DESCRIPTION
Implements **Phase 2a** of the broker-truth reconciliation-loop design ([#191](https://github.com/alex5imon/ai-broker/pull/191)), building on Phase 0 ([#192](https://github.com/alex5imon/ai-broker/pull/192)) and Phase 1 ([#193](https://github.com/alex5imon/ai-broker/pull/193)).

## What — the reconciler starts owning `status`, behind a flag

Adds the convergence engine that lets the derived desired-state **own the DB `status` column**, gated by a new `reconciler.drive` config flag (**default `false`**).

| `reconciler.drive` | Behaviour |
|---|---|
| `false` (default) | Identical to Phase 1 shadow — plans + logs, executes **nothing**. Zero behaviour change. |
| `true` | Reconciler executes the lossless, DB-only transition it can safely own; order actions stay delegated. |

When driven, the **only** action the reconciler performs itself is a lossless status normalization: a held + broker-stopped row recorded as `POSITION_OPEN` → `STOP_ACTIVE`. It fires **only when the broker reports a stop on the book**, so a transient/empty broker read can never trigger it — the design's *"never act on a transient read"* property holds by construction.

Every order-submitting / P&L-bearing action (`attach stop`, `flatten`, `journal exit`, `adopt`) is planned and logged as **delegated** — the existing in-tick healers (`StateRecovery` / `OrderManager`) still do that work.

## Why scoped to 2a (and what's deferred)

The design (§5) gates the full Phase 2 — routing order actions through the reconciler and **deleting the reactive patches** — on *"shadow-mode agreement ≥ N days"*. Phases 0/1 were authored today and have run zero paper ticks. Driving order logic on day-zero data is exactly what that gate guards against, so:

- **This PR ships the machinery, default-off, fully reversible.** Flip `drive: true` after the shadow log has been quiet/consistent for several paper days.
- **Phase 2b** (delegate→drive routing for stop/flatten/exit, delete dead reactive patches) is a follow-up once shadow evidence exists. Existing healers stay in place as belt-and-suspenders.

## New surface

- `plan_convergence(dispositions) -> [ConvergenceAction]` — pure; typed ops (`NORMALIZE_STATUS` reconciler-owned vs `ATTACH_STOP`/`FLATTEN`/`JOURNAL_CLOSED`/`ADOPT`/`INVESTIGATE` delegated).
- `converge(db_path, plan, *, drive)` — executes only the reconciler-owned subset when `drive` is on.
- `_write_status` — idempotent, **refuses to touch a terminal row** (never resurrects a CLOSED position).
- `run_reconcile(db_path, gateway, *, drive)` replaces `run_shadow_reconcile` in the tick (`run_shadow_reconcile` kept as a `drive=false` alias).

## Test plan

- [x] 17 new tests (`test_reconciler_drive.py`, `@pytest.mark.critical`):
  - `plan_convergence`: PROTECTED→normalize (owned), already-`STOP_ACTIVE`→no-op dropped, all order-bearing ops delegated, owned-first ordering.
  - `converge`: drive-off writes nothing; drive-on normalizes; **order-bearing ops never executed** even with drive on.
  - `_write_status`: refuses terminal rows, writes non-terminal.
  - `run_reconcile`: shadow leaves DB untouched + no `submit_order`; drive owns status for PROTECTED + still no order; **empty broker read drives nothing** (safety).
- [x] Phase 1 reconciler tests still green (backward-compatible alias)
- [x] `ruff` · `mypy` (CI scope) · `bandit -ll` · `vulture --min-confidence 80` clean
- [x] Full `-m critical` suite: **301 passed**
- [x] `config.yaml` parses; `reconciler.drive` defaults to `False`
