### PR TITLE
feat(reconcile): persist shadow-evidence journal to serve the Phase 2b gate

### DIFF
--- a/trading_bot/execution/reconciler.py
+++ b/trading_bot/execution/reconciler.py
@@ -41,10 +41,11 @@ import asyncio
 import logging
 import sqlite3
 from dataclasses import dataclass, field
+from datetime import datetime
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
-from trading_bot.constants import PositionStatus
+from trading_bot.constants import TZ_EASTERN, PositionStatus
 from trading_bot.execution.invariant_guard import BrokerView
 
 if TYPE_CHECKING:
@@ -472,11 +473,119 @@ async def broker_snapshot(gateway: GatewayConnection) -> BrokerView:
     return BrokerView.from_alpaca(positions, orders)
 
 
+# ---------------------------------------------------------------------------
+# Shadow evidence journal — persists per-day disagreement tallies so the
+# operator can make the Phase 2b "flip drive on" decision on DATA rather than
+# scrollback. This is the §5 gate's evidence ("run ~1 week to quantify how
+# often each divergence fires"). Stored in tick_state (no schema migration);
+# read it via load_shadow_evidence / surface it in the daily review.
+# ---------------------------------------------------------------------------
+
+_SHADOW_EVIDENCE_KEY: str = "__reconcile_shadow__"
+_EVIDENCE_RETENTION_DAYS: int = 14
+
+
+def _empty_day_tally() -> dict[str, Any]:
+    return {
+        "ticks": 0,
+        "disagreements": 0,      # cumulative across the day's ticks
+        "by_state": {},          # DesiredState.value -> cumulative count
+        "executed": 0,           # cumulative reconciler-driven actions
+        "max_diff_in_tick": 0,   # worst single tick that day
+    }
+
+
+def load_shadow_evidence(db_path: str) -> dict[str, dict[str, Any]]:
+    """Return the persisted per-day shadow tallies, keyed by ISO date.
+
+    Empty dict if nothing has been journaled yet. Callers (daily review,
+    operator) use this to judge whether divergence is rare/consistent enough
+    to flip ``reconciler.drive`` on (the Phase 2b gate).
+    """
+    from trading_bot.db import repository as repo
+
+    try:
+        conn: sqlite3.Connection = sqlite3.connect(db_path)
+        try:
+            row = repo.load_tick_state(conn, _SHADOW_EVIDENCE_KEY)
+        finally:
+            conn.close()
+    except sqlite3.OperationalError:
+        logger.warning("reconcile: shadow evidence unreadable", exc_info=True)
+        return {}
+    if row is None:
+        return {}
+    days = row.get("state", {}).get("days", {})
+    return {str(k): dict(v) for k, v in days.items()} if isinstance(days, dict) else {}
+
+
+def record_shadow_evidence(
+    db_path: str, result: ShadowReconcileResult, *, day_iso: str,
+) -> None:
+    """Fold one reconcile pass into the persisted per-day tally (idempotent-ish
+    accumulation). Prunes to the most recent ``_EVIDENCE_RETENTION_DAYS`` days.
+    Never raises — a journaling failure must not break the tick."""
+    from trading_bot.db import repository as repo
+
+    try:
+        days: dict[str, dict[str, Any]] = load_shadow_evidence(db_path)
+        tally: dict[str, Any] = days.get(day_iso) or _empty_day_tally()
+
+        n_diff: int = len(result.disagreements)
+        tally["ticks"] = int(tally.get("ticks", 0)) + 1
+        tally["disagreements"] = int(tally.get("disagreements", 0)) + n_diff
+        tally["executed"] = int(tally.get("executed", 0)) + len(result.executed)
+        tally["max_diff_in_tick"] = max(int(tally.get("max_diff_in_tick", 0)), n_diff)
+        by_state: dict[str, int] = dict(tally.get("by_state", {}))
+        for disp in result.disagreements:
+            key: str = disp.desired.value
+            by_state[key] = int(by_state.get(key, 0)) + 1
+        tally["by_state"] = by_state
+        days[day_iso] = tally
+
+        # Prune oldest days beyond the retention window.
+        if len(days) > _EVIDENCE_RETENTION_DAYS:
+            for stale in sorted(days)[: len(days) - _EVIDENCE_RETENTION_DAYS]:
+                days.pop(stale, None)
+
+        conn: sqlite3.Connection = sqlite3.connect(db_path)
+        try:
+            repo.save_tick_state(
+                conn, _SHADOW_EVIDENCE_KEY, last_bar_ts=None, state={"days": days},
+            )
+        finally:
+            conn.close()
+    except (sqlite3.OperationalError, ValueError, TypeError):
+        logger.warning("reconcile: failed to journal shadow evidence", exc_info=True)
+
+
+def summarize_shadow_evidence(days: dict[str, dict[str, Any]]) -> str:
+    """Readable multi-line summary of the persisted evidence (newest last)."""
+    if not days:
+        return "reconcile shadow evidence: none recorded yet"
+    lines: list[str] = ["reconcile shadow evidence (per day):"]
+    for day in sorted(days):
+        t: dict[str, Any] = days[day]
+        by_state: dict[str, int] = t.get("by_state", {}) or {}
+        breakdown: str = (
+            ", ".join(f"{k}={v}" for k, v in sorted(by_state.items()))
+            or "none"
+        )
+        lines.append(
+            f"  {day}: {t.get('ticks', 0)} ticks, "
+            f"{t.get('disagreements', 0)} disagreements "
+            f"(max {t.get('max_diff_in_tick', 0)}/tick), "
+            f"{t.get('executed', 0)} driven | {breakdown}"
+        )
+    return "\n".join(lines)
+
+
 async def run_reconcile(
     db_path: str,
     gateway: GatewayConnection,
     *,
     drive: bool = False,
+    now: datetime | None = None,
 ) -> ShadowReconcileResult:
     """Run one reconcile pass for a tick.
 
@@ -527,6 +636,12 @@ async def run_reconcile(
             len(delegated),
             "\n".join(f"  - {a.describe()}" for a in delegated),
         )
+
+    # Persist the day's disagreement tally so the Phase 2b flip decision is
+    # data-driven (the §5 gate evidence). Best-effort — never breaks the tick.
+    day_iso: str = (now or datetime.now(tz=TZ_EASTERN)).date().isoformat()
+    await asyncio.to_thread(record_shadow_evidence, db_path, result, day_iso=day_iso)
+
     return result
 
 

--- a/trading_bot/tests/test_reconciler_evidence.py
+++ b/trading_bot/tests/test_reconciler_evidence.py
@@ -1,0 +1,176 @@
+"""Tests for the reconciler shadow-evidence journal (PR #191 §5 gate evidence).
+
+The journal persists per-day disagreement tallies to ``tick_state`` so the
+"flip ``reconciler.drive`` on" (Phase 2b) decision can be made on data rather
+than scrollback. Covers round-trip accumulation, per-day separation, retention
+pruning, the summary, and that ``run_reconcile`` records evidence each tick.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from trading_bot.constants import PositionStatus, TZ_EASTERN
+from trading_bot.execution.reconciler import (
+    _EVIDENCE_RETENTION_DAYS,
+    DesiredState,
+    Disposition,
+    ShadowReconcileResult,
+    load_shadow_evidence,
+    record_shadow_evidence,
+    run_reconcile,
+    summarize_shadow_evidence,
+)
+
+pytestmark = pytest.mark.critical
+
+
+def _alpaca_position(symbol: str, qty: float):
+    p = MagicMock()
+    p.symbol = symbol
+    p.qty = qty
+    return p
+
+
+def _disp(ticker: str, desired: DesiredState, *, agrees: bool) -> Disposition:
+    return Disposition(
+        ticker=ticker,
+        intent_status=PositionStatus.STOP_ACTIVE.value,
+        desired=desired,
+        action="",
+        agrees_with_db=agrees,
+        trade_id=1,
+    )
+
+
+def _result(*disps: Disposition, executed: int = 0) -> ShadowReconcileResult:
+    r = ShadowReconcileResult(dispositions=list(disps))
+    # executed only needs a length for the tally.
+    r.executed = [MagicMock() for _ in range(executed)]
+    return r
+
+
+def _insert_position(db_path: str, ticker: str, status: str) -> None:
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            "INSERT INTO positions "
+            "(ticker, exchange, currency, quantity, entry_price, entry_time, "
+            "status, hold_type, phase, strategy_id) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                ticker, "US", "USD", 1.0, 100.0,
+                "2026-06-04T10:00:00-04:00", status, "intraday", 3,
+                "mean_reversion",
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+class TestEvidenceJournal:
+    def test_empty_when_nothing_recorded(self, tmp_db_path: str) -> None:
+        assert load_shadow_evidence(tmp_db_path) == {}
+
+    def test_single_record_round_trip(self, tmp_db_path: str) -> None:
+        result = _result(
+            _disp("SPY", DesiredState.NEEDS_STOP, agrees=False),
+            _disp("QQQ", DesiredState.PROTECTED, agrees=True),
+            executed=1,
+        )
+        record_shadow_evidence(tmp_db_path, result, day_iso="2026-06-04")
+        days = load_shadow_evidence(tmp_db_path)
+        assert set(days) == {"2026-06-04"}
+        t = days["2026-06-04"]
+        assert t["ticks"] == 1
+        assert t["disagreements"] == 1
+        assert t["executed"] == 1
+        assert t["max_diff_in_tick"] == 1
+        assert t["by_state"] == {"NEEDS_STOP": 1}
+
+    def test_accumulates_across_ticks_same_day(self, tmp_db_path: str) -> None:
+        record_shadow_evidence(
+            tmp_db_path,
+            _result(_disp("SPY", DesiredState.NEEDS_STOP, agrees=False)),
+            day_iso="2026-06-04",
+        )
+        record_shadow_evidence(
+            tmp_db_path,
+            _result(
+                _disp("SPY", DesiredState.NEEDS_STOP, agrees=False),
+                _disp("XLE", DesiredState.CLOSED, agrees=False),
+                executed=2,
+            ),
+            day_iso="2026-06-04",
+        )
+        t = load_shadow_evidence(tmp_db_path)["2026-06-04"]
+        assert t["ticks"] == 2
+        assert t["disagreements"] == 3
+        assert t["executed"] == 2
+        assert t["max_diff_in_tick"] == 2  # worst single tick
+        assert t["by_state"] == {"NEEDS_STOP": 2, "CLOSED": 1}
+
+    def test_separate_days_tracked_independently(self, tmp_db_path: str) -> None:
+        record_shadow_evidence(
+            tmp_db_path,
+            _result(_disp("SPY", DesiredState.CLOSED, agrees=False)),
+            day_iso="2026-06-03",
+        )
+        record_shadow_evidence(
+            tmp_db_path, _result(), day_iso="2026-06-04",
+        )
+        days = load_shadow_evidence(tmp_db_path)
+        assert days["2026-06-03"]["disagreements"] == 1
+        assert days["2026-06-04"]["disagreements"] == 0
+        assert days["2026-06-04"]["ticks"] == 1
+
+    def test_prunes_to_retention_window(self, tmp_db_path: str) -> None:
+        # Record more distinct days than the retention window allows.
+        total = _EVIDENCE_RETENTION_DAYS + 5
+        for i in range(total):
+            record_shadow_evidence(
+                tmp_db_path, _result(), day_iso=f"2026-06-{i + 1:02d}",
+            )
+        days = load_shadow_evidence(tmp_db_path)
+        assert len(days) == _EVIDENCE_RETENTION_DAYS
+        # Oldest days were pruned; the newest survive.
+        assert f"2026-06-{total:02d}" in days
+        assert "2026-06-01" not in days
+
+    def test_summary_empty_and_populated(self, tmp_db_path: str) -> None:
+        assert "none recorded" in summarize_shadow_evidence({})
+        record_shadow_evidence(
+            tmp_db_path,
+            _result(_disp("SPY", DesiredState.NEEDS_STOP, agrees=False)),
+            day_iso="2026-06-04",
+        )
+        text = summarize_shadow_evidence(load_shadow_evidence(tmp_db_path))
+        assert "2026-06-04" in text
+        assert "NEEDS_STOP=1" in text
+
+
+class TestRunReconcileRecordsEvidence:
+    @pytest.mark.asyncio
+    async def test_tick_records_evidence_under_injected_date(
+        self, tmp_db_path: str, mock_gateway
+    ) -> None:
+        # Orphan -> CLOSED disagreement; injected clock fixes the day.
+        _insert_position(
+            tmp_db_path, "QQQ", PositionStatus.STOP_ACTIVE.value
+        )
+        mock_gateway.get_positions.return_value = []
+        mock_gateway.get_open_orders.return_value = []
+        fixed = datetime(2026, 6, 4, 11, 0, tzinfo=TZ_EASTERN)
+
+        await run_reconcile(tmp_db_path, mock_gateway, drive=False, now=fixed)
+
+        days = load_shadow_evidence(tmp_db_path)
+        assert "2026-06-04" in days
+        assert days["2026-06-04"]["ticks"] == 1
+        assert days["2026-06-04"]["disagreements"] == 1
+        assert days["2026-06-04"]["by_state"] == {"CLOSED": 1}


### PR DESCRIPTION
Follows Phase 2a ([#194](https://github.com/alex5imon/ai-broker/pull/194)). Instrumentation that **unblocks the Phase 2b decision** — it does **not** change drive behaviour or touch order logic.

## Why

The reconciler's shadow disagreements only went to logs, which scroll away. Phase 2b (route order actions through the reconciler **and delete the existing healers**) is gated by the design (§5) on *shadow agreement holding for several paper days* — and that's a real structural gate, not just caution: turning on the reconciler's order path while the healers remain would cause **double-actions** (e.g. two stop attaches), and removing the healers safely requires proving the reconciler covers their cases. Making that call needs durable evidence; before this PR there was none.

## What

A per-day disagreement tally persisted to `tick_state` (key `__reconcile_shadow__`, **no schema migration**), folded in each tick by `run_reconcile`:

- `ticks`, cumulative `disagreements`, per-`DesiredState` breakdown, reconciler-`driven` count, and `max_diff_in_tick`
- pruned to the last **14 days**
- best-effort — a journaling failure never breaks the tick

Read it any time:

```python
from trading_bot.execution.reconciler import load_shadow_evidence, summarize_shadow_evidence
print(summarize_shadow_evidence(load_shadow_evidence("trading_bot/data/trading_bot.db")))
```

```
reconcile shadow evidence (per day):
  2026-06-04: 78 ticks, 3 disagreements (max 1/tick), 0 driven | CLOSED=2, NEEDS_STOP=1
  2026-06-05: 78 ticks, 0 disagreements (max 0/tick), 0 driven | none
```

When several consecutive days read quiet/consistent, that's the signal to flip `reconciler.drive: true` and proceed to Phase 2b.

## Test plan

- [x] 7 new tests (`test_reconciler_evidence.py`, `@pytest.mark.critical`): empty state, single round-trip, same-day accumulation (incl. `max_diff_in_tick` + by-state), per-day separation, retention pruning, summary, end-to-end recording from a tick with an injected clock.
- [x] `run_reconcile` gains an injectable `now` for deterministic per-day bucketing.
- [x] `ruff` · `mypy` (CI scope) · `bandit -ll` · `vulture --min-confidence 80` clean
- [x] Full `-m critical` suite: **308 passed**

## Follow-ups

- Surface `summarize_shadow_evidence` in the daily-review report (`self_improve`) so the operator sees it post-close without a manual query.
- **Phase 2b** (gated on this evidence): route attach-stop/flatten/journal-exit through the reconciler, delete the now-dead reactive patches.
- **Phase 3**: retire the out-of-band repair scripts to a thin nightly audit.
