### PR TITLE
feat(reconcile): surface shadow evidence in the daily-review report

### DIFF
--- a/trading_bot/self_improve/__main__.py
+++ b/trading_bot/self_improve/__main__.py
@@ -19,6 +19,7 @@ from datetime import date, datetime, timezone
 from pathlib import Path
 
 from trading_bot.config import Config
+from trading_bot.execution.reconciler import load_shadow_evidence
 from trading_bot.log_setup import setup_logging
 from trading_bot.self_improve.backtest_gate import (
     evaluate,
@@ -117,6 +118,11 @@ async def _async_main(args: argparse.Namespace) -> int:
         )
         comparisons = await evaluate(proposals, config, runner)
 
+    # Surface the reconciler's persisted shadow-evidence tally (PR #195) so
+    # the operator can see, post-close, whether DB<->broker divergence is rare
+    # enough to flip `reconciler.drive` on (the Phase 2b gate).
+    shadow_evidence = load_shadow_evidence(db_path)
+
     report_md = render_markdown(
         report_date=date.today(),
         window_days=args.window_days,
@@ -128,6 +134,7 @@ async def _async_main(args: argparse.Namespace) -> int:
             [t.strip() for t in args.tickers.split(",") if t.strip()]
             if not args.dry_run else None
         ),
+        shadow_evidence=shadow_evidence,
     )
 
     out_dir = Path(args.out)

--- a/trading_bot/self_improve/report.py
+++ b/trading_bot/self_improve/report.py
@@ -13,7 +13,7 @@ The agent never edits config.yaml directly — patches are advisory text.
 from __future__ import annotations
 
 from datetime import date
-from typing import Iterable
+from typing import Any, Iterable
 
 from trading_bot.self_improve.backtest_gate import BacktestComparison, StrategyMetrics
 from trading_bot.self_improve.hypotheses import Proposal
@@ -112,6 +112,54 @@ def _yaml_value(v: float) -> str:
     return f"{v:g}"
 
 
+def _render_shadow_evidence(days: dict[str, dict[str, Any]]) -> str:
+    """Render the reconciler shadow-evidence per-day tally as Markdown.
+
+    ``days`` is the structure persisted by the reconciler and read via
+    ``trading_bot.execution.reconciler.load_shadow_evidence`` — keyed by ISO
+    date. Surfaces the Phase 2b gate evidence (PR #191/#195): when several
+    consecutive days read quiet/consistent, the operator can flip
+    ``reconciler.drive`` on.
+    """
+    if not days:
+        return (
+            "_No reconciler shadow evidence recorded yet "
+            "(the bot has not run a tick since the journal shipped)._\n"
+        )
+
+    lines = [
+        "| Date | Ticks | Disagreements | Max/tick | Driven | By state |",
+        "|---|---:|---:|---:|---:|---|",
+    ]
+    total_diff: int = 0
+    for day in sorted(days):
+        t = days[day]
+        by_state = t.get("by_state", {}) or {}
+        breakdown = (
+            ", ".join(f"`{k}`={v}" for k, v in sorted(by_state.items()))
+            or "—"
+        )
+        diff = int(t.get("disagreements", 0))
+        total_diff += diff
+        lines.append(
+            f"| {day} | {int(t.get('ticks', 0))} | {diff} | "
+            f"{int(t.get('max_diff_in_tick', 0))} | "
+            f"{int(t.get('executed', 0))} | {breakdown} |"
+        )
+
+    quiet = sum(
+        1 for d in days.values() if int(d.get("disagreements", 0)) == 0
+    )
+    parts = ["\n".join(lines), ""]
+    parts.append(
+        f"_{quiet} of {len(days)} recorded day(s) had zero disagreements. "
+        f"**Phase 2b gate:** flip `reconciler.drive` on only after several "
+        f"consecutive quiet/consistent days (design §5)._"
+    )
+    parts.append("")
+    return "\n".join(parts)
+
+
 def render_markdown(
     *,
     report_date: date,
@@ -121,6 +169,7 @@ def render_markdown(
     comparisons: list[BacktestComparison],
     backtest_window: tuple[date, date] | None = None,
     backtest_universe: Iterable[str] | None = None,
+    shadow_evidence: dict[str, dict[str, Any]] | None = None,
 ) -> str:
     """Render the full report as a single Markdown string."""
     parts: list[str] = [
@@ -162,6 +211,11 @@ def render_markdown(
     else:
         for comp in comparisons:
             parts.append(_render_comparison(comp))
+
+    if shadow_evidence is not None:
+        parts.append("## Reconciler shadow evidence")
+        parts.append("")
+        parts.append(_render_shadow_evidence(shadow_evidence))
 
     parts.append("---")
     parts.append("")

--- a/trading_bot/tests/test_self_improve_report.py
+++ b/trading_bot/tests/test_self_improve_report.py
@@ -138,3 +138,60 @@ def test_render_handles_zero_trade_strategy():
     )
     assert "no closed trades in window" in md
     assert "n/a" in md  # PF rendered as n/a
+
+
+@pytest.mark.unit
+def test_shadow_evidence_omitted_when_none():
+    # Backward compat: callers that don't pass evidence get no section.
+    md = render_markdown(
+        report_date=date(2026, 6, 4),
+        window_days=20,
+        stats_by_strategy={"mean_reversion": _stats("mean_reversion")},
+        proposals=[],
+        comparisons=[],
+    )
+    assert "Reconciler shadow evidence" not in md
+
+
+@pytest.mark.unit
+def test_shadow_evidence_empty_dict_renders_placeholder():
+    md = render_markdown(
+        report_date=date(2026, 6, 4),
+        window_days=20,
+        stats_by_strategy={"mean_reversion": _stats("mean_reversion")},
+        proposals=[],
+        comparisons=[],
+        shadow_evidence={},
+    )
+    assert "## Reconciler shadow evidence" in md
+    assert "No reconciler shadow evidence recorded yet" in md
+
+
+@pytest.mark.unit
+def test_shadow_evidence_table_and_gate_note():
+    evidence = {
+        "2026-06-03": {
+            "ticks": 78, "disagreements": 3, "executed": 0,
+            "max_diff_in_tick": 1,
+            "by_state": {"CLOSED": 2, "NEEDS_STOP": 1},
+        },
+        "2026-06-04": {
+            "ticks": 78, "disagreements": 0, "executed": 0,
+            "max_diff_in_tick": 0, "by_state": {},
+        },
+    }
+    md = render_markdown(
+        report_date=date(2026, 6, 4),
+        window_days=20,
+        stats_by_strategy={"mean_reversion": _stats("mean_reversion")},
+        proposals=[],
+        comparisons=[],
+        shadow_evidence=evidence,
+    )
+    assert "## Reconciler shadow evidence" in md
+    # Both days appear, with their disagreement counts and by-state breakdown.
+    assert "2026-06-03" in md and "2026-06-04" in md
+    assert "`CLOSED`=2" in md and "`NEEDS_STOP`=1" in md
+    # Gate note reports the quiet-day count (1 of 2 here).
+    assert "1 of 2 recorded day(s) had zero disagreements" in md
+    assert "reconciler.drive" in md


### PR DESCRIPTION
Follows [#195](https://github.com/alex5imon/ai-broker/pull/195), which persists the reconciler's per-day shadow-disagreement tally to `tick_state` — but left it queryable only by a manual Python one-liner. This surfaces it where the operator actually looks post-close: the `self_improve` daily-review markdown report.

## What

Adds a **"Reconciler shadow evidence"** section to the daily report:

```
## Reconciler shadow evidence

| Date | Ticks | Disagreements | Max/tick | Driven | By state |
|---|---:|---:|---:|---:|---|
| 2026-06-03 | 78 | 3 | 1 | 0 | `CLOSED`=2, `NEEDS_STOP`=1 |
| 2026-06-04 | 78 | 0 | 0 | 0 | — |

_1 of 2 recorded day(s) had zero disagreements. **Phase 2b gate:** flip
`reconciler.drive` on only after several consecutive quiet/consistent days (design §5)._
```

The daily-review workflow already runs post-close (`daily-review.yml`, 21:30 UTC weekdays), so the operator now sees the Phase 2b gate evidence in the same artifact as the postmortem — no manual query.

## How

- `render_markdown` gains an optional `shadow_evidence` param (**default `None` → section omitted**, fully backward-compatible).
- `_render_shadow_evidence` is pure (no DB access — the report layer stays pure).
- `__main__` loads it via `load_shadow_evidence(db_path)` and passes it through.

## Test plan

- [x] 3 new unit tests (`test_self_improve_report.py`): section omitted when `None`; empty-dict placeholder; populated table asserts both days, by-state breakdown, the quiet-day count ("1 of 2"), and the `reconciler.drive` gate note.
- [x] Existing report tests still green (backward compat).
- [x] `ruff check .` clean · self_improve + report suites: **24 passed** · full `-m critical`: **308 passed**

## No behaviour change

Pure reporting — no order logic, no `reconciler.drive` change. Completes the evidence loop (#195 records → this shows it). Phase 2b/3 remain gated on the paper-trading evidence this now makes visible.
